### PR TITLE
Revert previous workaround for C++14 compilation with HIP-clang.

### DIFF
--- a/benchmark/benchmark_device_binary_search.cpp
+++ b/benchmark/benchmark_device_binary_search.cpp
@@ -20,13 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// This is compatiblity code for hip-clang and will be removed in the future
-// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
-#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-#undef _GLIBCXX14_CONSTEXPR
-#define _GLIBCXX14_CONSTEXPR
-#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-
 #include <iostream>
 #include <chrono>
 #include <vector>

--- a/benchmark/benchmark_device_merge.cpp
+++ b/benchmark/benchmark_device_merge.cpp
@@ -20,13 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// This is compatiblity code for hip-clang and will be removed in the future
-// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
-#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-#undef _GLIBCXX14_CONSTEXPR
-#define _GLIBCXX14_CONSTEXPR
-#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-
 #include <iostream>
 #include <chrono>
 #include <vector>

--- a/test/rocprim/test_block_radix_sort.cpp
+++ b/test/rocprim/test_block_radix_sort.cpp
@@ -20,13 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// This is compatiblity code for hip-clang and will be removed in the future
-// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
-#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-#undef _GLIBCXX14_CONSTEXPR
-#define _GLIBCXX14_CONSTEXPR
-#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-
 #include <algorithm>
 #include <functional>
 #include <iostream>

--- a/test/rocprim/test_block_sort.cpp
+++ b/test/rocprim/test_block_sort.cpp
@@ -20,13 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// This is compatiblity code for hip-clang and will be removed in the future
-// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
-#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-#undef _GLIBCXX14_CONSTEXPR
-#define _GLIBCXX14_CONSTEXPR
-#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-
 #include <algorithm>
 #include <iostream>
 #include <random>

--- a/test/rocprim/test_device_binary_search.cpp
+++ b/test/rocprim/test_device_binary_search.cpp
@@ -20,13 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// This is compatiblity code for hip-clang and will be removed in the future
-// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
-#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-#undef _GLIBCXX14_CONSTEXPR
-#define _GLIBCXX14_CONSTEXPR
-#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-
 #include <algorithm>
 #include <functional>
 #include <iostream>

--- a/test/rocprim/test_device_merge.cpp
+++ b/test/rocprim/test_device_merge.cpp
@@ -20,13 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// This is compatiblity code for hip-clang and will be removed in the future
-// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
-#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-#undef _GLIBCXX14_CONSTEXPR
-#define _GLIBCXX14_CONSTEXPR
-#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-
 #include <iostream>
 #include <vector>
 #include <algorithm>

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -20,13 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// This is compatiblity code for hip-clang and will be removed in the future
-// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
-#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-#undef _GLIBCXX14_CONSTEXPR
-#define _GLIBCXX14_CONSTEXPR
-#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-
 #include <iostream>
 #include <vector>
 #include <algorithm>

--- a/test/rocprim/test_device_radix_sort.cpp
+++ b/test/rocprim/test_device_radix_sort.cpp
@@ -20,13 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// This is compatiblity code for hip-clang and will be removed in the future
-// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
-#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-#undef _GLIBCXX14_CONSTEXPR
-#define _GLIBCXX14_CONSTEXPR
-#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-
 #include <algorithm>
 #include <functional>
 #include <iostream>

--- a/test/rocprim/test_device_segmented_radix_sort.cpp
+++ b/test/rocprim/test_device_segmented_radix_sort.cpp
@@ -20,13 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// This is compatiblity code for hip-clang and will be removed in the future
-// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
-#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-#undef _GLIBCXX14_CONSTEXPR
-#define _GLIBCXX14_CONSTEXPR
-#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-
 #include <algorithm>
 #include <functional>
 #include <iostream>

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -20,13 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// This is compatiblity code for hip-clang and will be removed in the future
-// Please see https://github.com/ROCmSoftwarePlatform/rocPRIM/issues/100
-#if defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-#undef _GLIBCXX14_CONSTEXPR
-#define _GLIBCXX14_CONSTEXPR
-#endif // defined(__HIPCC__) && __HIP_DEVICE_COMPILE__
-
 #include <algorithm>
 #include <iostream>
 #include <random>


### PR DESCRIPTION
- That workaround is not required as the bug in clang is fixed.