### PR TITLE
Revert "Avoid template specialization when not using HCC or HIP-CLANG"

### DIFF
--- a/rocprim/include/rocprim/detail/various.hpp
+++ b/rocprim/include/rocprim/detail/various.hpp
@@ -209,21 +209,6 @@ auto load_volatile(T * input)
     return retval;
 }
 
-#if __HCC_OR_HIP_CLANG__
-ROCPRIM_DEVICE inline
-void store_volatile(half * output, half value)
-{
-    *reinterpret_cast<volatile _Float16*>(output) = value;
-}
-
-ROCPRIM_DEVICE inline
-half load_volatile(half * input)
-{
-    half retval = *reinterpret_cast<volatile _Float16*>(input);
-    return retval;
-}
-#endif
-
 // A storage-backing wrapper that allows types with non-trivial constructors to be aliased in unions
 template <typename T>
 struct raw_storage


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/rocPRIM#128

Again this is failing testing for Caffe2. Need to incorporate a test case for this into rocPRIM before any new attempt at template specialization.