### PR TITLE
Add definition to max_grid_size and shared_impl_max_bins

### DIFF
--- a/rocprim/include/rocprim/device/device_histogram_config.hpp
+++ b/rocprim/include/rocprim/device/device_histogram_config.hpp
@@ -55,6 +55,21 @@ struct histogram_config
 #endif
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+template<
+    class HistogramConfig,
+    unsigned int MaxGridSize,
+    unsigned int SharedImplMaxBins
+> constexpr unsigned int
+histogram_config<HistogramConfig, MaxGridSize, SharedImplMaxBins>::max_grid_size;
+template<
+    class HistogramConfig,
+    unsigned int MaxGridSize,
+    unsigned int SharedImplMaxBins
+> constexpr unsigned int
+histogram_config<HistogramConfig, MaxGridSize, SharedImplMaxBins>::shared_impl_max_bins;
+#endif
+
 namespace detail
 {
 


### PR DESCRIPTION
Both max_grid_size and shared_impl_max_bins are declared but not defined. This is causing the dependent application to fail to link. 

Eg, tensorflow-rocm uses rocPRIM as a dependency. When doing debug build of tensorflow-rocm using
$ bazel build --config=rocm --copt=-g --copt=-O0  //tensorflow/core/kernels:conv_ops_test --compilation_mode=dbg --strip=never
The build would fail with the below error message:
`bazel-out/k8-dbg/bin/_solib_local/libtensorflow_Score_Skernels_Slibbincount_Uop_Ugpu.so: undefined reference to rocprim::histogram_config<rocprim::kernel_config<256u, 8u>, 1024u, 2048u>::max_grid_size`

@whchung @deven-amd