### PR TITLE
Fix tests to compile with HIP-Clang

### DIFF
--- a/test/rocprim/test_hip_block_exchange.cpp
+++ b/test/rocprim/test_hip_block_exchange.cpp
@@ -28,8 +28,6 @@
 
 // Google Test
 #include <gtest/gtest.h>
-// HC API
-#include <hcc/hc.hpp>
 // rocPRIM API
 #include <rocprim/rocprim.hpp>
 

--- a/test/rocprim/test_hip_block_load_store.cpp
+++ b/test/rocprim/test_hip_block_load_store.cpp
@@ -26,9 +26,9 @@
 
 // Google Test
 #include <gtest/gtest.h>
-// HC API
-#include <hcc/hc.hpp>
-#include <hcc/hc_short_vector.hpp>
+// HIP API
+#include <hip/hip_runtime.h>
+#include <hip/hip_vector_types.h>
 // rocPRIM API
 #include <rocprim/rocprim.hpp>
 
@@ -221,26 +221,26 @@ typedef ::testing::Types<
     params<float, int, 11, false>,
     params<float, rp::detail::int4, 16, true>,
 
-    params<hc::short_vector::int2, rp::detail::int2, 3, false>,
-    params<hc::short_vector::int2, rp::detail::int4, 4, true>,
-    params<hc::short_vector::int2, rp::detail::int2, 7, false>,
-    params<hc::short_vector::int2, rp::detail::int4, 8, true>,
-    params<hc::short_vector::int2, rp::detail::int2, 11, false>,
-    params<hc::short_vector::int2, rp::detail::int4, 16, true>,
+    params<int2, rp::detail::int2, 3, false>,
+    params<int2, rp::detail::int4, 4, true>,
+    params<int2, rp::detail::int2, 7, false>,
+    params<int2, rp::detail::int4, 8, true>,
+    params<int2, rp::detail::int2, 11, false>,
+    params<int2, rp::detail::int4, 16, true>,
 
-    params<hc::short_vector::float2, rp::detail::int2, 3, false>,
-    params<hc::short_vector::float2, rp::detail::int4, 4, true>,
-    params<hc::short_vector::float2, rp::detail::int2, 7, false>,
-    params<hc::short_vector::float2, rp::detail::int4, 8, true>,
-    params<hc::short_vector::float2, rp::detail::int2, 11, false>,
-    params<hc::short_vector::float2, rp::detail::int4, 16, true>,
+    params<float2, rp::detail::int2, 3, false>,
+    params<float2, rp::detail::int4, 4, true>,
+    params<float2, rp::detail::int2, 7, false>,
+    params<float2, rp::detail::int4, 8, true>,
+    params<float2, rp::detail::int2, 11, false>,
+    params<float2, rp::detail::int4, 16, true>,
 
-    params<hc::short_vector::char4, int, 3, false>,
-    params<hc::short_vector::char4, rp::detail::int4, 4, true>,
-    params<hc::short_vector::char4, int, 7, false>,
-    params<hc::short_vector::char4, rp::detail::int4, 8, true>,
-    params<hc::short_vector::char4, int, 11, false>,
-    params<hc::short_vector::char4, rp::detail::int4, 16, true>
+    params<char4, int, 3, false>,
+    params<char4, rp::detail::int4, 4, true>,
+    params<char4, int, 7, false>,
+    params<char4, rp::detail::int4, 8, true>,
+    params<char4, int, 11, false>,
+    params<char4, rp::detail::int4, 16, true>
 > Params;
 
 TYPED_TEST_CASE(RocprimBlockLoadStoreClassTests, ClassParams);

--- a/test/rocprim/test_hip_transform_iterator.cpp
+++ b/test/rocprim/test_hip_transform_iterator.cpp
@@ -39,6 +39,7 @@
 template<class T>
 struct times_two
 {
+    ROCPRIM_HOST_DEVICE
     T operator()(const T& value) const
     {
         return 2 * value;
@@ -48,6 +49,7 @@ struct times_two
 template<class T>
 struct plus_ten
 {
+    ROCPRIM_HOST_DEVICE
     T operator()(const T& value) const
     {
         return value + 10;

--- a/test/rocprim/test_hip_warp_reduce.cpp
+++ b/test/rocprim/test_hip_warp_reduce.cpp
@@ -97,7 +97,7 @@ void warp_reduce_sum_kernel(T* device_input, T* device_output)
     T value = device_input[index];
 
     using wreduce_t = rp::warp_reduce<T, LogicalWarpSize>;
-    tile_static typename wreduce_t::storage_type storage[warps_no];
+    __shared__ typename wreduce_t::storage_type storage[warps_no];
     wreduce_t().reduce(value, value, storage[warp_id]);
 
     if(hipThreadIdx_x%LogicalWarpSize == 0)
@@ -204,7 +204,7 @@ void warp_allreduce_sum_kernel(T* device_input, T* device_output)
     T value = device_input[index];
 
     using wreduce_t = rp::warp_reduce<T, LogicalWarpSize, true>;
-    tile_static typename wreduce_t::storage_type storage[warps_no];
+    __shared__ typename wreduce_t::storage_type storage[warps_no];
     wreduce_t().reduce(value, value, storage[warp_id]);
 
     device_output[index] = value;
@@ -312,7 +312,7 @@ void warp_reduce_sum_kernel(T* device_input, T* device_output, size_t valid)
     T value = device_input[index];
 
     using wreduce_t = rp::warp_reduce<T, LogicalWarpSize>;
-    tile_static typename wreduce_t::storage_type storage[warps_no];
+    __shared__ typename wreduce_t::storage_type storage[warps_no];
     wreduce_t().reduce(value, value, valid, storage[warp_id]);
 
     if(hipThreadIdx_x%LogicalWarpSize == 0)
@@ -420,7 +420,7 @@ void warp_allreduce_sum_kernel(T* device_input, T* device_output, size_t valid)
     T value = device_input[index];
 
     using wreduce_t = rp::warp_reduce<T, LogicalWarpSize, true>;
-    tile_static typename wreduce_t::storage_type storage[warps_no];
+    __shared__ typename wreduce_t::storage_type storage[warps_no];
     wreduce_t().reduce(value, value, valid, storage[warp_id]);
 
     device_output[index] = value;
@@ -623,7 +623,7 @@ void head_segmented_warp_reduce_kernel(T* input, Flag* flags, T* output)
     auto flag = flags[index];
 
     using wreduce_t = rp::warp_reduce<T, LogicalWarpSize, true>;
-    tile_static typename wreduce_t::storage_type storage[warps_no];
+    __shared__ typename wreduce_t::storage_type storage[warps_no];
     wreduce_t().head_segmented_reduce(value, value, flag, storage[warp_id]);
 
     output[index] = value;
@@ -750,7 +750,7 @@ void tail_segmented_warp_reduce_kernel(T* input, Flag* flags, T* output)
     auto flag = flags[index];
 
     using wreduce_t = rp::warp_reduce<T, LogicalWarpSize, true>;
-    tile_static typename wreduce_t::storage_type storage[warps_no];
+    __shared__ typename wreduce_t::storage_type storage[warps_no];
     wreduce_t().tail_segmented_reduce(value, value, flag, storage[warp_id]);
 
     output[index] = value;

--- a/test/rocprim/test_hip_warp_sort.cpp
+++ b/test/rocprim/test_hip_warp_sort.cpp
@@ -52,7 +52,7 @@ public:
 };
 
 template<class T>
-bool test(const T& a, const T& b) [[hc]]
+bool test(const T& a, const T& b)
 {
     return a < b;
 }


### PR DESCRIPTION
Remove references to HCC files and vector types, replacing with hip vectors. Add __device__ attribute to functions called by device functions. Replace tile_static with __shared__ attribute.