### PR TITLE
Remove invalid semicolon

### DIFF
--- a/rocprim/include/rocprim/types/tuple.hpp
+++ b/rocprim/include/rocprim/types/tuple.hpp
@@ -186,7 +186,7 @@ namespace detail
     using is_final = std::integral_constant<bool, __is_final(T)>;
 #else
     template<class T>
-    struct is_final : std::false_type;
+    struct is_final : std::false_type
     {
     };
 #endif


### PR DESCRIPTION
Remove a semicolon that causes this struct to have no definition.