### PR TITLE
Fix race condition on shared memory in histogram with sort algorithm

### DIFF
--- a/rocprim/include/rocprim/block/detail/block_histogram_sort.hpp
+++ b/rocprim/include/rocprim/block/detail/block_histogram_sort.hpp
@@ -94,6 +94,7 @@ public:
         storage_type_& storage_ = storage.get();
 
         radix_sort().sort(input, storage_.sort);
+        ::rocprim::syncthreads(); // Fix race condition that appeared on Vega10 hardware, storage LDS is reused below.
 
         #pragma unroll
         for(unsigned int offset = 0; offset < Bins; offset += BlockSize)


### PR DESCRIPTION
New tests revealed intermittent failures in the block histogram function using the sort algorithm on vega10. Looks like a race condition on shared memory that is being reused among many parts of the algorithm. Block histogram (sort) uses rocprim's radix sort function. When radix sort is called with only keys and no values, there is no synchronization after the final write to shared memory in the exchange_keys function. The memory is then reused in the histogram function.

In other words, there is no synchronization between this read from shared memory at the end of :

https://github.com/ROCmSoftwarePlatform/rocPRIM/blob/77494254aaff94751fd816a3fbb038e2ba292060/rocprim/include/rocprim/block/block_radix_sort.hpp#L900

And this write to the same block of shared memory:

https://github.com/ROCmSoftwarePlatform/rocPRIM/blob/77494254aaff94751fd816a3fbb038e2ba292060/rocprim/include/rocprim/block/detail/block_histogram_sort.hpp#L104

