### PR TITLE
Hliao/develop/fix.dpp

### DIFF
--- a/rocprim/include/rocprim/intrinsics/warp_shuffle.hpp
+++ b/rocprim/include/rocprim/intrinsics/warp_shuffle.hpp
@@ -59,10 +59,9 @@ ROCPRIM_DEVICE
 int __amdgcn_update_dpp(int old, int src, int dpp_ctrl, int row_mask, int bank_mask, bool bound_ctrl)
     __asm("llvm.amdgcn.update.dpp.i32");
 
-template<class T>
+template<class T, int dpp_ctrl, int row_mask = 0xf, int bank_mask = 0xf, bool bound_ctrl = false>
 ROCPRIM_DEVICE inline
-T warp_move_dpp(T input, int dpp_ctrl,
-                int row_mask = 0xf, int bank_mask = 0xf, bool bound_ctrl = false)
+T warp_move_dpp(T input)
 {
     constexpr int words_no = (sizeof(T) + sizeof(int) - 1) / sizeof(int);
 

--- a/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -56,32 +56,32 @@ public:
         if(WarpSize > 1)
         {
             // quad_perm:[1,0,3,2] -> 10110001
-            output = reduce_op(warp_move_dpp(output, 0xb1), output);
+            output = reduce_op(warp_move_dpp<T, 0xb1>(output), output);
         }
         if(WarpSize > 2)
         {
             // quad_perm:[2,3,0,1] -> 01001110
-            output = reduce_op(warp_move_dpp(output, 0x4e), output);
+            output = reduce_op(warp_move_dpp<T, 0x4e>(output), output);
         }
         if(WarpSize > 4)
         {
             // row_shr:4
-            output = reduce_op(warp_move_dpp(output, 0x114), output);
+            output = reduce_op(warp_move_dpp<T, 0x114>(output), output);
         }
         if(WarpSize > 8)
         {
             // row_shr:8
-            output = reduce_op(warp_move_dpp(output, 0x118), output);
+            output = reduce_op(warp_move_dpp<T, 0x118>(output), output);
         }
         if(WarpSize > 16)
         {
             // row_bcast:15
-            output = reduce_op(warp_move_dpp(output, 0x142), output);
+            output = reduce_op(warp_move_dpp<T, 0x142>(output), output);
         }
         if(WarpSize > 32)
         {
             // row_bcast:31
-            output = reduce_op(warp_move_dpp(output, 0x143), output);
+            output = reduce_op(warp_move_dpp<T, 0x143>(output), output);
         }
 
         // Read the result from the last lane of the logical warp

--- a/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
@@ -56,32 +56,32 @@ public:
 
         if(WarpSize > 1)
         {
-            T t = scan_op(warp_move_dpp(output, 0x111), output); // row_shr:1
+            T t = scan_op(warp_move_dpp<T, 0x111>(output), output); // row_shr:1
             if(row_lane_id >= 1) output = t;
         }
         if(WarpSize > 2)
         {
-            T t = scan_op(warp_move_dpp(output, 0x112), output); // row_shr:2
+            T t = scan_op(warp_move_dpp<T, 0x112>(output), output); // row_shr:2
             if(row_lane_id >= 2) output = t;
         }
         if(WarpSize > 4)
         {
-            T t = scan_op(warp_move_dpp(output, 0x114), output); // row_shr:4
+            T t = scan_op(warp_move_dpp<T, 0x114>(output), output); // row_shr:4
             if(row_lane_id >= 4) output = t;
         }
         if(WarpSize > 8)
         {
-            T t = scan_op(warp_move_dpp(output, 0x118), output); // row_shr:8
+            T t = scan_op(warp_move_dpp<T, 0x118>(output), output); // row_shr:8
             if(row_lane_id >= 8) output = t;
         }
         if(WarpSize > 16)
         {
-            T t = scan_op(warp_move_dpp(output, 0x142), output); // row_bcast:15
+            T t = scan_op(warp_move_dpp<T, 0x142>(output), output); // row_bcast:15
             if(lane_id % 32 >= 16) output = t;
         }
         if(WarpSize > 32)
         {
-            T t = scan_op(warp_move_dpp(output, 0x143), output); // row_bcast:31
+            T t = scan_op(warp_move_dpp<T, 0x143>(output), output); // row_bcast:31
             if(lane_id >= 32) output = t;
         }
     }


### PR DESCRIPTION
`llvm.amdgcn.update.dpp.i32` requires immediate argument to prevent generating broken LLVM IR. Rewrite these parameters as template parameters to ensure constant/immediate values are used in clang's codegen.