### PR TITLE
Modifying unit test params to not have warpSize > 32 for Navi21/gfx1030

### DIFF
--- a/test/rocprim/test_utils_types.hpp
+++ b/test/rocprim/test_utils_types.hpp
@@ -48,18 +48,28 @@ struct block_params
     static constexpr unsigned int block_size = BlockSize;
 };
 
-#define warp_param_type(type) \
-    warp_params<type, 4U>, \
-    warp_params<type, 8U>, \
-    warp_params<type, 16U>, \
-    warp_params<type, 32U>, \
-    warp_params<type, 64U>, \
-    warp_params<type, 3U>, \
-    warp_params<type, 7U>, \
-    warp_params<type, 15U>, \
-    warp_params<type, 37U>, \
-    warp_params<type, 61U>
-
+#if (defined(__gfx1030__))
+    #define warp_param_type(type) \
+        warp_params<type, 4U>, \
+        warp_params<type, 8U>, \
+        warp_params<type, 16U>, \
+        warp_params<type, 32U>, \
+        warp_params<type, 3U>, \
+        warp_params<type, 7U>, \
+        warp_params<type, 15U>
+#else
+    #define warp_param_type(type) \
+       warp_params<type, 4U>, \
+       warp_params<type, 8U>, \
+       warp_params<type, 16U>, \
+       warp_params<type, 32U>, \
+       warp_params<type, 64U>, \
+       warp_params<type, 3U>, \
+       warp_params<type, 7U>, \
+       warp_params<type, 15U>, \
+       warp_params<type, 37U>, \
+       warp_params<type, 61U>
+#endif
 #define block_param_type(input_type, output_type) \
     block_params<input_type, output_type, 64U>, \
     block_params<input_type, output_type, 128U>, \

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -34,14 +34,22 @@ public:
     using params = Params;
 };
 
-#define warp_sort_param_type(type) \
-    warp_params<type, 2U>, \
-    warp_params<type, 4U>, \
-    warp_params<type, 8U>, \
-    warp_params<type, 16U>, \
-    warp_params<type, 32U>, \
-    warp_params<type, 64U>
-
+#if (defined(__gfx1030__))
+    #define warp_sort_param_type(type) \
+        warp_params<type, 2U>, \
+        warp_params<type, 4U>, \
+        warp_params<type, 8U>, \
+        warp_params<type, 16U>, \
+        warp_params<type, 32U>
+#else
+    #define warp_sort_param_type(type) \
+       warp_params<type, 2U>, \
+       warp_params<type, 4U>, \
+       warp_params<type, 8U>, \
+       warp_params<type, 16U>, \
+       warp_params<type, 32U>, \
+       warp_params<type, 64U>
+#endif
 typedef ::testing::Types<
     warp_sort_param_type(int),
     warp_sort_param_type(test_utils::custom_test_type<int>),


### PR DESCRIPTION
For gfx1030 warpSize is now 32.  Updating the unit tests so that they build and run properly on gfx1030.