### PR TITLE
HIP-Clang requires __device__ attr for device func callees

### DIFF
--- a/rocprim/include/rocprim/device/device_scan_by_key_hip.hpp
+++ b/rocprim/include/rocprim/device/device_scan_by_key_hip.hpp
@@ -304,7 +304,8 @@ hipError_t exclusive_scan_by_key(void * temporary_storage,
                     )
                 )
             ),
-            [initial_value, key_compare_op](const ::rocprim::tuple<input_type, key_type, key_type>& t)
+            [initial_value, key_compare_op] ROCPRIM_HOST_DEVICE
+            (const ::rocprim::tuple<input_type, key_type, key_type>& t)
                 -> ::rocprim::tuple<input_type, key_type>
             {
                 if(!key_compare_op(::rocprim::get<1>(t), ::rocprim::get<2>(t)))

--- a/rocprim/include/rocprim/device/device_segmented_scan_hip.hpp
+++ b/rocprim/include/rocprim/device/device_segmented_scan_hip.hpp
@@ -617,7 +617,8 @@ hipError_t segmented_exclusive_scan(void * temporary_storage,
                     head_flags
                 )
             ),
-            [initial_value](const ::rocprim::tuple<input_type, flag_type>& t)
+            [initial_value] ROCPRIM_HOST_DEVICE
+            (const ::rocprim::tuple<input_type, flag_type>& t)
                 -> ::rocprim::tuple<input_type, flag_type>
             {
                 if(::rocprim::get<1>(t))

--- a/rocprim/include/rocprim/iterator/zip_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/zip_iterator.hpp
@@ -74,6 +74,7 @@ void for_each_in_tuple(::rocprim::tuple<Types...>& t, Function f)
 struct increment_iterator
 {
     template<class Iterator>
+    ROCPRIM_HOST_DEVICE inline
     void operator()(Iterator& it)
     {
         ++it;
@@ -83,6 +84,7 @@ struct increment_iterator
 struct decrement_iterator
 {
     template<class Iterator>
+    ROCPRIM_HOST_DEVICE inline
     void operator()(Iterator& it)
     {
         --it;
@@ -92,12 +94,14 @@ struct decrement_iterator
 template<class Difference>
 struct advance_iterator
 {
+    ROCPRIM_HOST_DEVICE inline
     advance_iterator(Difference distance)
         : distance_(distance)
     {
     }
 
     template<class Iterator>
+    ROCPRIM_HOST_DEVICE inline
     void operator()(Iterator& it)
     {
         using it_distance_type = typename std::iterator_traits<Iterator>::difference_type;


### PR DESCRIPTION
HIP-Clang is more strict than HCC. All functions called by device functions must also have __device__ attribute, unlike HCC where device functions can call __host__ only functions.