### PR TITLE
Fix HIP-Clang C++14 benchmark compiling

### DIFF
--- a/benchmark/benchmark_device_binary_search.cpp
+++ b/benchmark/benchmark_device_binary_search.cpp
@@ -20,6 +20,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// This is compatiblity code for hip-clang and will be removed in the future
+// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
+#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+#undef _GLIBCXX14_CONSTEXPR
+#define _GLIBCXX14_CONSTEXPR
+#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+
 #include <iostream>
 #include <chrono>
 #include <vector>

--- a/benchmark/benchmark_device_merge.cpp
+++ b/benchmark/benchmark_device_merge.cpp
@@ -20,6 +20,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// This is compatiblity code for hip-clang and will be removed in the future
+// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
+#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+#undef _GLIBCXX14_CONSTEXPR
+#define _GLIBCXX14_CONSTEXPR
+#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
+
 #include <iostream>
 #include <chrono>
 #include <vector>


### PR DESCRIPTION
Workaround C++14 benchmark compilation issue due to `constexpr` automarking with `__host__` and `__device__` in HIP-Clang.

This is related to issue #100 .