### PR TITLE
Use HIP-Clang new intrinsics instead of hc::

### DIFF
--- a/hipcub/include/hipcub/rocprim/util_ptx.hpp
+++ b/hipcub/include/hipcub/rocprim/util_ptx.hpp
@@ -183,7 +183,10 @@ auto unsigned_bit_extract(UnsignedBits source,
     -> typename std::enable_if<sizeof(UnsignedBits) == 8, unsigned int>::type
 {
     #ifdef __HIP_PLATFORM_HCC__
-        return ::hc::__bitextract_u64(source, bit_start, num_bits);
+        #ifdef __HCC__
+        using ::hc::__bitextract_u64;
+        #endif
+        return __bitextract_u64(source, bit_start, num_bits);
     #else
         return (source << (64 - bit_start - num_bits)) >> (64 - num_bits);
     #endif // __HIP_PLATFORM_HCC__
@@ -197,7 +200,10 @@ auto unsigned_bit_extract(UnsignedBits source,
     -> typename std::enable_if<sizeof(UnsignedBits) < 8, unsigned int>::type
 {
     #ifdef __HIP_PLATFORM_HCC__
-        return ::hc::__bitextract_u32(source, bit_start, num_bits);
+        #ifdef __HCC__
+        using ::hc::__bitextract_u32;
+        #endif
+        return __bitextract_u32(source, bit_start, num_bits);
     #else
         return (static_cast<unsigned int>(source) << (32 - bit_start - num_bits)) >> (32 - num_bits);
     #endif // __HIP_PLATFORM_HCC__
@@ -228,7 +234,10 @@ void BFI(unsigned int &ret,
          unsigned int num_bits)
 {
     #ifdef __HIP_PLATFORM_HCC__
-        ret = ::hc::__bitinsert_u32(x, y, bit_start, num_bits);
+        #ifdef __HCC__
+        using ::hc::__bitinsert_u32;
+        #endif
+        ret = __bitinsert_u32(x, y, bit_start, num_bits);
     #else
         x <<= bit_start;
         unsigned int MASK_X = ((1 << num_bits) - 1) << bit_start;

--- a/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
@@ -53,6 +53,9 @@ unsigned int last_in_warp_segment(Flag flag)
     // Make sure last item in logical warp is marked as a tail
     warp_flags |= ballot_type(1) << (WarpSize - 1U);
     // Calculate logical lane id of the last valid value in the segment
+    #ifdef __HIP_CLANG_ONLY__
+    return ::__lastbit_u32_u64(warp_flags);
+    #endif
     return hc::__lastbit_u32_u64(warp_flags);
 }
 

--- a/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
@@ -55,8 +55,9 @@ unsigned int last_in_warp_segment(Flag flag)
     // Calculate logical lane id of the last valid value in the segment
     #ifdef __HIP_CLANG_ONLY__
     return ::__lastbit_u32_u64(warp_flags);
-    #endif
+    #else
     return hc::__lastbit_u32_u64(warp_flags);
+    #endif
 }
 
 } // end namespace detail

--- a/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
@@ -53,7 +53,7 @@ unsigned int last_in_warp_segment(Flag flag)
     // Make sure last item in logical warp is marked as a tail
     warp_flags |= ballot_type(1) << (WarpSize - 1U);
     // Calculate logical lane id of the last valid value in the segment
-    #ifdef __HIP_CLANG_ONLY__
+    #if __HIP_CLANG_ONLY__
     return ::__lastbit_u32_u64(warp_flags);
     #else
     return hc::__lastbit_u32_u64(warp_flags);


### PR DESCRIPTION
New intrinsics were added to HIP project, so we can use those instead of hc::.