### PR TITLE
Allow including device_radix_sort separately

### DIFF
--- a/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -35,6 +35,7 @@
 #include "../types.hpp"
 
 #include "device_radix_sort_config.hpp"
+#include "device_transform.hpp"
 #include "detail/device_radix_sort.hpp"
 
 /// \addtogroup devicemodule


### PR DESCRIPTION
Include the device_transform.hpp header in device_radix_sort.hpp to fix a compilation issue that occurs when including device_radix_sort alone.