### PR TITLE
add gfx906 as target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ include(cmake/Summary.cmake)
 print_configuration_summary()
 
 # AMD targets
-set(AMDGPU_TARGETS gfx803;gfx900 CACHE STRING "List of specific machine types for library to target")
+set(AMDGPU_TARGETS gfx803;gfx900;gfx906 CACHE STRING "List of specific machine types for library to target")
 
 # rocPRIM works only on hcc
 if(HIP_PLATFORM STREQUAL "hcc")


### PR DESCRIPTION
Since ROCm 1.9 has already VG20 support enabled so we can add gfx906 as target now.
We can delete develop-gfx9 branch as no meaning to keep 2 branch now.