### PR TITLE
Fix missing gridlaunch.h build issue

### DIFF
--- a/rocprim/CMakeLists.txt
+++ b/rocprim/CMakeLists.txt
@@ -59,8 +59,7 @@ add_library(rocprim_hip INTERFACE)
 target_link_libraries(rocprim_hip
   INTERFACE
     rocprim
-    hip::hip_hcc
-    hip::hip_device
+    hip::device
 )
 target_compile_definitions(rocprim_hip
   INTERFACE

--- a/rocprim/CMakeLists.txt
+++ b/rocprim/CMakeLists.txt
@@ -59,8 +59,15 @@ add_library(rocprim_hip INTERFACE)
 target_link_libraries(rocprim_hip
   INTERFACE
     rocprim
-    hip::device
 )
+
+# Remove this check when we no longer build with older rocm stack(ie < 1.8.2)
+if(TARGET hip::device)
+  target_link_libraries( rocprim_hip INTERFACE hip::device )
+else()
+  target_link_libraries( rocprim_hip INTERFACE hip::hip_hcc hip::hip_device )
+endif()
+
 target_compile_definitions(rocprim_hip
   INTERFACE
     ROCPRIM_HIP_API=1

--- a/rocprim/CMakeLists.txt
+++ b/rocprim/CMakeLists.txt
@@ -56,16 +56,12 @@ target_compile_definitions(rocprim_hc
 # This target allows using both HIP and HC interfaces,
 # links against HIP library (which depends on HC)
 add_library(rocprim_hip INTERFACE)
-target_link_libraries(rocprim_hip
-  INTERFACE
-    rocprim
-)
 
 # Remove this check when we no longer build with older rocm stack(ie < 1.8.2)
 if(TARGET hip::device)
-  target_link_libraries( rocprim_hip INTERFACE hip::device )
+  target_link_libraries( rocprim_hip INTERFACE rocprim hip::device )
 else()
-  target_link_libraries( rocprim_hip INTERFACE hip::hip_hcc hip::hip_device )
+  target_link_libraries( rocprim_hip INTERFACE rocprim hip::hip_hcc hip::hip_device )
 endif()
 
 target_compile_definitions(rocprim_hip


### PR DESCRIPTION
When building with top of 1.8.x branches of HIP and HCC, there is a build issues with missing gridlaunch.h header file. hip::hip_hcc no longer has a dependency on HCC runtime, so we need to use hip::device now. Then we can configure HCC to be the compiler for rocPRIM build using `CXX=/opt/rocm/bin/hcc cmake .. `