### PR TITLE
rocPRIM changes to support reloctable ROCM installation

### DIFF
--- a/install
+++ b/install
@@ -11,6 +11,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-i|--install] install after build"
     echo "    [-p]--package build package"
+    echo "    [-r]--relocatable] create a package to support relocatable ROCm"
     #Not implemented yet
     #    echo "    [-d|--dependencies] install build dependencies"
     echo "    [-c|--clients] build library clients too (combines with -i & -d)"
@@ -28,7 +29,9 @@ build_clients=false
 build_release=true
 build_hip_clang=false
 run_tests=false
-rocm_path=/opt/rocm/bin
+rocm_path=/opt/rocm
+build_relocatable=false
+
 # #################################################
 # Parameter parsing
 # #################################################
@@ -36,7 +39,7 @@ rocm_path=/opt/rocm/bin
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,debug,hip-clang,test,package --options hicdtp -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,debug,hip-clang,test,package,relocatable --options hicdtpgr -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -62,7 +65,10 @@ while true; do
 	-p|--package)
 	    build_package=true
 	    shift ;;
-	 -c|--clients)
+        -r|--relocatable)
+             build_relocatable=true
+             shift ;;
+        -c|--clients)
 	    build_clients=true
 	    shift ;;
 	-g|--debug)
@@ -81,6 +87,11 @@ while true; do
     esac
     done
 
+if [[ "${build_relocatable}" == true ]]; then
+    if ! [ -z ${ROCM_PATH+x} ]; then
+        rocm_path=${ROCM_PATH}
+    fi
+fi
 
 # Instal the pre-commit hook
 bash ./githooks/install
@@ -110,10 +121,17 @@ if [[ "${build_hip_clang}" == true ]]; then
     compiler="hipcc"
 fi
 
+cmake_executable="cmake"
 if [ -e /etc/redhat-release ] ; then
-    CXX=$rocm_path/${compiler} cmake3  -DBUILD_BENCHMARK=ON ../../. # or cmake-gui ../.
+    cmake_executable="cmake3"
+fi
+
+if [[ "${build_relocatable}" == true ]]; then
+    CXX=${rocm_path}/bin/${compiler} ${cmake_executable} -DCMAKE_INSTALL_PREFIX=${rocm_path} -DBUILD_BENCHMARK=ON \
+    -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc  ${rocm_path}/hip" \
+    -DCMAKE_MODULE_PATH="${rocm_path}/hip/cmake" ../../.     # or cmake-gui ../.
 else
-    CXX=$rocm_path/${compiler} cmake -DBUILD_BENCHMARK=ON ../../. # or cmake-gui ../.
+    CXX=${rocm_path}/bin/${compiler} ${cmake_executable} -DBUILD_BENCHMARK=ON ../../. # or cmake-gui ../.
 fi
 
 # Build


### PR DESCRIPTION
- New mode of building is added "-r,--relocatable" which is used
  for ROCm stack installed in /opt/rocm-ver.
- Below CMAKE parameters are set/overwritten in above mode
  CMAKE_INSTALL_PREFIX
  CMAKE_MODULE_PATH
  CMAKE_PREFIX_PATH

Signed-off-by: Pruthvi Madugundu <mpruthvi@gmail.com>