### PR TITLE
Use HIP API shfl functions rather than hc::

### DIFF
--- a/rocprim/include/rocprim/intrinsics/warp_shuffle.hpp
+++ b/rocprim/include/rocprim/intrinsics/warp_shuffle.hpp
@@ -102,7 +102,7 @@ T warp_shuffle(T input, const int src_lane, const int width = warp_size())
         input,
         [=](int v) -> int
         {
-            #if defined(ROCPRIM_HC_API) || defined(__HIP_PLATFORM_HCC__)
+            #if defined(ROCPRIM_HC_API)
                 return hc::__shfl(v, src_lane, width);
             #else
                 return __shfl(v, src_lane, width);
@@ -131,7 +131,7 @@ T warp_shuffle_up(T input, const unsigned int delta, const int width = warp_size
         input,
         [=](int v) -> int
         {
-            #if defined(ROCPRIM_HC_API) || defined(__HIP_PLATFORM_HCC__)
+            #if defined(ROCPRIM_HC_API)
                 return hc::__shfl_up(v, delta, width);
             #else
                 return __shfl_up(v, delta, width);
@@ -160,7 +160,7 @@ T warp_shuffle_down(T input, const unsigned int delta, const int width = warp_si
         input,
         [=](int v) -> int
         {
-            #if defined(ROCPRIM_HC_API) || defined(__HIP_PLATFORM_HCC__)
+            #if defined(ROCPRIM_HC_API)
                 return hc::__shfl_down(v, delta, width);
             #else
                 return __shfl_down(v, delta, width);
@@ -188,7 +188,7 @@ T warp_shuffle_xor(T input, const int lane_mask, const int width = warp_size())
         input,
         [=](int v) -> int
         {
-            #if defined(ROCPRIM_HC_API) || defined(__HIP_PLATFORM_HCC__)
+            #if defined(ROCPRIM_HC_API)
                 return hc::__shfl_xor(v, lane_mask, width);
             #else
                 return __shfl_xor(v, lane_mask, width);


### PR DESCRIPTION
The HIP Platform should have it's own shuffle functions, and when using HIP-Clang, we don't want to use HCC specific functions.