### PR TITLE
Update calculate_warp_prefixes to initialize BlockSize

### DIFF
--- a/rocprim/include/rocprim/block/detail/block_scan_warp_scan.hpp
+++ b/rocprim/include/rocprim/block/detail/block_scan_warp_scan.hpp
@@ -688,7 +688,7 @@ private:
     }
 
     // i-th warp will have its prefix stored in storage_.warp_prefixes[i-1]
-    template<class BinaryFunction>
+    template<class BinaryFunction, unsigned int BlockSize_ = BlockSize>
     ROCPRIM_DEVICE inline
     void calculate_warp_prefixes(const unsigned int flat_tid,
                                  const unsigned int warp_id,
@@ -699,7 +699,7 @@ private:
         storage_type_& storage_ = storage.get();
         // Save the warp reduction result, that is the scan result
         // for last element in each warp
-        if(flat_tid == ::rocprim::min((warp_id+1) * warp_size_, BlockSize) - 1)
+        if(flat_tid == ::rocprim::min((warp_id+1) * warp_size_, BlockSize_) - 1)
         {
             storage_.warp_prefixes[warp_id] = inclusive_input;
         }


### PR DESCRIPTION
BlockSize is only declared in the class. It reports missing symbol error when compiled with -O0 and its address is taken or it is passed by reference. Observed while building PyTorch in debug mode.