### PR TITLE
Revert "Add half-overload for load/store-volatile"

### DIFF
--- a/rocprim/include/rocprim/detail/various.hpp
+++ b/rocprim/include/rocprim/detail/various.hpp
@@ -180,12 +180,6 @@ auto store_volatile(T * output, T value)
     }
 }
 
-ROCPRIM_DEVICE inline
-void store_volatile(half * output, half value)
-{
-    *reinterpret_cast<volatile _Float16*>(output) = value;
-}
-
 template<class T>
 ROCPRIM_DEVICE inline
 auto load_volatile(T * input)
@@ -212,13 +206,6 @@ auto load_volatile(T * input)
     {
         output_ptr[i] = input_ptr[i];
     }
-    return retval;
-}
-
-ROCPRIM_DEVICE inline
-half load_volatile(half * input)
-{
-    half retval = *reinterpret_cast<volatile _Float16*>(input);
     return retval;
 }
 


### PR DESCRIPTION
This reverts commit f1ab775c716973eaff5fbee70fe2c4403d6ab5b6.

This is required to fix Cafe2/PyTorch failures