### PR TITLE
Fix Hip-clang c++14 test compiling

### DIFF
--- a/test/rocprim/test_block_radix_sort.cpp
+++ b/test/rocprim/test_block_radix_sort.cpp
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// This is compatiblity code for hip-clang and will be removed in the future
+// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
 #if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
 #undef _GLIBCXX14_CONSTEXPR
 #define _GLIBCXX14_CONSTEXPR

--- a/test/rocprim/test_block_radix_sort.cpp
+++ b/test/rocprim/test_block_radix_sort.cpp
@@ -20,6 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+#undef _GLIBCXX14_CONSTEXPR
+#define _GLIBCXX14_CONSTEXPR
+#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+
 #include <algorithm>
 #include <functional>
 #include <iostream>

--- a/test/rocprim/test_block_sort.cpp
+++ b/test/rocprim/test_block_sort.cpp
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// This is compatiblity code for hip-clang and will be removed in the future
+// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
 #if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
 #undef _GLIBCXX14_CONSTEXPR
 #define _GLIBCXX14_CONSTEXPR

--- a/test/rocprim/test_block_sort.cpp
+++ b/test/rocprim/test_block_sort.cpp
@@ -20,6 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+#undef _GLIBCXX14_CONSTEXPR
+#define _GLIBCXX14_CONSTEXPR
+#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/test/rocprim/test_device_binary_search.cpp
+++ b/test/rocprim/test_device_binary_search.cpp
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// This is compatiblity code for hip-clang and will be removed in the future
+// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
 #if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
 #undef _GLIBCXX14_CONSTEXPR
 #define _GLIBCXX14_CONSTEXPR

--- a/test/rocprim/test_device_binary_search.cpp
+++ b/test/rocprim/test_device_binary_search.cpp
@@ -20,6 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+#undef _GLIBCXX14_CONSTEXPR
+#define _GLIBCXX14_CONSTEXPR
+#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+
 #include <algorithm>
 #include <functional>
 #include <iostream>

--- a/test/rocprim/test_device_merge.cpp
+++ b/test/rocprim/test_device_merge.cpp
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// This is compatiblity code for hip-clang and will be removed in the future
+// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
 #if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
 #undef _GLIBCXX14_CONSTEXPR
 #define _GLIBCXX14_CONSTEXPR

--- a/test/rocprim/test_device_merge.cpp
+++ b/test/rocprim/test_device_merge.cpp
@@ -20,6 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+#undef _GLIBCXX14_CONSTEXPR
+#define _GLIBCXX14_CONSTEXPR
+#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+
 #include <iostream>
 #include <vector>
 #include <algorithm>

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// This is compatiblity code for hip-clang and will be removed in the future
+// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
 #if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
 #undef _GLIBCXX14_CONSTEXPR
 #define _GLIBCXX14_CONSTEXPR

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -20,6 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+#undef _GLIBCXX14_CONSTEXPR
+#define _GLIBCXX14_CONSTEXPR
+#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+
 #include <iostream>
 #include <vector>
 #include <algorithm>

--- a/test/rocprim/test_device_radix_sort.cpp
+++ b/test/rocprim/test_device_radix_sort.cpp
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// This is compatiblity code for hip-clang and will be removed in the future
+// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
 #if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
 #undef _GLIBCXX14_CONSTEXPR
 #define _GLIBCXX14_CONSTEXPR

--- a/test/rocprim/test_device_radix_sort.cpp
+++ b/test/rocprim/test_device_radix_sort.cpp
@@ -20,6 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+#undef _GLIBCXX14_CONSTEXPR
+#define _GLIBCXX14_CONSTEXPR
+#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+
 #include <algorithm>
 #include <functional>
 #include <iostream>

--- a/test/rocprim/test_device_segmented_radix_sort.cpp
+++ b/test/rocprim/test_device_segmented_radix_sort.cpp
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// This is compatiblity code for hip-clang and will be removed in the future
+// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
 #if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
 #undef _GLIBCXX14_CONSTEXPR
 #define _GLIBCXX14_CONSTEXPR

--- a/test/rocprim/test_device_segmented_radix_sort.cpp
+++ b/test/rocprim/test_device_segmented_radix_sort.cpp
@@ -20,6 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+#undef _GLIBCXX14_CONSTEXPR
+#define _GLIBCXX14_CONSTEXPR
+#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+
 #include <algorithm>
 #include <functional>
 #include <iostream>

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// This is compatiblity code for hip-clang and will be removed in the future
+// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
 #if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
 #undef _GLIBCXX14_CONSTEXPR
 #define _GLIBCXX14_CONSTEXPR

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -20,6 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+#undef _GLIBCXX14_CONSTEXPR
+#define _GLIBCXX14_CONSTEXPR
+#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+
 #include <algorithm>
 #include <iostream>
 #include <random>


### PR DESCRIPTION
Supporting hip-clang compiler with C++14. This is a temporary fix and will be removed. Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100