### PR TITLE
Gfx 1030 1031 support 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,9 @@ endif()
 
 # Use target ID syntax if supported for AMDGPU_TARGETS
 if(TARGET_ID_SUPPORT)
-  set(AMDGPU_TARGETS gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack- CACHE STRING "List of specific machine types for library to target")
+  set(AMDGPU_TARGETS gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx1030:xnack- CACHE STRING "List of specific machine types for library to target")
 else()
-  set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target")
+  set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908;gfx1030 CACHE STRING "List of specific machine types for library to target")
 endif()
 set(AMDGPU_TEST_TARGETS "" CACHE STRING "List of specific device types to test for") # Leave empty for default system device
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,9 @@ endif()
 
 # Use target ID syntax if supported for AMDGPU_TARGETS
 if(TARGET_ID_SUPPORT)
-  set(AMDGPU_TARGETS gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx1030:xnack- CACHE STRING "List of specific machine types for library to target")
+  set(AMDGPU_TARGETS gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx1030;gfx1031 CACHE STRING "List of specific machine types for library to target")
 else()
-  set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908;gfx1030 CACHE STRING "List of specific machine types for library to target")
+  set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908;gfx1030;gfx1031 CACHE STRING "List of specific machine types for library to target")
 endif()
 set(AMDGPU_TEST_TARGETS "" CACHE STRING "List of specific device types to test for") # Leave empty for default system device
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -51,7 +51,7 @@ if(BUILD_TEST)
   download_project(
     PROJ           googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        release-1.8.1
+    GIT_TAG        release-1.10.0
     INSTALL_DIR    ${GTEST_ROOT}
     CMAKE_ARGS     -DBUILD_GTEST=ON -DINSTALL_GTEST=ON -Dgtest_force_shared_crt=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
     LOG_DOWNLOAD   TRUE

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -296,7 +296,7 @@ public:
                                  U (&output)[ItemsPerThread],
                                  storage_type& storage)
     {
-        constexpr unsigned int items_per_warp = get_selected_warp_size() * ItemsPerThread;
+        const unsigned int items_per_warp = get_selected_warp_size() * ItemsPerThread;
         const unsigned int lane_id = ::rocprim::lane_id();
         const unsigned int warp_id = ::rocprim::warp_id<BlockSizeX, BlockSizeY, BlockSizeZ>();
         const unsigned int current_warp_size = get_current_warp_size();
@@ -365,7 +365,7 @@ public:
                                  U (&output)[ItemsPerThread],
                                  storage_type& storage)
     {
-        constexpr unsigned int items_per_warp = get_selected_warp_size() * ItemsPerThread;
+        const unsigned int items_per_warp = get_selected_warp_size() * ItemsPerThread;
         const unsigned int lane_id = ::rocprim::lane_id();
         const unsigned int warp_id = ::rocprim::warp_id<BlockSizeX, BlockSizeY, BlockSizeZ>();
         const unsigned int current_warp_size = get_current_warp_size();
@@ -702,14 +702,14 @@ public:
 private:
 
     ROCPRIM_DEVICE inline
-    constexpr unsigned int get_selected_warp_size() const
+    unsigned int get_selected_warp_size() const
     {
         return detail::get_min_warp_size(BlockSize, ::rocprim::warp_size());
     }
 
     // Number of warps in block
     ROCPRIM_DEVICE inline
-    constexpr unsigned int get_warps_count() const
+    unsigned int get_warps_count() const
     {
         return (BlockSize + get_selected_warp_size() - 1) / get_selected_warp_size();
     }

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -83,7 +83,7 @@ class block_exchange
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
     // Select warp size
     static constexpr unsigned int warp_size =
-        detail::get_min_warp_size(BlockSize, ::rocprim::warp_size());
+        detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
     // Number of warps in block
     static constexpr unsigned int warps_no = (BlockSize + warp_size - 1) / warp_size;
 

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -81,6 +81,11 @@ template<
 class block_exchange
 {
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
+    // Select warp size
+    static constexpr unsigned int warp_size =
+        detail::get_min_warp_size(BlockSize, ::rocprim::warp_size());
+    // Number of warps in block
+    static constexpr unsigned int warps_no = (BlockSize + warp_size - 1) / warp_size;
 
     // Minimize LDS bank conflicts for power-of-two strides, i.e. when items accessed
     // using `thread_id * ItemsPerThread` pattern where ItemsPerThread is power of two
@@ -296,7 +301,7 @@ public:
                                  U (&output)[ItemsPerThread],
                                  storage_type& storage)
     {
-        const unsigned int items_per_warp = get_selected_warp_size() * ItemsPerThread;
+        constexpr unsigned int items_per_warp = warp_size * ItemsPerThread;
         const unsigned int lane_id = ::rocprim::lane_id();
         const unsigned int warp_id = ::rocprim::warp_id<BlockSizeX, BlockSizeY, BlockSizeZ>();
         const unsigned int current_warp_size = get_current_warp_size();
@@ -365,7 +370,7 @@ public:
                                  U (&output)[ItemsPerThread],
                                  storage_type& storage)
     {
-        const unsigned int items_per_warp = get_selected_warp_size() * ItemsPerThread;
+        constexpr unsigned int items_per_warp = warp_size * ItemsPerThread;
         const unsigned int lane_id = ::rocprim::lane_id();
         const unsigned int warp_id = ::rocprim::warp_id<BlockSizeX, BlockSizeY, BlockSizeZ>();
         const unsigned int current_warp_size = get_current_warp_size();
@@ -702,25 +707,12 @@ public:
 private:
 
     ROCPRIM_DEVICE inline
-    unsigned int get_selected_warp_size() const
-    {
-        return detail::get_min_warp_size(BlockSize, ::rocprim::warp_size());
-    }
-
-    // Number of warps in block
-    ROCPRIM_DEVICE inline
-    unsigned int get_warps_count() const
-    {
-        return (BlockSize + get_selected_warp_size() - 1) / get_selected_warp_size();
-    }
-
-    ROCPRIM_DEVICE inline
     unsigned int get_current_warp_size() const
     {
         const unsigned int warp_id = ::rocprim::warp_id<BlockSizeX, BlockSizeY, BlockSizeZ>();
-        return (warp_id == get_warps_count() - 1)
-            ? (BlockSize % get_selected_warp_size() > 0 ? BlockSize % get_selected_warp_size() : get_selected_warp_size())
-            : get_selected_warp_size();
+        return (warp_id == warps_no - 1)
+            ? (BlockSize % warp_size > 0 ? BlockSize % warp_size : warp_size)
+            : warp_size;
     }
 
     // Change index to minimize LDS bank conflicts if necessary

--- a/rocprim/include/rocprim/block/block_load.hpp
+++ b/rocprim/include/rocprim/block/block_load.hpp
@@ -649,7 +649,7 @@ private:
     using block_exchange_type = block_exchange<T, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ>;
 
 public:
-    static_assert(BlockSize % warp_size() == 0,
+    static_assert(BlockSize % ::rocprim::device_warp_size() == 0,
                  "BlockSize must be a multiple of hardware warpsize");
 
     using storage_type = typename block_exchange_type::storage_type;

--- a/rocprim/include/rocprim/block/block_load_func.hpp
+++ b/rocprim/include/rocprim/block/block_load_func.hpp
@@ -367,7 +367,7 @@ void block_load_direct_striped(unsigned int flat_id,
 /// \param block_input - the input iterator from the thread block to load from
 /// \param items - array that data is loaded to
 template<
-    unsigned int WarpSize = warp_size(),
+    unsigned int WarpSize = device_warp_size(),
     class InputIterator,
     class T,
     unsigned int ItemsPerThread
@@ -377,7 +377,7 @@ void block_load_direct_warp_striped(unsigned int flat_id,
                                     InputIterator block_input,
                                     T (&items)[ItemsPerThread])
 {
-    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= warp_size(),
+    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
                  "WarpSize must be a power of two and equal or less"
                  "than the size of hardware warp.");
     unsigned int thread_id = detail::logical_lane_id<WarpSize>();
@@ -418,7 +418,7 @@ void block_load_direct_warp_striped(unsigned int flat_id,
 /// \param items - array that data is loaded to
 /// \param valid - maximum range of valid numbers to load
 template<
-    unsigned int WarpSize = warp_size(),
+    unsigned int WarpSize = device_warp_size(),
     class InputIterator,
     class T,
     unsigned int ItemsPerThread
@@ -429,7 +429,7 @@ void block_load_direct_warp_striped(unsigned int flat_id,
                                     T (&items)[ItemsPerThread],
                                     unsigned int valid)
 {
-    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= warp_size(),
+    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
                  "WarpSize must be a power of two and equal or less"
                  "than the size of hardware warp.");
     unsigned int thread_id = detail::logical_lane_id<WarpSize>();
@@ -477,7 +477,7 @@ void block_load_direct_warp_striped(unsigned int flat_id,
 /// \param valid - maximum range of valid numbers to load
 /// \param out_of_bounds - default value assigned to out-of-bound items
 template<
-    unsigned int WarpSize = warp_size(),
+    unsigned int WarpSize = device_warp_size(),
     class InputIterator,
     class T,
     unsigned int ItemsPerThread,
@@ -490,7 +490,7 @@ void block_load_direct_warp_striped(unsigned int flat_id,
                                     unsigned int valid,
                                     Default out_of_bounds)
 {
-    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= warp_size(),
+    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
                  "WarpSize must be a power of two and equal or less"
                  "than the size of hardware warp.");
     #pragma unroll

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -56,7 +56,7 @@ class block_bit_plus_scan
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
     // Select warp size
     static constexpr unsigned int warp_size =
-        detail::get_min_warp_size(BlockSize, ::rocprim::warp_size());
+        detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
     // Number of warps in block
     static constexpr unsigned int warps_no = (BlockSize + warp_size - 1) / warp_size;
 

--- a/rocprim/include/rocprim/block/block_reduce.hpp
+++ b/rocprim/include/rocprim/block/block_reduce.hpp
@@ -87,7 +87,7 @@ struct select_block_reduce_impl<block_reduce_algorithm::raking_reduce>
 ///   * \p ItemsPerThread is greater than one,
 ///   * \p T is an arithmetic type,
 ///   * reduce operation is simple addition operator, and
-///   * the number of threads in the block is a multiple of the hardware warp size (see rocprim::warp_size()).
+///   * the number of threads in the block is a multiple of the hardware warp size (see rocprim::device_warp_size()).
 /// * block_reduce has two alternative implementations: \p block_reduce_algorithm::using_warp_reduce
 ///   and block_reduce_algorithm::raking_reduce.
 ///

--- a/rocprim/include/rocprim/block/block_scan.hpp
+++ b/rocprim/include/rocprim/block/block_scan.hpp
@@ -70,7 +70,7 @@ struct select_block_scan_impl<block_scan_algorithm::reduce_then_scan>
     // When BlockSize is less than hardware warp size block_scan_warp_scan performs better than
     // block_scan_reduce_then_scan by specializing for warps
     using type = typename std::conditional<
-                    (BlockSizeX * BlockSizeY * BlockSizeZ <= ::rocprim::warp_size()),
+                    (BlockSizeX * BlockSizeY * BlockSizeZ <= ::rocprim::device_warp_size()),
                     block_scan_warp_scan<T, BlockSizeX, BlockSizeY, BlockSizeZ>,
                     block_scan_reduce_then_scan<T, BlockSizeX, BlockSizeY, BlockSizeZ>
                  >::type;
@@ -96,7 +96,7 @@ struct select_block_scan_impl<block_scan_algorithm::reduce_then_scan>
 ///   * \p ItemsPerThread is greater than one,
 ///   * \p T is an arithmetic type,
 ///   * scan operation is simple addition operator, and
-///   * the number of threads in the block is a multiple of the hardware warp size (see rocprim::warp_size()).
+///   * the number of threads in the block is a multiple of the hardware warp size (see rocprim::device_warp_size()).
 /// * block_scan has two alternative implementations: \p block_scan_algorithm::using_warp_scan
 ///   and block_scan_algorithm::reduce_then_scan.
 ///

--- a/rocprim/include/rocprim/block/block_store.hpp
+++ b/rocprim/include/rocprim/block/block_store.hpp
@@ -433,7 +433,7 @@ private:
     using block_exchange_type = block_exchange<T, BlockSize, ItemsPerThread>;
 
 public:
-    static_assert(BlockSize % warp_size() == 0,
+    static_assert(BlockSize % ::rocprim::device_warp_size() == 0,
                  "BlockSize must be a multiple of hardware warpsize");
 
     using storage_type = typename block_exchange_type::storage_type;

--- a/rocprim/include/rocprim/block/block_store_func.hpp
+++ b/rocprim/include/rocprim/block/block_store_func.hpp
@@ -296,7 +296,7 @@ void block_store_direct_striped(unsigned int flat_id,
 /// \param block_output - the input iterator from the thread block to store to
 /// \param items - array that data is stored to thread block
 template<
-    unsigned int WarpSize = warp_size(),
+    unsigned int WarpSize = device_warp_size(),
     class OutputIterator,
     class T,
     unsigned int ItemsPerThread
@@ -310,7 +310,7 @@ void block_store_direct_warp_striped(unsigned int flat_id,
                   "The type T must be such that an object of type OutputIterator "
                   "can be dereferenced and assigned a value of type T.");
 
-    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= warp_size(),
+    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
                  "WarpSize must be a power of two and equal or less"
                  "than the size of hardware warp.");
     unsigned int thread_id = detail::logical_lane_id<WarpSize>();
@@ -351,7 +351,7 @@ void block_store_direct_warp_striped(unsigned int flat_id,
 /// \param items - array that data is stored to thread block
 /// \param valid - maximum range of valid numbers to store
 template<
-    unsigned int WarpSize = warp_size(),
+    unsigned int WarpSize = device_warp_size(),
     class OutputIterator,
     class T,
     unsigned int ItemsPerThread
@@ -366,7 +366,7 @@ void block_store_direct_warp_striped(unsigned int flat_id,
                   "The type T must be such that an object of type OutputIterator "
                   "can be dereferenced and assigned a value of type T.");
 
-    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= warp_size(),
+    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
                  "WarpSize must be a power of two and equal or less"
                  "than the size of hardware warp.");
     unsigned int thread_id = detail::logical_lane_id<WarpSize>();

--- a/rocprim/include/rocprim/block/detail/block_reduce_raking_reduce.hpp
+++ b/rocprim/include/rocprim/block/detail/block_reduce_raking_reduce.hpp
@@ -47,12 +47,12 @@ class block_reduce_raking_reduce
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
     // Number of items to reduce per thread
     static constexpr unsigned int thread_reduction_size_ =
-        (BlockSize + ::rocprim::warp_size() - 1)/ ::rocprim::warp_size();
+        (BlockSize + ::rocprim::device_warp_size() - 1)/ ::rocprim::device_warp_size();
 
     // Warp reduce, warp_reduce_crosslane does not require shared memory (storage), but
     // logical warp size must be a power of two.
     static constexpr unsigned int warp_size_ =
-        detail::get_min_warp_size(BlockSize, ::rocprim::warp_size());
+        detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
     // BlockSize is multiple of hardware warp
     static constexpr bool block_size_smaller_than_warp_size_ = (BlockSize < warp_size_);
     using warp_reduce_prefix_type = ::rocprim::detail::warp_reduce_crosslane<T, warp_size_, false>;

--- a/rocprim/include/rocprim/block/detail/block_reduce_warp_reduce.hpp
+++ b/rocprim/include/rocprim/block/detail/block_reduce_warp_reduce.hpp
@@ -47,7 +47,7 @@ class block_reduce_warp_reduce
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
     // Select warp size
     static constexpr unsigned int warp_size_ =
-        detail::get_min_warp_size(BlockSize, ::rocprim::warp_size());
+        detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
     // Number of warps in block
     static constexpr unsigned int warps_no_ = (BlockSize + warp_size_ - 1) / warp_size_;
 

--- a/rocprim/include/rocprim/block/detail/block_scan_reduce_then_scan.hpp
+++ b/rocprim/include/rocprim/block/detail/block_scan_reduce_then_scan.hpp
@@ -47,12 +47,12 @@ class block_scan_reduce_then_scan
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
     // Number of items to reduce per thread
     static constexpr unsigned int thread_reduction_size_ =
-        (BlockSize + ::rocprim::warp_size() - 1)/ ::rocprim::warp_size();
+        (BlockSize + ::rocprim::device_warp_size() - 1)/ ::rocprim::device_warp_size();
 
     // Warp scan, warp_scan_crosslane does not require shared memory (storage), but
     // logical warp size must be a power of two.
     static constexpr unsigned int warp_size_ =
-        detail::get_min_warp_size(BlockSize, ::rocprim::warp_size());
+        detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
     using warp_scan_prefix_type = ::rocprim::detail::warp_scan_crosslane<T, warp_size_>;
 
     // Minimize LDS bank conflicts

--- a/rocprim/include/rocprim/block/detail/block_scan_warp_scan.hpp
+++ b/rocprim/include/rocprim/block/detail/block_scan_warp_scan.hpp
@@ -47,7 +47,7 @@ class block_scan_warp_scan
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
     // Select warp size
     static constexpr unsigned int warp_size_ =
-        detail::get_min_warp_size(BlockSize, ::rocprim::warp_size());
+        detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
     // Number of warps in block
     static constexpr unsigned int warps_no_ = (BlockSize + warp_size_ - 1) / warp_size_;
 
@@ -501,7 +501,7 @@ private:
                              T& output,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<(BlockSize_ > ::rocprim::warp_size())>::type
+        -> typename std::enable_if<(BlockSize_ > ::rocprim::device_warp_size())>::type
     {
         storage_type_& storage_ = storage.get();
         // Perform warp scan
@@ -530,7 +530,7 @@ private:
                              T& output,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<!(BlockSize_ > ::rocprim::warp_size())>::type
+        -> typename std::enable_if<!(BlockSize_ > ::rocprim::device_warp_size())>::type
     {
         (void) storage;
         (void) flat_tid;
@@ -557,7 +557,7 @@ private:
                              T init,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<(BlockSize_ > ::rocprim::warp_size())>::type
+        -> typename std::enable_if<(BlockSize_ > ::rocprim::device_warp_size())>::type
     {
         storage_type_& storage_ = storage.get();
         // Perform warp scan on input values
@@ -597,7 +597,7 @@ private:
                              T init,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<!(BlockSize_ > ::rocprim::warp_size())>::type
+        -> typename std::enable_if<!(BlockSize_ > ::rocprim::device_warp_size())>::type
     {
         (void) flat_tid;
         (void) storage;
@@ -632,7 +632,7 @@ private:
                              T& output,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<(BlockSize_ > ::rocprim::warp_size())>::type
+        -> typename std::enable_if<(BlockSize_ > ::rocprim::device_warp_size())>::type
     {
         storage_type_& storage_ = storage.get();
         // Perform warp scan on input values
@@ -668,7 +668,7 @@ private:
                              T& output,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<!(BlockSize_ > ::rocprim::warp_size())>::type
+        -> typename std::enable_if<!(BlockSize_ > ::rocprim::device_warp_size())>::type
     {
         (void) flat_tid;
         (void) storage;

--- a/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
@@ -203,7 +203,7 @@ private:
         class... KeyValue
     >
     ROCPRIM_DEVICE inline
-    typename std::enable_if<(Size <= ::rocprim::warp_size())>::type
+    typename std::enable_if<(Size <= ::rocprim::device_warp_size())>::type
     sort_power_two(const unsigned int flat_tid,
                    storage_type& storage,
                    BinaryFunction compare_function,
@@ -222,14 +222,14 @@ private:
         class... KeyValue
     >
     ROCPRIM_DEVICE inline
-    typename std::enable_if<(Size > ::rocprim::warp_size())>::type
+    typename std::enable_if<(Size > ::rocprim::device_warp_size())>::type
     sort_power_two(const unsigned int flat_tid,
                    storage_type& storage,
                    BinaryFunction compare_function,
                    KeyValue&... kv)
     {
-        const auto warp_id_is_even = ((flat_tid / ::rocprim::warp_size()) % 2) == 0;
-        ::rocprim::warp_sort<Key, ::rocprim::warp_size(), Value> wsort;
+        const auto warp_id_is_even = ((flat_tid / ::rocprim::device_warp_size()) % 2) == 0;
+        ::rocprim::warp_sort<Key, ::rocprim::device_warp_size(), Value> wsort;
         auto compare_function2 =
             [compare_function, warp_id_is_even](const Key& a, const Key& b) mutable -> bool
             {
@@ -241,7 +241,7 @@ private:
         wsort.sort(kv..., compare_function2);
 
         #pragma unroll
-        for(unsigned int length = ::rocprim::warp_size(); length < Size; length *= 2)
+        for(unsigned int length = ::rocprim::device_warp_size(); length < Size; length *= 2)
         {
             bool dir = (flat_tid & (length * 2)) != 0;
             #pragma unroll

--- a/rocprim/include/rocprim/config.hpp
+++ b/rocprim/include/rocprim/config.hpp
@@ -73,4 +73,8 @@
     #define ROCPRIM_TARGET_ARCH 0
 #endif
 
+/// Supported warp sizes
+#define ROCPRIM_WARP_SIZE_32 32u
+#define ROCPRIM_WARP_SIZE_64 64u
+
 #endif // ROCPRIM_CONFIG_HPP_

--- a/rocprim/include/rocprim/config.hpp
+++ b/rocprim/include/rocprim/config.hpp
@@ -76,5 +76,6 @@
 /// Supported warp sizes
 #define ROCPRIM_WARP_SIZE_32 32u
 #define ROCPRIM_WARP_SIZE_64 64u
+#define ROCPRIM_MAX_WARP_SIZE ROCPRIM_WARP_SIZE_64
 
 #endif // ROCPRIM_CONFIG_HPP_

--- a/rocprim/include/rocprim/device/config_types.hpp
+++ b/rocprim/include/rocprim/device/config_types.hpp
@@ -57,7 +57,7 @@ template<
     unsigned int MaxBlockSize,
     unsigned int SharedMemoryPerThread,
     // Most kernels require block sizes not smaller than warp
-    unsigned int MinBlockSize
+    unsigned int MinBlockSize, 
     // Can fit in shared memory?
     // Although GPUs have 64KiB, 32KiB is used here as a "soft" limit,
     // because some additional memory may be required in kernels

--- a/rocprim/include/rocprim/device/config_types.hpp
+++ b/rocprim/include/rocprim/device/config_types.hpp
@@ -57,7 +57,7 @@ template<
     unsigned int MaxBlockSize,
     unsigned int SharedMemoryPerThread,
     // Most kernels require block sizes not smaller than warp
-    unsigned int MinBlockSize = ::rocprim::warp_size(),
+    unsigned int MinBlockSize
     // Can fit in shared memory?
     // Although GPUs have 64KiB, 32KiB is used here as a "soft" limit,
     // because some additional memory may be required in kernels

--- a/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -526,11 +526,11 @@ void histogram_global(SampleIterator samples,
             if(sample_to_bin_op[channel](values[i].values[channel], bin))
             {
                 const unsigned int pos = flat_id * ItemsPerThread + i;
-                unsigned long long same_bin_lanes_mask = ::rocprim::ballot(pos < valid_count);
+                lane_mask_type same_bin_lanes_mask = ::rocprim::ballot(pos < valid_count);
                 for(unsigned int b = 0; b < bins_bits[channel]; b++)
                 {
                     const unsigned int bit_set = bin & (1u << b);
-                    const unsigned long long bit_set_mask = ::rocprim::ballot(bit_set);
+                    const lane_mask_type bit_set_mask = ::rocprim::ballot(bit_set);
                     same_bin_lanes_mask &= (bit_set ? bit_set_mask : ~bit_set_mask);
                 }
                 const unsigned int same_bin_count = ::rocprim::bit_count(same_bin_lanes_mask);

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -158,11 +158,11 @@ struct radix_digit_count_helper
                 const bit_key_type bit_key = key_codec::encode(keys[i]);
                 const unsigned int digit = (bit_key >> bit) & radix_mask;
                 const unsigned int pos = i * BlockSize + flat_id;
-                unsigned long long same_digit_lanes_mask = ::rocprim::ballot(IsFull || (pos < valid_count));
+                lane_mask_type same_digit_lanes_mask = ::rocprim::ballot(IsFull || (pos < valid_count));
                 for(unsigned int b = 0; b < RadixBits; b++)
                 {
                     const unsigned int bit_set = digit & (1u << b);
-                    const unsigned long long bit_set_mask = ::rocprim::ballot(bit_set);
+                    const lane_mask_type bit_set_mask = ::rocprim::ballot(bit_set);
                     same_digit_lanes_mask &= (bit_set ? bit_set_mask : ~bit_set_mask);
                 }
                 const unsigned int same_digit_count = ::rocprim::bit_count(same_digit_lanes_mask);

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -86,6 +86,7 @@ void sort_block(SortType sorter,
 }
 
 template<
+    unsigned int WarpSize,
     unsigned int BlockSize,
     unsigned int ItemsPerThread,
     unsigned int RadixBits,
@@ -95,7 +96,7 @@ struct radix_digit_count_helper
 {
     static constexpr unsigned int radix_size = 1 << RadixBits;
 
-    static constexpr unsigned int warp_size = ::rocprim::warp_size();
+    static constexpr unsigned int warp_size = WarpSize;
     static constexpr unsigned int warps_no = BlockSize / warp_size;
     static_assert(BlockSize % warp_size == 0, "BlockSize must be divisible by warp size");
     static_assert(radix_size <= BlockSize, "Radix size must not exceed BlockSize");
@@ -396,7 +397,7 @@ void fill_digit_counts(KeysInputIterator keys_input,
     constexpr unsigned int radix_size = 1 << RadixBits;
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
-    using count_helper_type = radix_digit_count_helper<BlockSize, ItemsPerThread, RadixBits, Descending>;
+    using count_helper_type = radix_digit_count_helper<::rocprim::warp_size(), BlockSize, ItemsPerThread, RadixBits, Descending>;
 
     ROCPRIM_SHARED_MEMORY typename count_helper_type::storage_type storage;
 

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -98,7 +98,7 @@ struct radix_digit_count_helper
 
     static constexpr unsigned int warp_size = WarpSize;
     static constexpr unsigned int warps_no = BlockSize / warp_size;
-    static_assert(BlockSize % warp_size == 0, "BlockSize must be divisible by warp size");
+    static_assert(BlockSize % ::rocprim::device_warp_size() == 0, "BlockSize must be divisible by warp size");
     static_assert(radix_size <= BlockSize, "Radix size must not exceed BlockSize");
 
     struct storage_type
@@ -397,7 +397,7 @@ void fill_digit_counts(KeysInputIterator keys_input,
     constexpr unsigned int radix_size = 1 << RadixBits;
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
-    using count_helper_type = radix_digit_count_helper<::rocprim::warp_size(), BlockSize, ItemsPerThread, RadixBits, Descending>;
+    using count_helper_type = radix_digit_count_helper<::rocprim::device_warp_size(), BlockSize, ItemsPerThread, RadixBits, Descending>;
 
     ROCPRIM_SHARED_MEMORY typename count_helper_type::storage_type storage;
 

--- a/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
+++ b/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
@@ -165,7 +165,7 @@ void fill_unique_counts(KeysInputIterator keys_input,
                         unsigned int full_batches)
 {
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
-    constexpr unsigned int warp_size = ::rocprim::warp_size();
+    constexpr unsigned int warp_size = ::rocprim::device_warp_size();
     constexpr unsigned int warps_no = BlockSize / warp_size;
 
     using key_type = typename std::iterator_traits<KeysInputIterator>::value_type;

--- a/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
@@ -45,6 +45,7 @@ namespace detail
 template<
     class Key,
     class Value,
+    unsigned int WarpSize,
     unsigned int BlockSize,
     unsigned int ItemsPerThread,
     unsigned int RadixBits,
@@ -57,7 +58,7 @@ class segmented_radix_sort_helper
     using key_type = Key;
     using value_type = Value;
 
-    using count_helper_type = radix_digit_count_helper<BlockSize, ItemsPerThread, RadixBits, Descending>;
+    using count_helper_type = radix_digit_count_helper<WarpSize, BlockSize, ItemsPerThread, RadixBits, Descending>;
     using scan_type = typename ::rocprim::block_scan<unsigned int, radix_size>;
     using sort_and_scatter_helper = radix_sort_and_scatter_helper<
         BlockSize, ItemsPerThread, RadixBits, Descending,
@@ -505,12 +506,12 @@ void segmented_sort(KeysInputIterator keys_input,
     >;
     using long_radix_helper_type = segmented_radix_sort_helper<
         key_type, value_type,
-        block_size, items_per_thread,
+        ::rocprim::warp_size(), block_size, items_per_thread,
         long_radix_bits, Descending
     >;
     using short_radix_helper_type = segmented_radix_sort_helper<
         key_type, value_type,
-        block_size, items_per_thread,
+        ::rocprim::warp_size(), block_size, items_per_thread,
         short_radix_bits, Descending
     >;
 

--- a/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
@@ -506,12 +506,12 @@ void segmented_sort(KeysInputIterator keys_input,
     >;
     using long_radix_helper_type = segmented_radix_sort_helper<
         key_type, value_type,
-        ::rocprim::warp_size(), block_size, items_per_thread,
+        ::rocprim::device_warp_size(), block_size, items_per_thread,
         long_radix_bits, Descending
     >;
     using short_radix_helper_type = segmented_radix_sort_helper<
         key_type, value_type,
-        ::rocprim::warp_size(), block_size, items_per_thread,
+        ::rocprim::device_warp_size(), block_size, items_per_thread,
         short_radix_bits, Descending
     >;
 

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -84,11 +84,11 @@ private:
     static constexpr unsigned int padding = ::rocprim::warp_size();
 
     // Helper struct
-    struct prefix_type
+    struct alignas(sizeof(prefix_underlying_type)) prefix_type
     {
         flag_type_ flag;
         T value;
-    } __attribute__((aligned(sizeof(prefix_underlying_type))));
+    };
 
     static_assert(sizeof(prefix_underlying_type) == sizeof(prefix_type), "");
 

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -81,8 +81,6 @@ private:
             unsigned int
         >::type;
 
-    static constexpr unsigned int padding = ::rocprim::warp_size();
-
     // Helper struct
     struct alignas(sizeof(prefix_underlying_type)) prefix_type
     {
@@ -110,13 +108,15 @@ public:
     ROCPRIM_HOST static inline
     size_t get_storage_size(const unsigned int number_of_blocks)
     {
-        return sizeof(prefix_underlying_type) * (padding + number_of_blocks);
+        return sizeof(prefix_underlying_type) * (::rocprim::host_warp_size() + number_of_blocks);
     }
 
     ROCPRIM_DEVICE inline
     void initialize_prefix(const unsigned int block_id,
                            const unsigned int number_of_blocks)
     {
+        constexpr unsigned int padding = ::rocprim::warp_size();
+
         if(block_id < number_of_blocks)
         {
             prefix_type prefix;
@@ -151,6 +151,8 @@ public:
     ROCPRIM_DEVICE inline
     void get(const unsigned int block_id, flag_type& flag, T& value)
     {
+        constexpr unsigned int padding = ::rocprim::warp_size();
+
         prefix_type prefix;
 
         const uint SLEEP_MAX = 32;
@@ -181,6 +183,8 @@ private:
     ROCPRIM_DEVICE inline
     void set(const unsigned int block_id, const flag_type flag, const T value)
     {
+        constexpr unsigned int padding = ::rocprim::warp_size();
+
         prefix_type prefix = { flag, value };
         prefix_underlying_type p;
         __builtin_memcpy(&p, &prefix, sizeof(prefix_type));
@@ -195,8 +199,6 @@ private:
 template<class T, bool UseSleep>
 struct lookback_scan_state<T, UseSleep, false>
 {
-private:
-    static constexpr unsigned int padding = ::rocprim::warp_size();
 
 public:
     using flag_type = char;
@@ -206,7 +208,7 @@ public:
     ROCPRIM_HOST static inline
     lookback_scan_state create(void* temp_storage, const unsigned int number_of_blocks)
     {
-        const auto n = padding + number_of_blocks;
+        const auto n = ::rocprim::host_warp_size() + number_of_blocks;
         lookback_scan_state state;
 
         auto ptr = reinterpret_cast<char*>(temp_storage);
@@ -224,7 +226,7 @@ public:
     ROCPRIM_HOST static inline
     size_t get_storage_size(const unsigned int number_of_blocks)
     {
-        const auto n = padding + number_of_blocks;
+        const auto n = ::rocprim::host_warp_size() + number_of_blocks;
         size_t size = ::rocprim::detail::align_size(n * sizeof(flag_type));
         size += 2 * ::rocprim::detail::align_size(n * sizeof(T));
         return size;
@@ -234,6 +236,7 @@ public:
     void initialize_prefix(const unsigned int block_id,
                            const unsigned int number_of_blocks)
     {
+        constexpr unsigned int padding = ::rocprim::warp_size();
         if(block_id < number_of_blocks)
         {
             prefixes_flags[padding + block_id] = PREFIX_EMPTY;
@@ -247,6 +250,8 @@ public:
     ROCPRIM_DEVICE inline
     void set_partial(const unsigned int block_id, const T value)
     {
+        constexpr unsigned int padding = ::rocprim::warp_size();
+
         store_volatile(&prefixes_partial_values[padding + block_id], value);
         ::rocprim::detail::memory_fence_device();
         store_volatile<flag_type>(&prefixes_flags[padding + block_id], PREFIX_PARTIAL);
@@ -255,6 +260,8 @@ public:
     ROCPRIM_DEVICE inline
     void set_complete(const unsigned int block_id, const T value)
     {
+        constexpr unsigned int padding = ::rocprim::warp_size();
+
         store_volatile(&prefixes_complete_values[padding + block_id], value);
         ::rocprim::detail::memory_fence_device();
         store_volatile<flag_type>(&prefixes_flags[padding + block_id], PREFIX_COMPLETE);
@@ -264,6 +271,8 @@ public:
     ROCPRIM_DEVICE inline
     void get(const unsigned int block_id, flag_type& flag, T& value)
     {
+        constexpr unsigned int padding = ::rocprim::warp_size();
+
         const uint SLEEP_MAX = 32;
         uint times_through = 1;
 

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -115,7 +115,7 @@ public:
     void initialize_prefix(const unsigned int block_id,
                            const unsigned int number_of_blocks)
     {
-        constexpr unsigned int padding = ::rocprim::warp_size();
+        constexpr unsigned int padding = ::rocprim::device_warp_size();
 
         if(block_id < number_of_blocks)
         {
@@ -151,7 +151,7 @@ public:
     ROCPRIM_DEVICE inline
     void get(const unsigned int block_id, flag_type& flag, T& value)
     {
-        constexpr unsigned int padding = ::rocprim::warp_size();
+        constexpr unsigned int padding = ::rocprim::device_warp_size();
 
         prefix_type prefix;
 
@@ -183,7 +183,7 @@ private:
     ROCPRIM_DEVICE inline
     void set(const unsigned int block_id, const flag_type flag, const T value)
     {
-        constexpr unsigned int padding = ::rocprim::warp_size();
+        constexpr unsigned int padding = ::rocprim::device_warp_size();
 
         prefix_type prefix = { flag, value };
         prefix_underlying_type p;
@@ -236,7 +236,7 @@ public:
     void initialize_prefix(const unsigned int block_id,
                            const unsigned int number_of_blocks)
     {
-        constexpr unsigned int padding = ::rocprim::warp_size();
+        constexpr unsigned int padding = ::rocprim::device_warp_size();
         if(block_id < number_of_blocks)
         {
             prefixes_flags[padding + block_id] = PREFIX_EMPTY;
@@ -250,7 +250,7 @@ public:
     ROCPRIM_DEVICE inline
     void set_partial(const unsigned int block_id, const T value)
     {
-        constexpr unsigned int padding = ::rocprim::warp_size();
+        constexpr unsigned int padding = ::rocprim::device_warp_size();
 
         store_volatile(&prefixes_partial_values[padding + block_id], value);
         ::rocprim::detail::memory_fence_device();
@@ -260,7 +260,7 @@ public:
     ROCPRIM_DEVICE inline
     void set_complete(const unsigned int block_id, const T value)
     {
-        constexpr unsigned int padding = ::rocprim::warp_size();
+        constexpr unsigned int padding = ::rocprim::device_warp_size();
 
         store_volatile(&prefixes_complete_values[padding + block_id], value);
         ::rocprim::detail::memory_fence_device();
@@ -271,7 +271,7 @@ public:
     ROCPRIM_DEVICE inline
     void get(const unsigned int block_id, flag_type& flag, T& value)
     {
-        constexpr unsigned int padding = ::rocprim::warp_size();
+        constexpr unsigned int padding = ::rocprim::device_warp_size();
 
         const uint SLEEP_MAX = 32;
         uint times_through = 1;
@@ -342,7 +342,7 @@ public:
             BinaryFunction, T, T
         >;
         using warp_reduce_prefix_type = warp_reduce_crosslane<
-            T, ::rocprim::warp_size(), false
+            T, ::rocprim::device_warp_size(), false
         >;
 
         T block_prefix;
@@ -381,7 +381,7 @@ public:
             {
                 prefix = scan_op_(partial_prefix, prefix);
             }
-            previous_block_id -= ::rocprim::warp_size();
+            previous_block_id -= ::rocprim::device_warp_size();
             // while we don't load a complete prefix, reduce partial prefixes
         } while(::rocprim::detail::warp_all(flag != PREFIX_COMPLETE));
         return prefix;

--- a/rocprim/include/rocprim/device/device_merge_sort_config.hpp
+++ b/rocprim/include/rocprim/device/device_merge_sort_config.hpp
@@ -45,25 +45,37 @@ namespace detail
 template<class Key, class Value>
 struct merge_sort_config_803
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value)>::value>;
+    using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 template<class Key>
 struct merge_sort_config_803<Key, empty_type>
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key)>::value>;
+    using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 template<class Key, class Value>
 struct merge_sort_config_900
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value)>::value>;
+    using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 template<class Key>
 struct merge_sort_config_900<Key, empty_type>
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key)>::value>;
+    using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>;
+};
+
+template<class Key, class Value>
+struct merge_sort_config_1031
+{
+    using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_32>::value>;
+};
+
+template<class Key>
+struct merge_sort_config_1031<Key, empty_type>
+{
+    using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_32>::value>;
 };
 
 template<unsigned int TargetArch, class Key, class Value>
@@ -72,6 +84,7 @@ struct default_merge_sort_config
         TargetArch,
         select_arch_case<803, merge_sort_config_803<Key, Value>>,
         select_arch_case<900, merge_sort_config_900<Key, Value>>,
+        select_arch_case<1031, merge_sort_config_1031<Key, Value>>,
         merge_sort_config_900<Key, Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_radix_sort_config.hpp
+++ b/rocprim/include/rocprim/device/device_radix_sort_config.hpp
@@ -95,7 +95,7 @@ struct radix_sort_config_803
         radix_sort_config<
             6, 4, scan,
             kernel_config<
-                limit_block_size<256U, sizeof(Value)>::value,
+                limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
                 ::rocprim::max(1u, 15u / item_scale)
             >
         >
@@ -139,7 +139,7 @@ struct radix_sort_config_900
         radix_sort_config<
             6, 4, scan,
             kernel_config<
-                limit_block_size<256U, sizeof(Value)>::value,
+                limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
                 ::rocprim::max(1u, 15u / item_scale)
             >
         >
@@ -155,12 +155,59 @@ struct radix_sort_config_900<Key, empty_type>
         select_type_case<sizeof(Key) == 8, radix_sort_config<7, 6, kernel_config<256, 2>, kernel_config<256, 15> > >
     > { };
 
+
+// TODO: We need to update these parameters
+template<class Key, class Value>
+struct radix_sort_config_1031
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
+
+    using scan = kernel_config<256, 2>;
+
+    using type = select_type<
+        select_type_case<
+            (sizeof(Key) == 1 && sizeof(Value) <= 8),
+            radix_sort_config<4, 4, scan, kernel_config<256, 10> >
+        >,
+        select_type_case<
+            (sizeof(Key) == 2 && sizeof(Value) <= 8),
+            radix_sort_config<6, 5, scan, kernel_config<256, 10> >
+        >,
+        select_type_case<
+            (sizeof(Key) == 4 && sizeof(Value) <= 8),
+            radix_sort_config<7, 6, scan, kernel_config<256, 15> >
+        >,
+        select_type_case<
+            (sizeof(Key) == 8 && sizeof(Value) <= 8),
+            radix_sort_config<7, 6, scan, kernel_config<256, 15> >
+        >,
+        radix_sort_config<
+            6, 4, scan,
+            kernel_config<
+                limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_32>::value,
+                ::rocprim::max(1u, 15u / item_scale)
+            >
+        >
+    >;
+};
+
+template<class Key>
+struct radix_sort_config_1031<Key, empty_type>
+    : select_type<
+        select_type_case<sizeof(Key) == 1, radix_sort_config<4, 3, kernel_config<256, 2>, kernel_config<256, 10> > >,
+        select_type_case<sizeof(Key) == 2, radix_sort_config<6, 5, kernel_config<256, 2>, kernel_config<256, 10> > >,
+        select_type_case<sizeof(Key) == 4, radix_sort_config<7, 6, kernel_config<256, 2>, kernel_config<256, 17> > >,
+        select_type_case<sizeof(Key) == 8, radix_sort_config<7, 6, kernel_config<256, 2>, kernel_config<256, 15> > >
+    > { };
+
 template<unsigned int TargetArch, class Key, class Value>
 struct default_radix_sort_config
     : select_arch<
         TargetArch,
         select_arch_case<803, radix_sort_config_803<Key, Value> >,
         select_arch_case<900, radix_sort_config_900<Key, Value> >,
+        select_arch_case<1031, radix_sort_config_1031<Key, Value> >,
         radix_sort_config_900<Key, Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_reduce_by_key_config.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_by_key_config.hpp
@@ -65,7 +65,7 @@ struct reduce_by_key_config_803
             (sizeof(Key) <= 8 && sizeof(Value) <= 8),
             reduce_by_key_config<scan, kernel_config<256, 7> >
         >,
-        reduce_by_key_config<scan, kernel_config<limit_block_size<256U, sizeof(Key) + sizeof(Value)>::value, ::rocprim::max(1u, 15u / item_scale)> >
+        reduce_by_key_config<scan, kernel_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_64>::value, ::rocprim::max(1u, 15u / item_scale)> >
     >;
 };
 
@@ -82,7 +82,25 @@ struct reduce_by_key_config_900
             (sizeof(Key) <= 8 && sizeof(Value) <= 8),
             reduce_by_key_config<scan, kernel_config<256, 10> >
         >,
-        reduce_by_key_config<scan, kernel_config<limit_block_size<256U, sizeof(Key) + sizeof(Value)>::value, ::rocprim::max(1u, 15u / item_scale)> >
+        reduce_by_key_config<scan, kernel_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_64>::value, ::rocprim::max(1u, 15u / item_scale)> >
+    >;
+};
+
+// TODO: Need to update
+template<class Key, class Value>
+struct reduce_by_key_config_1031
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Key) + sizeof(Value), 2 * sizeof(int));
+
+    using scan = kernel_config<256, 2>;
+
+    using type = select_type<
+        select_type_case<
+            (sizeof(Key) <= 8 && sizeof(Value) <= 8),
+            reduce_by_key_config<scan, kernel_config<256, 10> >
+        >,
+        reduce_by_key_config<scan, kernel_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_32>::value, ::rocprim::max(1u, 15u / item_scale)> >
     >;
 };
 
@@ -92,6 +110,7 @@ struct default_reduce_by_key_config
         TargetArch,
         select_arch_case<803, reduce_by_key_config_803<Key, Value> >,
         select_arch_case<900, reduce_by_key_config_900<Key, Value> >,
+        select_arch_case<1031, reduce_by_key_config_1031<Key, Value> >,
         reduce_by_key_config_900<Key, Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_reduce_config.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_config.hpp
@@ -65,7 +65,7 @@ struct reduce_config_803
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
 
     using type = reduce_config<
-        limit_block_size<256U, sizeof(Value)>::value,
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
         ::rocprim::max(1u, 16u / item_scale),
         ::rocprim::block_reduce_algorithm::using_warp_reduce
     >;
@@ -78,7 +78,20 @@ struct reduce_config_900
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
 
     using type = reduce_config<
-        limit_block_size<256U, sizeof(Value)>::value,
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
+        ::rocprim::max(1u, 16u / item_scale),
+        ::rocprim::block_reduce_algorithm::using_warp_reduce
+    >;
+};
+
+template<class Value>
+struct reduce_config_1031
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
+
+    using type = reduce_config<
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_32>::value,
         ::rocprim::max(1u, 16u / item_scale),
         ::rocprim::block_reduce_algorithm::using_warp_reduce
     >;
@@ -90,6 +103,7 @@ struct default_reduce_config
         TargetArch,
         select_arch_case<803, reduce_config_803<Value>>,
         select_arch_case<900, reduce_config_900<Value>>,
+        select_arch_case<1031, reduce_config_1031<Value>>,
         reduce_config_900<Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_scan.hpp
+++ b/rocprim/include/rocprim/device/device_scan.hpp
@@ -326,8 +326,10 @@ auto scan_impl(void * temporary_storage,
     -> typename std::enable_if<Config::use_lookback, hipError_t>::type
 {
     using input_type = typename std::iterator_traits<InputIterator>::value_type;
-    using result_type = typename ::rocprim::detail::match_result_type<
-        input_type, BinaryFunction
+    using result_type = typename std::remove_reference<
+        typename ::rocprim::detail::match_result_type<
+            input_type, BinaryFunction
+        >::type
     >::type;
 
     using config = Config;
@@ -566,7 +568,7 @@ hipError_t inclusive_scan(void * temporary_storage,
     return detail::scan_impl<false, config>(
         temporary_storage, storage_size,
         // result_type() is a dummy initial value (not used)
-        input, output, result_type(), size,
+        input, output, result_type{}, size,
         scan_op, stream, debug_synchronous
     );
 }

--- a/rocprim/include/rocprim/device/device_scan_config.hpp
+++ b/rocprim/include/rocprim/device/device_scan_config.hpp
@@ -79,7 +79,7 @@ struct scan_config_803
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
 
     using type = scan_config<
-        limit_block_size<256U, sizeof(Value)>::value,
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
         ::rocprim::max(1u, 16u / item_scale),
         ROCPRIM_DETAIL_USE_LOOKBACK_SCAN,
         ::rocprim::block_load_method::block_load_transpose,
@@ -95,7 +95,23 @@ struct scan_config_900
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
 
     using type = scan_config<
-        limit_block_size<256U, sizeof(Value)>::value,
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
+        ::rocprim::max(1u, 16u / item_scale),
+        ROCPRIM_DETAIL_USE_LOOKBACK_SCAN,
+        ::rocprim::block_load_method::block_load_transpose,
+        ::rocprim::block_store_method::block_store_transpose,
+        ::rocprim::block_scan_algorithm::using_warp_scan
+    >;
+};
+
+template<class Value>
+struct scan_config_1031
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
+
+    using type = scan_config<
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_32>::value,
         ::rocprim::max(1u, 16u / item_scale),
         ROCPRIM_DETAIL_USE_LOOKBACK_SCAN,
         ::rocprim::block_load_method::block_load_transpose,
@@ -110,6 +126,7 @@ struct default_scan_config
         TargetArch,
         select_arch_case<803, scan_config_803<Value>>,
         select_arch_case<900, scan_config_900<Value>>,
+        select_arch_case<1031, scan_config_1031<Value>>,
         scan_config_900<Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_select_config.hpp
+++ b/rocprim/include/rocprim/device/device_select_config.hpp
@@ -74,7 +74,7 @@ struct select_config_803
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
 
     using type = select_config<
-        limit_block_size<256U, sizeof(Value)>::value,
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
         ::rocprim::max(1u, 13u / item_scale),
         ::rocprim::block_load_method::block_load_transpose,
         ::rocprim::block_load_method::block_load_transpose,
@@ -89,7 +89,7 @@ struct select_config_900
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
 
     using type = select_config<
-        limit_block_size<256U, sizeof(Value)>::value,
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
         ::rocprim::max(1u, 15u / item_scale),
         ::rocprim::block_load_method::block_load_transpose,
         ::rocprim::block_load_method::block_load_transpose,
@@ -97,12 +97,29 @@ struct select_config_900
     >;
 };
 
+template<class Value>
+struct select_config_1031
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
+
+    using type = select_config<
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_32>::value,
+        ::rocprim::max(1u, 15u / item_scale),
+        ::rocprim::block_load_method::block_load_transpose,
+        ::rocprim::block_load_method::block_load_transpose,
+        ::rocprim::block_scan_algorithm::using_warp_scan
+    >;
+};
+
+
 template<unsigned int TargetArch, class Value>
 struct default_select_config
     : select_arch<
         TargetArch,
         select_arch_case<803, select_config_803<Value>>,
         select_arch_case<900, select_config_900<Value>>,
+        select_arch_case<1031, select_config_1031<Value>>,
         select_config_803<Value>
     > { };
 

--- a/rocprim/include/rocprim/functional.hpp
+++ b/rocprim/include/rocprim/functional.hpp
@@ -31,6 +31,15 @@ BEGIN_ROCPRIM_NAMESPACE
 /// \addtogroup utilsmodule_functional
 /// @{
 
+#define ROCPRIM_PRINT_ERROR_ONCE(message) \
+{                                          \
+    unsigned int idx = hipThreadIdx_x + (hipBlockIdx_x * hipBlockDim_x); \
+    idx += hipThreadIdx_y + (hipBlockIdx_y * hipBlockDim_y);             \
+    idx += hipThreadIdx_z + (hipBlockIdx_z * hipBlockDim_z);             \
+    if (idx == 0)                                                        \
+        printf("%s\n", #message);                                        \
+}
+
 template<class T>
 ROCPRIM_HOST_DEVICE inline
 constexpr T max(const T& a, const T& b)

--- a/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -51,7 +51,7 @@ unsigned int host_warp_size()
 /// \brief Returns a number of threads in a hardware warp.
 ///
 /// It is constant for a device.
-ROCPRIM_HOST_DEVICE inline
+ROCPRIM_DEVICE inline
 constexpr unsigned int warp_size()
 {
     return warpSize;

--- a/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -34,7 +34,7 @@ BEGIN_ROCPRIM_NAMESPACE
 // Sizes
 
 /// \brief Returns a number of threads in a hardware warp for the actual device.
-/// At device side this constant is not available at compile time.
+/// At host side this constant is available at runtime time only.
 ///
 /// It is constant for a device.
 ROCPRIM_HOST inline

--- a/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -33,7 +33,8 @@ BEGIN_ROCPRIM_NAMESPACE
 
 // Sizes
 
-/// \brief Returns a number of threads in a hardware warp for the actual device
+/// \brief Returns a number of threads in a hardware warp for the actual device.
+/// At device side this constant is not available at compile time.
 ///
 /// It is constant for a device.
 ROCPRIM_HOST inline
@@ -48,11 +49,12 @@ unsigned int host_warp_size()
     return warp_size;
 };
 
-/// \brief Returns a number of threads in a hardware warp.
+/// \brief Returns a number of threads in a hardware warp for the actual target.
+/// At device side this constant is available at compile time.
 ///
 /// It is constant for a device.
 ROCPRIM_DEVICE inline
-constexpr unsigned int warp_size()
+constexpr unsigned int device_warp_size()
 {
     return warpSize;
 }
@@ -126,13 +128,13 @@ unsigned int flat_tile_thread_id()
 ROCPRIM_DEVICE inline
 unsigned int warp_id()
 {
-    return flat_block_thread_id()/warp_size();
+    return flat_block_thread_id()/device_warp_size();
 }
 
 ROCPRIM_DEVICE inline
 unsigned int warp_id(unsigned int flat_id)
 {
-    return flat_id/warp_size();
+    return flat_id/device_warp_size();
 }
 
 /// \brief Returns warp id in a block (tile). Use template parameters to optimize 1D or 2D kernels.
@@ -140,7 +142,7 @@ template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSiz
 ROCPRIM_DEVICE inline
 unsigned int warp_id()
 {
-    return flat_block_thread_id<BlockSizeX, BlockSizeY, BlockSizeZ>()/warp_size();
+    return flat_block_thread_id<BlockSizeX, BlockSizeY, BlockSizeZ>()/device_warp_size();
 }
 
 /// \brief Returns flat (linear, 1D) block identifier in a multidimensional grid.
@@ -269,7 +271,7 @@ namespace detail
 
     template<>
     ROCPRIM_DEVICE inline
-    unsigned int logical_lane_id<warp_size()>()
+    unsigned int logical_lane_id<device_warp_size()>()
     {
         return lane_id();
     }
@@ -284,7 +286,7 @@ namespace detail
 
     template<>
     ROCPRIM_DEVICE inline
-    unsigned int logical_warp_id<warp_size()>()
+    unsigned int logical_warp_id<device_warp_size()>()
     {
         return warp_id();
     }

--- a/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -33,6 +33,21 @@ BEGIN_ROCPRIM_NAMESPACE
 
 // Sizes
 
+/// \brief Returns a number of threads in a hardware warp for the actual device
+///
+/// It is constant for a device.
+ROCPRIM_HOST inline
+unsigned int host_warp_size()
+{
+    unsigned int warp_size = -1;
+    int default_hip_device;
+    hipGetDevice(&default_hip_device);
+    hipDeviceProp_t device_prop;
+    hipGetDeviceProperties(&device_prop,default_hip_device);
+    warp_size = device_prop.warpSize;
+    return warp_size;
+};
+
 /// \brief Returns a number of threads in a hardware warp.
 ///
 /// It is constant for a device.

--- a/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -51,7 +51,7 @@ unsigned int host_warp_size()
 /// \brief Returns a number of threads in a hardware warp.
 ///
 /// It is constant for a device.
-ROCPRIM_DEVICE inline
+ROCPRIM_HOST_DEVICE inline
 constexpr unsigned int warp_size()
 {
     return warpSize;

--- a/rocprim/include/rocprim/intrinsics/warp.hpp
+++ b/rocprim/include/rocprim/intrinsics/warp.hpp
@@ -34,7 +34,7 @@ BEGIN_ROCPRIM_NAMESPACE
 ///
 /// \param predicate - input to be evaluated for all active lanes
 ROCPRIM_DEVICE inline
-unsigned long long ballot(int predicate)
+lane_mask_type ballot(int predicate)
 {
     return ::__ballot(predicate);
 }
@@ -44,16 +44,24 @@ unsigned long long ballot(int predicate)
 /// For each thread, this function returns the number of active threads which
 /// have <tt>i</tt>-th bit of \p x set and come before the current thread.
 ROCPRIM_DEVICE inline
-unsigned int masked_bit_count(unsigned long long x, unsigned int add = 0)
+unsigned int masked_bit_count(lane_mask_type x, unsigned int add = 0)
 {
     int c;
-    #ifdef __HIP__
-    c = ::__builtin_amdgcn_mbcnt_lo(static_cast<int>(x), add);
-    c = ::__builtin_amdgcn_mbcnt_hi(static_cast<int>(x >> 32), c);
+    #if __AMDGCN_WAVEFRONT_SIZE == 32
+        #ifdef __HIP__
+        c = ::__builtin_amdgcn_mbcnt_lo(x, add);
+        #else
+        c = ::__mbcnt_lo(x, add);
+        #endif
     #else
-    c = ::__mbcnt_lo(static_cast<int>(x), add);
-    c = ::__mbcnt_hi(static_cast<int>(x >> 32), c);
-    #endif  
+        #ifdef __HIP__
+        c = ::__builtin_amdgcn_mbcnt_lo(static_cast<int>(x), add);
+        c = ::__builtin_amdgcn_mbcnt_hi(static_cast<int>(x >> 32), c);
+        #else
+        c = ::__mbcnt_lo(static_cast<int>(x), add);
+        c = ::__mbcnt_hi(static_cast<int>(x >> 32), c);
+        #endif
+    #endif
     return c;
 }
 

--- a/rocprim/include/rocprim/intrinsics/warp_shuffle.hpp
+++ b/rocprim/include/rocprim/intrinsics/warp_shuffle.hpp
@@ -84,20 +84,20 @@ T warp_move_dpp(T input)
 /// \brief Shuffle for any data type.
 ///
 /// Each thread in warp obtains \p input from <tt>src_lane</tt>-th thread
-/// in warp. If \p width is less than warp_size() then each subsection of the
+/// in warp. If \p width is less than device_warp_size() then each subsection of the
 /// warp behaves as a separate entity with a starting logical lane id of 0.
 /// If \p src_lane is not in [0; \p width) range, the returned value is
 /// equal to \p input passed by the <tt>src_lane modulo width</tt> thread.
 ///
 /// Note: The optional \p width parameter must be a power of 2; results are
-/// undefined if it is not a power of 2, or it is greater than warp_size().
+/// undefined if it is not a power of 2, or it is greater than device_warp_size().
 ///
 /// \param input - input to pass to other threads
 /// \param src_lane - warp if of a thread whose \p input should be returned
 /// \param width - logical warp width
 template<class T>
 ROCPRIM_DEVICE inline
-T warp_shuffle(T input, const int src_lane, const int width = warp_size())
+T warp_shuffle(T input, const int src_lane, const int width = device_warp_size())
 {
     return detail::warp_shuffle_op(
         input,
@@ -115,14 +115,14 @@ T warp_shuffle(T input, const int src_lane, const int width = warp_size())
 /// thread's own \p input is returned.
 ///
 /// Note: The optional \p width parameter must be a power of 2; results are
-/// undefined if it is not a power of 2, or it is greater than warp_size().
+/// undefined if it is not a power of 2, or it is greater than device_warp_size().
 ///
 /// \param input - input to pass to other threads
 /// \param delta - offset for calculating source lane id
 /// \param width - logical warp width
 template<class T>
 ROCPRIM_DEVICE inline
-T warp_shuffle_up(T input, const unsigned int delta, const int width = warp_size())
+T warp_shuffle_up(T input, const unsigned int delta, const int width = device_warp_size())
 {
     return detail::warp_shuffle_op(
         input,
@@ -140,14 +140,14 @@ T warp_shuffle_up(T input, const unsigned int delta, const int width = warp_size
 /// thread's own \p input is returned.
 ///
 /// Note: The optional \p width parameter must be a power of 2; results are
-/// undefined if it is not a power of 2, or it is greater than warp_size().
+/// undefined if it is not a power of 2, or it is greater than device_warp_size().
 ///
 /// \param input - input to pass to other threads
 /// \param delta - offset for calculating source lane id
 /// \param width - logical warp width
 template<class T>
 ROCPRIM_DEVICE inline
-T warp_shuffle_down(T input, const unsigned int delta, const int width = warp_size())
+T warp_shuffle_down(T input, const unsigned int delta, const int width = device_warp_size())
 {
     return detail::warp_shuffle_op(
         input,
@@ -164,14 +164,14 @@ T warp_shuffle_down(T input, const unsigned int delta, const int width = warp_si
 /// thread in warp.
 ///
 /// Note: The optional \p width parameter must be a power of 2; results are
-/// undefined if it is not a power of 2, or it is greater than warp_size().
+/// undefined if it is not a power of 2, or it is greater than device_warp_size().
 ///
 /// \param input - input to pass to other threads
 /// \param lane_mask - mask used for calculating source lane id
 /// \param width - logical warp width
 template<class T>
 ROCPRIM_DEVICE inline
-T warp_shuffle_xor(T input, const int lane_mask, const int width = warp_size())
+T warp_shuffle_xor(T input, const int lane_mask, const int width = device_warp_size())
 {
     return detail::warp_shuffle_op(
         input,

--- a/rocprim/include/rocprim/types.hpp
+++ b/rocprim/include/rocprim/types.hpp
@@ -112,6 +112,12 @@ struct empty_type
 /// \brief Half-precision floating point type
 using half = ::__half;
 
+#if __AMDGCN_WAVEFRONT_SIZE == 32
+using lane_mask_type = unsigned int;
+#else
+using lane_mask_type = unsigned long long int;
+#endif
+
 END_ROCPRIM_NAMESPACE
 
 /// @}

--- a/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
@@ -37,8 +37,7 @@ ROCPRIM_DEVICE inline
 unsigned int last_in_warp_segment(Flag flag)
 {
     // Get flags (now every thread know where the flags are)
-    auto warp_flags = ::rocprim::ballot(flag);
-    using ballot_type = decltype(warp_flags);
+    lane_mask_type warp_flags = ::rocprim::ballot(flag);
 
     // In case of head flags change them to tail flags
     if(HeadSegmented)
@@ -47,13 +46,17 @@ unsigned int last_in_warp_segment(Flag flag)
     }
     const auto lane_id = ::rocprim::lane_id();
     // Zero bits from thread with lower lane id
-    warp_flags &= ballot_type(-1) ^ ((ballot_type(1) << lane_id) - 1U);
+    warp_flags &= lane_mask_type(-1) ^ ((lane_mask_type(1) << lane_id) - 1U);
     // Ignore bits from thread from other (previous) logical warps
     warp_flags >>= (lane_id / WarpSize) * WarpSize;
     // Make sure last item in logical warp is marked as a tail
-    warp_flags |= ballot_type(1) << (WarpSize - 1U);
+    warp_flags |= lane_mask_type(1) << (WarpSize - 1U);
     // Calculate logical lane id of the last valid value in the segment
-    return ::__lastbit_u32_u64(warp_flags);
+    #if __AMDGCN_WAVEFRONT_SIZE == 32
+    return ::__ffs(warp_flags) - 1;
+    #else
+    return ::__ffsll(warp_flags) - 1;
+    #endif
 }
 
 } // end namespace detail

--- a/rocprim/include/rocprim/warp/warp_reduce.hpp
+++ b/rocprim/include/rocprim/warp/warp_reduce.hpp
@@ -118,9 +118,6 @@ class warp_reduce
 {
     using base_type = typename detail::select_warp_reduce_impl<T, WarpSize, UseAllReduce>::type;
 
-    // Check if WarpSize is correct
-    static_assert(WarpSize <= warp_size(), "WarpSize can't be greater than hardware warp size.");
-
 public:
     /// \brief Struct used to allocate a temporary memory that is required for thread
     /// communication during operations provided by related parallel primitive.
@@ -183,6 +180,12 @@ public:
                 storage_type& storage,
                 BinaryFunction reduce_op = BinaryFunction())
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+
         base_type::reduce(input, output, storage, reduce_op);
     }
 
@@ -240,6 +243,12 @@ public:
                 storage_type& storage,
                 BinaryFunction reduce_op = BinaryFunction())
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+
         base_type::reduce(input, output, valid_items, storage, reduce_op);
     }
 
@@ -269,6 +278,12 @@ public:
                                storage_type& storage,
                                BinaryFunction reduce_op = BinaryFunction())
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+
         base_type::head_segmented_reduce(input, output, flag, storage, reduce_op);
     }
 
@@ -298,6 +313,12 @@ public:
                                storage_type& storage,
                                BinaryFunction reduce_op = BinaryFunction())
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+        
         base_type::tail_segmented_reduce(input, output, flag, storage, reduce_op);
     }
 };

--- a/rocprim/include/rocprim/warp/warp_reduce.hpp
+++ b/rocprim/include/rocprim/warp/warp_reduce.hpp
@@ -173,20 +173,30 @@ public:
     /// }
     /// \endcode
     /// \endparblock
-    template<class BinaryFunction = ::rocprim::plus<T>>
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void reduce(T input,
+    auto reduce(T input,
                 T& output,
                 storage_type& storage,
                 BinaryFunction reduce_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-
         base_type::reduce(input, output, storage, reduce_op);
+    }
+
+    /// \brief Performs reduction across threads in a logical warp.
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto reduce(T ,
+                T& ,
+                storage_type& ,
+                BinaryFunction reduce_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) reduce_op;
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+        return;
     }
 
     /// \brief Performs reduction across threads in a logical warp.
@@ -235,21 +245,32 @@ public:
     /// }
     /// \endcode
     /// \endparblock
-    template<class BinaryFunction = ::rocprim::plus<T>>
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void reduce(T input,
+    auto reduce(T input,
                 T& output,
                 int valid_items,
                 storage_type& storage,
                 BinaryFunction reduce_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-
         base_type::reduce(input, output, valid_items, storage, reduce_op);
+    }
+
+    /// \brief Performs reduction across threads in a logical warp.
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto reduce(T ,
+                T& ,
+                int ,
+                storage_type& ,
+                BinaryFunction reduce_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) reduce_op;
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+        return;
     }
 
     /// \brief Performs head-segmented reduction across threads in a logical warp.
@@ -270,21 +291,32 @@ public:
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
     /// or repurposed: \p __syncthreads() or \p rocprim::syncthreads().
-    template<class Flag, class BinaryFunction = ::rocprim::plus<T>>
+    template<class Flag, class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void head_segmented_reduce(T input,
+    auto head_segmented_reduce(T input,
                                T& output,
                                Flag flag,
                                storage_type& storage,
                                BinaryFunction reduce_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-
         base_type::head_segmented_reduce(input, output, flag, storage, reduce_op);
+    }
+
+    /// \brief Performs head-segmented reduction across threads in a logical warp.
+    /// Invalid Warp Size
+    template<class Flag, class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto head_segmented_reduce(T ,
+                               T& ,
+                               Flag ,
+                               storage_type& ,
+                               BinaryFunction reduce_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) reduce_op;
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+        return;
     }
 
     /// \brief Performs tail-segmented reduction across threads in a logical warp.
@@ -305,21 +337,32 @@ public:
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
     /// or repurposed: \p __syncthreads() or \p rocprim::syncthreads().
-    template<class Flag, class BinaryFunction = ::rocprim::plus<T>>
+    template<class Flag, class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void tail_segmented_reduce(T input,
+    auto tail_segmented_reduce(T input,
                                T& output,
                                Flag flag,
                                storage_type& storage,
                                BinaryFunction reduce_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-        
         base_type::tail_segmented_reduce(input, output, flag, storage, reduce_op);
+    }
+
+    /// \brief Performs tail-segmented reduction across threads in a logical warp.
+    /// Invalid Warp Size
+    template<class Flag, class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto tail_segmented_reduce(T ,
+                               T& ,
+                               Flag ,
+                               storage_type& ,
+                               BinaryFunction reduce_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) reduce_op;
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+        return;
     }
 };
 

--- a/rocprim/include/rocprim/warp/warp_reduce.hpp
+++ b/rocprim/include/rocprim/warp/warp_reduce.hpp
@@ -61,14 +61,14 @@ struct select_warp_reduce_impl
 ///
 /// \tparam T - the input/output type.
 /// \tparam WarpSize - the size of logical warp size, which can be equal to or less than
-/// the size of hardware warp (see rocprim::warp_size()). Reduce operations are performed
+/// the size of hardware warp (see rocprim::device_warp_size()). Reduce operations are performed
 /// separately within groups determined by WarpSize.
 /// \tparam UseAllReduce - input parameter to determine whether to broadcast final reduction
 /// value to all threads (default is false).
 ///
 /// \par Overview
 /// * \p WarpSize must be equal to or less than the size of hardware warp (see
-/// rocprim::warp_size()). If it is less, reduce is performed separately within groups
+/// rocprim::device_warp_size()). If it is less, reduce is performed separately within groups
 /// determined by WarpSize. \n
 /// For example, if \p WarpSize is 4, hardware warp is 64, reduction will be performed in logical
 /// warps grouped like this: `{ {0, 1, 2, 3}, {4, 5, 6, 7 }, ..., {60, 61, 62, 63} }`
@@ -108,7 +108,7 @@ struct select_warp_reduce_impl
 /// \endparblock
 template<
     class T,
-    unsigned int WarpSize = warp_size(),
+    unsigned int WarpSize = device_warp_size(),
     bool UseAllReduce = false
 >
 class warp_reduce

--- a/rocprim/include/rocprim/warp/warp_reduce.hpp
+++ b/rocprim/include/rocprim/warp/warp_reduce.hpp
@@ -118,6 +118,9 @@ class warp_reduce
 {
     using base_type = typename detail::select_warp_reduce_impl<T, WarpSize, UseAllReduce>::type;
 
+    // Check if WarpSize is valid for the targets
+    static_assert(WarpSize <= ROCPRIM_MAX_WARP_SIZE, "WarpSize can't be greater than hardware warp size.");
+
 public:
     /// \brief Struct used to allocate a temporary memory that is required for thread
     /// communication during operations provided by related parallel primitive.

--- a/rocprim/include/rocprim/warp/warp_scan.hpp
+++ b/rocprim/include/rocprim/warp/warp_scan.hpp
@@ -61,12 +61,12 @@ struct select_warp_scan_impl
 ///
 /// \tparam T - the input/output type.
 /// \tparam WarpSize - the size of logical warp size, which can be equal to or less than
-/// the size of hardware warp (see rocprim::warp_size()). Scan operations are performed
+/// the size of hardware warp (see rocprim::device_warp_size()). Scan operations are performed
 /// separately within groups determined by WarpSize.
 ///
 /// \par Overview
 /// * \p WarpSize must be equal to or less than the size of hardware warp (see
-/// rocprim::warp_size()). If it is less, scan is performed separately within groups
+/// rocprim::device_warp_size()). If it is less, scan is performed separately within groups
 /// determined by WarpSize. \n
 /// For example, if \p WarpSize is 4, hardware warp is 64, scan will be performed in logical
 /// warps grouped like this: `{ {0, 1, 2, 3}, {4, 5, 6, 7 }, ..., {60, 61, 62, 63} }`
@@ -106,7 +106,7 @@ struct select_warp_scan_impl
 /// \endparblock
 template<
     class T,
-    unsigned int WarpSize = warp_size()
+    unsigned int WarpSize = device_warp_size()
 >
 class warp_scan
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/rocprim/include/rocprim/warp/warp_scan.hpp
+++ b/rocprim/include/rocprim/warp/warp_scan.hpp
@@ -115,6 +115,9 @@ class warp_scan
 {
     using base_type = typename detail::select_warp_scan_impl<T, WarpSize>::type;
 
+    // Check if WarpSize is valid for the targets
+    static_assert(WarpSize <= ROCPRIM_MAX_WARP_SIZE, "WarpSize can't be greater than hardware warp size.");
+
 public:
     /// \brief Struct used to allocate a temporary memory that is required for thread
     /// communication during operations provided by related parallel primitive.

--- a/rocprim/include/rocprim/warp/warp_scan.hpp
+++ b/rocprim/include/rocprim/warp/warp_scan.hpp
@@ -115,9 +115,6 @@ class warp_scan
 {
     using base_type = typename detail::select_warp_scan_impl<T, WarpSize>::type;
 
-    // Check if WarpSize is correct
-    static_assert(WarpSize <= warp_size(), "WarpSize can't be greater than hardware warp size.");
-
 public:
     /// \brief Struct used to allocate a temporary memory that is required for thread
     /// communication during operations provided by related parallel primitive.
@@ -184,6 +181,12 @@ public:
                         storage_type& storage,
                         BinaryFunction scan_op = BinaryFunction())
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+
         base_type::inclusive_scan(input, output, storage, scan_op);
     }
 
@@ -244,6 +247,12 @@ public:
                         storage_type& storage,
                         BinaryFunction scan_op = BinaryFunction())
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+
         base_type::inclusive_scan(input, output, reduction, storage, scan_op);
     }
 
@@ -307,6 +316,12 @@ public:
                         storage_type& storage,
                         BinaryFunction scan_op = BinaryFunction())
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+
         base_type::exclusive_scan(input, output, init, storage, scan_op);
     }
 
@@ -372,6 +387,12 @@ public:
                         storage_type& storage,
                         BinaryFunction scan_op = BinaryFunction())
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+
         base_type::exclusive_scan(input, output, init, reduction, storage, scan_op);
     }
 
@@ -442,6 +463,12 @@ public:
               storage_type& storage,
               BinaryFunction scan_op = BinaryFunction())
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+
         base_type::scan(input, inclusive_output, exclusive_output, init, storage, scan_op);
     }
 
@@ -513,6 +540,12 @@ public:
               storage_type& storage,
               BinaryFunction scan_op = BinaryFunction())
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+
         base_type::scan(
             input, inclusive_output, exclusive_output, init, reduction,
             storage, scan_op
@@ -533,6 +566,12 @@ public:
                 const unsigned int src_lane,
                 storage_type& storage)
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+
         return base_type::broadcast(input, src_lane, storage);
     }
 
@@ -541,6 +580,12 @@ protected:
     ROCPRIM_DEVICE inline
     void to_exclusive(T inclusive_input, T& exclusive_output, storage_type& storage)
     {
+        if( WarpSize > ::rocprim::warp_size() )
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
+        
         return base_type::to_exclusive(inclusive_input, exclusive_output, storage);
     }
 #endif

--- a/rocprim/include/rocprim/warp/warp_scan.hpp
+++ b/rocprim/include/rocprim/warp/warp_scan.hpp
@@ -174,20 +174,30 @@ public:
     /// output values in the first logical warp will be <tt>{1, -2, -2, -4, ..., -32},</tt> in the second:
     /// <tt>{33, -34, -34, -36, ..., -64}</tt> etc.
     /// \endparblock
-    template<class BinaryFunction = ::rocprim::plus<T>>
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void inclusive_scan(T input,
+    auto inclusive_scan(T input,
                         T& output,
                         storage_type& storage,
                         BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-
         base_type::inclusive_scan(input, output, storage, scan_op);
+    }
+
+    /// \brief Performs inclusive scan across threads in a logical warp.
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto inclusive_scan(T ,
+                        T& ,
+                        storage_type& ,
+                        BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) scan_op;
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+        return;
     }
 
     /// \brief Performs inclusive scan and reduction across threads in a logical warp.
@@ -239,21 +249,32 @@ public:
     /// \p output values in the every logical warp will be <tt>{1, 2, 3, 4, ..., 64}</tt>.
     /// The \p reduction will be equal \p 64.
     /// \endparblock
-    template<class BinaryFunction = ::rocprim::plus<T>>
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void inclusive_scan(T input,
+    auto inclusive_scan(T input,
                         T& output,
                         T& reduction,
                         storage_type& storage,
                         BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-
         base_type::inclusive_scan(input, output, reduction, storage, scan_op);
+    }
+
+    /// \brief Performs inclusive scan and reduction across threads in a logical warp.
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto inclusive_scan(T ,
+                        T& ,
+                        T& ,
+                        storage_type& ,
+                        BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) scan_op;
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+        return;
     }
 
     /// \brief Performs exclusive scan across threads in a logical warp.
@@ -308,21 +329,32 @@ public:
     /// warp will be <tt>{100, 1, -2, -2, -4, ..., -30},</tt> in the second:
     /// <tt>{100, 33, -34, -34, -36, ..., -62}</tt> etc.
     /// \endparblock
-    template<class BinaryFunction = ::rocprim::plus<T>>
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void exclusive_scan(T input,
+    auto exclusive_scan(T input,
                         T& output,
                         T init,
                         storage_type& storage,
                         BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-
         base_type::exclusive_scan(input, output, init, storage, scan_op);
+    }
+
+    /// \brief Performs exclusive scan across threads in a logical warp.
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto exclusive_scan(T ,
+                        T& ,
+                        T ,
+                        storage_type& ,
+                        BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) scan_op;
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+        return;
     }
 
     /// \brief Performs exclusive scan and reduction across threads in a logical warp.
@@ -378,22 +410,34 @@ public:
     /// <tt>{1, 1, ..., 1, 1}</tt>, then \p output values in every logical warp will be
     /// <tt>{10, 11, 12, 13, ..., 73}</tt>. The \p reduction will be 64.
     /// \endparblock
-    template<class BinaryFunction = ::rocprim::plus<T>>
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void exclusive_scan(T input,
+    auto exclusive_scan(T input,
                         T& output,
                         T init,
                         T& reduction,
                         storage_type& storage,
                         BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-
         base_type::exclusive_scan(input, output, init, reduction, storage, scan_op);
+    }
+
+    /// \brief Performs exclusive scan and reduction across threads in a logical warp.
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto exclusive_scan(T ,
+                        T& ,
+                        T ,
+                        T& ,
+                        storage_type& ,
+                        BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) scan_op;
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+        return;
     }
 
     /// \brief Performs inclusive and exclusive scan operations across threads
@@ -454,22 +498,34 @@ public:
     /// logical warp will be <tt>{100, 1, -2, -2, -4, ..., -30},</tt> in the second:
     /// <tt>{100, 33, -34, -34, -36, ..., -62}</tt> etc.
     /// \endparblock
-    template<class BinaryFunction = ::rocprim::plus<T>>
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void scan(T input,
+    auto scan(T input,
               T& inclusive_output,
               T& exclusive_output,
               T init,
               storage_type& storage,
               BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-
         base_type::scan(input, inclusive_output, exclusive_output, init, storage, scan_op);
+    }
+
+    /// \brief Performs inclusive and exclusive scan operations across threads
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto scan(T ,
+              T& ,
+              T& ,
+              T ,
+              storage_type& ,
+              BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) scan_op;
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+        return;
     }
 
     /// \brief Performs inclusive and exclusive scan operations, and reduction across
@@ -530,26 +586,39 @@ public:
     /// <tt>{1, 2, 3, 4, ..., 63, 64}</tt>, and \p ex_output values in every logical warp will
     /// be <tt>{10, 11, 12, 13, ..., 73}</tt>. The \p reduction will be 64.
     /// \endparblock
-    template<class BinaryFunction = ::rocprim::plus<T>>
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void scan(T input,
+    auto scan(T input,
               T& inclusive_output,
               T& exclusive_output,
               T init,
               T& reduction,
               storage_type& storage,
               BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-
         base_type::scan(
             input, inclusive_output, exclusive_output, init, reduction,
             storage, scan_op
         );
+    }
+
+    /// \brief Performs inclusive and exclusive scan operations across threads
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto scan(T ,
+              T& ,
+              T& ,
+              T ,
+              T& ,
+              storage_type& ,
+              BinaryFunction scan_op = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) scan_op;
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+        return;
     }
 
     /// \brief Broadcasts value from one thread to all threads in logical warp.
@@ -561,32 +630,47 @@ public:
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
     /// or repurposed: \p __syncthreads() or \p rocprim::syncthreads().
+    template<unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    T broadcast(T input,
-                const unsigned int src_lane,
-                storage_type& storage)
+    auto broadcast(T input,
+                   const unsigned int src_lane,
+                   storage_type& storage)
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), T>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-
         return base_type::broadcast(input, src_lane, storage);
+    }
+
+    /// \brief Broadcasts value from one thread to all threads in logical warp.
+    /// Invalid Warp Size
+    template<unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto broadcast(T ,
+                   const unsigned int ,
+                   storage_type& )
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), T>::type
+    {
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+        return T();
     }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 protected:
+
+    template<unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void to_exclusive(T inclusive_input, T& exclusive_output, storage_type& storage)
+    auto to_exclusive(T inclusive_input, T& exclusive_output, storage_type& storage)
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
-        
         return base_type::to_exclusive(inclusive_input, exclusive_output, storage);
+    }
+
+    template<unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto to_exclusive(T , T& , storage_type&)
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+        return;
     }
 #endif
 };

--- a/rocprim/include/rocprim/warp/warp_sort.hpp
+++ b/rocprim/include/rocprim/warp/warp_sort.hpp
@@ -47,7 +47,7 @@ BEGIN_ROCPRIM_NAMESPACE
 /// \par Overview
 /// * \p WarpSize must be power of two.
 /// * \p WarpSize must be equal to or less than the size of hardware warp (see
-/// rocprim::warp_size()). If it is less, sort is performed separately within groups
+/// rocprim::device_warp_size()). If it is less, sort is performed separately within groups
 /// determined by WarpSize.
 /// For example, if \p WarpSize is 4, hardware warp is 64, sort will be performed in logical
 /// warps grouped like this: `{ {0, 1, 2, 3}, {4, 5, 6, 7 }, ..., {60, 61, 62, 63} }`
@@ -93,7 +93,7 @@ BEGIN_ROCPRIM_NAMESPACE
 /// \endparblock
 template<
     class Key,
-    unsigned int WarpSize = warp_size(),
+    unsigned int WarpSize = device_warp_size(),
     class Value = empty_type
 >
 class warp_sort : detail::warp_sort_shuffle<Key, WarpSize, Value>

--- a/rocprim/include/rocprim/warp/warp_sort.hpp
+++ b/rocprim/include/rocprim/warp/warp_sort.hpp
@@ -100,6 +100,9 @@ class warp_sort : detail::warp_sort_shuffle<Key, WarpSize, Value>
 {
     typedef typename detail::warp_sort_shuffle<Key, WarpSize, Value> base_type;
 
+    // Check if WarpSize is valid for the targets
+    static_assert(WarpSize <= ROCPRIM_MAX_WARP_SIZE, "WarpSize can't be greater than hardware warp size.");
+    
 public:
     /// \brief Struct used to allocate a temporary memory that is required for thread
     /// communication during operations provided by related parallel primitive.

--- a/rocprim/include/rocprim/warp/warp_sort.hpp
+++ b/rocprim/include/rocprim/warp/warp_sort.hpp
@@ -131,7 +131,7 @@ public:
     }
 
     /// \brief Warp sort for any data type.
-    ///
+    /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
     auto sort(Key& ,

--- a/rocprim/include/rocprim/warp/warp_sort.hpp
+++ b/rocprim/include/rocprim/warp/warp_sort.hpp
@@ -121,17 +121,26 @@ public:
     /// The signature of the function should be equivalent to the following:
     /// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
-    template<class BinaryFunction = ::rocprim::less<Key>>
+    template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void sort(Key& thread_key,
+    auto sort(Key& thread_key,
               BinaryFunction compare_function = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
-            return;
-        }
         base_type::sort(thread_key, compare_function);
+    }
+
+    /// \brief Warp sort for any data type.
+    ///
+    template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto sort(Key& ,
+              BinaryFunction compare_function = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) compare_function; // disables unused parameter warning
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+        return;
     }
 
     /// \brief Warp sort for any data type using temporary storage.
@@ -162,20 +171,30 @@ public:
     ///     ...
     /// }
     /// \endcode
-    template<class BinaryFunction = ::rocprim::less<Key>>
+    template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void sort(Key& thread_key,
+    auto sort(Key& thread_key,
               storage_type& storage,
               BinaryFunction compare_function = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
-            return;
-        }
         base_type::sort(
             thread_key, storage, compare_function
         );
+    }
+
+    /// \brief Warp sort for any data type using temporary storage.
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto sort(Key& ,
+              storage_type& ,
+              BinaryFunction compare_function = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) compare_function; // disables unused parameter warning
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+        return;
     }
 
     /// \brief Warp sort by key for any data type.
@@ -189,20 +208,30 @@ public:
     /// The signature of the function should be equivalent to the following:
     /// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
-    template<class BinaryFunction = ::rocprim::less<Key>>
+    template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void sort(Key& thread_key,
+    auto sort(Key& thread_key,
               Value& thread_value,
               BinaryFunction compare_function = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
-            return;
-        }
         base_type::sort(
             thread_key, thread_value, compare_function
         );
+    }
+
+    /// \brief Warp sort by key for any data type.
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto sort(Key& ,
+              Value& ,
+              BinaryFunction compare_function = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) compare_function; // disables unused parameter warning
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+        return;
     }
 
     /// \brief Warp sort by key for any data type using temporary storage.
@@ -234,21 +263,32 @@ public:
     ///     ...
     /// }
     /// \endcode
-    template<class BinaryFunction = ::rocprim::less<Key>>
+    template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE inline
-    void sort(Key& thread_key,
+    auto sort(Key& thread_key,
               Value& thread_value,
               storage_type& storage,
               BinaryFunction compare_function = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize<=__AMDGCN_WAVEFRONT_SIZE), void>::type
     {
-        if( WarpSize > ::rocprim::warp_size() )
-        {
-            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
-            return;
-        }
         base_type::sort(
             thread_key, thread_value, storage, compare_function
         );
+    }
+
+    /// \brief Warp sort by key for any data type using temporary storage.
+    /// Invalid Warp Size
+    template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
+    ROCPRIM_DEVICE inline
+    auto sort(Key& ,
+              Value& ,
+              storage_type& ,
+              BinaryFunction compare_function = BinaryFunction())
+        -> typename std::enable_if<(FunctionWarpSize>__AMDGCN_WAVEFRONT_SIZE), void>::type
+    {
+        (void) compare_function; // disables unused parameter warning
+        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+        return;
     }
 };
 

--- a/rocprim/include/rocprim/warp/warp_sort.hpp
+++ b/rocprim/include/rocprim/warp/warp_sort.hpp
@@ -126,7 +126,7 @@ public:
     void sort(Key& thread_key,
               BinaryFunction compare_function = BinaryFunction())
     {
-        if (WarpSize > warp_size())
+        if( WarpSize > ::rocprim::warp_size() )
         {
             ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
             return;
@@ -168,7 +168,7 @@ public:
               storage_type& storage,
               BinaryFunction compare_function = BinaryFunction())
     {
-        if (WarpSize > warp_size())
+        if( WarpSize > ::rocprim::warp_size() )
         {
             ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
             return;
@@ -195,7 +195,7 @@ public:
               Value& thread_value,
               BinaryFunction compare_function = BinaryFunction())
     {
-        if (WarpSize > warp_size())
+        if( WarpSize > ::rocprim::warp_size() )
         {
             ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
             return;
@@ -241,7 +241,7 @@ public:
               storage_type& storage,
               BinaryFunction compare_function = BinaryFunction())
     {
-        if (WarpSize > warp_size())
+        if( WarpSize > ::rocprim::warp_size() )
         {
             ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
             return;

--- a/rocprim/include/rocprim/warp/warp_sort.hpp
+++ b/rocprim/include/rocprim/warp/warp_sort.hpp
@@ -100,9 +100,6 @@ class warp_sort : detail::warp_sort_shuffle<Key, WarpSize, Value>
 {
     typedef typename detail::warp_sort_shuffle<Key, WarpSize, Value> base_type;
 
-    // Check if WarpSize is correct
-    static_assert(WarpSize <= warp_size(), "WarpSize can't be greater than hardware warp size.");
-
 public:
     /// \brief Struct used to allocate a temporary memory that is required for thread
     /// communication during operations provided by related parallel primitive.
@@ -129,6 +126,11 @@ public:
     void sort(Key& thread_key,
               BinaryFunction compare_function = BinaryFunction())
     {
+        if (WarpSize > warp_size())
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
+            return;
+        }
         base_type::sort(thread_key, compare_function);
     }
 
@@ -166,6 +168,11 @@ public:
               storage_type& storage,
               BinaryFunction compare_function = BinaryFunction())
     {
+        if (WarpSize > warp_size())
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+            return;
+        }
         base_type::sort(
             thread_key, storage, compare_function
         );
@@ -188,6 +195,11 @@ public:
               Value& thread_value,
               BinaryFunction compare_function = BinaryFunction())
     {
+        if (WarpSize > warp_size())
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+            return;
+        }
         base_type::sort(
             thread_key, thread_value, compare_function
         );
@@ -229,6 +241,11 @@ public:
               storage_type& storage,
               BinaryFunction compare_function = BinaryFunction())
     {
+        if (WarpSize > warp_size())
+        {
+            ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
+            return;
+        }
         base_type::sort(
             thread_key, thread_value, storage, compare_function
         );

--- a/test/extra/CMakeLists.txt
+++ b/test/extra/CMakeLists.txt
@@ -34,9 +34,9 @@ list(APPEND CMAKE_MODULE_PATH
 
 # Use target ID syntax if supported for AMDGPU_TARGETS
 if(TARGET_ID_SUPPORT)
-  set(AMDGPU_TARGETS gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack- CACHE STRING "List of specific machine types for library to target")
+  set(AMDGPU_TARGETS gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx1030:xnack- CACHE STRING "List of specific machine types for library to target")
 else()
-  set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target")
+  set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908;gfx1030 CACHE STRING "List of specific machine types for library to target")
 endif()
 
 # Verify that hcc compiler is used on ROCM platform

--- a/test/rocprim/test_arg_index_iterator.cpp
+++ b/test/rocprim/test_arg_index_iterator.cpp
@@ -53,7 +53,7 @@ typedef ::testing::Types<
     RocprimArgIndexIteratorParams<float>
 > RocprimArgIndexIteratorTestsParams;
 
-TYPED_TEST_CASE(RocprimArgIndexIteratorTests, RocprimArgIndexIteratorTestsParams);
+TYPED_TEST_SUITE(RocprimArgIndexIteratorTests, RocprimArgIndexIteratorTestsParams);
 
 TYPED_TEST(RocprimArgIndexIteratorTests, Equal)
 {

--- a/test/rocprim/test_block_discontinuity.cpp
+++ b/test/rocprim/test_block_discontinuity.cpp
@@ -98,7 +98,7 @@ typedef ::testing::Types<
     block_param_type(rocprim::half, int)
 > BlockDiscParams;
 
-TYPED_TEST_CASE(RocprimBlockDiscontinuity, BlockDiscParams);
+TYPED_TEST_SUITE(RocprimBlockDiscontinuity, BlockDiscParams);
 
 template<
     class Type,

--- a/test/rocprim/test_block_exchange.cpp
+++ b/test/rocprim/test_block_exchange.cpp
@@ -36,7 +36,7 @@ public:
     using params = Params;
 };
 
-TYPED_TEST_CASE(RocprimBlockExchangeTests, BlockParams);
+TYPED_TEST_SUITE(RocprimBlockExchangeTests, BlockParams);
 
 template<
     class Type,

--- a/test/rocprim/test_block_exchange.cpp
+++ b/test/rocprim/test_block_exchange.cpp
@@ -382,10 +382,10 @@ auto test_block_exchange()
     std::vector<output_type> expected(size);
     std::vector<output_type> output(size, output_type(0));
 
-    constexpr size_t warp_size =
-        ::rocprim::detail::get_min_warp_size(block_size, size_t(::rocprim::warp_size()));
-    constexpr size_t warps_no = (block_size + warp_size - 1) / warp_size;
-    constexpr size_t items_per_warp = warp_size * items_per_thread;
+    const size_t warp_size =
+        ::rocprim::detail::get_min_warp_size(block_size, size_t(::rocprim::host_warp_size()));
+    const size_t warps_no = (block_size + warp_size - 1) / warp_size;
+    const size_t items_per_warp = warp_size * items_per_thread;
 
     // Calculate input and expected results on host
     std::vector<type> values(size);
@@ -479,10 +479,10 @@ auto test_block_exchange()
     std::vector<output_type> expected(size);
     std::vector<output_type> output(size, output_type(0));
 
-    constexpr size_t warp_size =
-        ::rocprim::detail::get_min_warp_size(block_size, size_t(::rocprim::warp_size()));
-    constexpr size_t warps_no = (block_size + warp_size - 1) / warp_size;
-    constexpr size_t items_per_warp = warp_size * items_per_thread;
+    const size_t warp_size =
+        ::rocprim::detail::get_min_warp_size(block_size, size_t(::rocprim::host_warp_size()));
+    const size_t warps_no = (block_size + warp_size - 1) / warp_size;
+    const size_t items_per_warp = warp_size * items_per_thread;
 
     // Calculate input and expected results on host
     std::vector<type> values(size);

--- a/test/rocprim/test_block_histogram.cpp
+++ b/test/rocprim/test_block_histogram.cpp
@@ -69,8 +69,8 @@ typedef ::testing::Types<
     block_param_type(unsigned int, rocprim::half)
 > BlockHistSortParams;
 
-TYPED_TEST_CASE(RocprimBlockHistogramAtomicInputArrayTests, BlockHistAtomicParams);
-TYPED_TEST_CASE(RocprimBlockHistogramSortInputArrayTests, BlockHistSortParams);
+TYPED_TEST_SUITE(RocprimBlockHistogramAtomicInputArrayTests, BlockHistAtomicParams);
+TYPED_TEST_SUITE(RocprimBlockHistogramSortInputArrayTests, BlockHistSortParams);
 
 template<
     unsigned int BlockSize,

--- a/test/rocprim/test_block_load_store.cpp
+++ b/test/rocprim/test_block_load_store.cpp
@@ -234,8 +234,8 @@ typedef ::testing::Types<
     params<char4, rocprim::detail::int4, 16, true>
 > Params;
 
-TYPED_TEST_CASE(RocprimBlockLoadStoreClassTests, ClassParams);
-TYPED_TEST_CASE(RocprimVectorizationTests, Params);
+TYPED_TEST_SUITE(RocprimBlockLoadStoreClassTests, ClassParams);
+TYPED_TEST_SUITE(RocprimVectorizationTests, Params);
 
 template<
     class Type,

--- a/test/rocprim/test_block_radix_sort.cpp
+++ b/test/rocprim/test_block_radix_sort.cpp
@@ -53,7 +53,7 @@ static constexpr unsigned int end_radix[n_sizes] = {
     0, 0, 0, 10, 11, 12, 0, 0, 0, 10, 11, 12
 };
 
-TYPED_TEST_CASE(RocprimBlockRadixSort, BlockParams);
+TYPED_TEST_SUITE(RocprimBlockRadixSort, BlockParams);
 
 template<class Key, bool Descending, unsigned int StartBit, unsigned int EndBit>
 struct key_comparator

--- a/test/rocprim/test_block_reduce.cpp
+++ b/test/rocprim/test_block_reduce.cpp
@@ -41,7 +41,7 @@ public:
     static constexpr unsigned int block_size = Params::block_size;
 };
 
-TYPED_TEST_CASE(RocprimBlockReduceSingleValueTests, BlockParams);
+TYPED_TEST_SUITE(RocprimBlockReduceSingleValueTests, BlockParams);
 
 template<
     unsigned int BlockSize,
@@ -384,7 +384,7 @@ public:
     static constexpr unsigned int block_size = Params::block_size;
 };
 
-TYPED_TEST_CASE(RocprimBlockReduceInputArrayTests, BlockParams);
+TYPED_TEST_SUITE(RocprimBlockReduceInputArrayTests, BlockParams);
 
 template<
     unsigned int BlockSize,

--- a/test/rocprim/test_block_scan.cpp
+++ b/test/rocprim/test_block_scan.cpp
@@ -43,7 +43,7 @@ public:
     static constexpr unsigned int block_size = Params::block_size;
 };
 
-TYPED_TEST_CASE(RocprimBlockScanSingleValueTests, BlockParams);
+TYPED_TEST_SUITE(RocprimBlockScanSingleValueTests, BlockParams);
 
 template<
     int Method,
@@ -689,7 +689,7 @@ public:
     static constexpr unsigned int block_size = Params::block_size;
 };
 
-TYPED_TEST_CASE(RocprimBlockScanInputArrayTests, BlockParams);
+TYPED_TEST_SUITE(RocprimBlockScanInputArrayTests, BlockParams);
 
 template<
     unsigned int BlockSize,

--- a/test/rocprim/test_block_sort.cpp
+++ b/test/rocprim/test_block_sort.cpp
@@ -38,7 +38,7 @@ public:
     static constexpr unsigned int block_size = Params::block_size;
 };
 
-TYPED_TEST_CASE(RocprimBlockSortTests, BlockParams);
+TYPED_TEST_SUITE(RocprimBlockSortTests, BlockParams);
 
 template<
     unsigned int BlockSize,

--- a/test/rocprim/test_constant_iterator.cpp
+++ b/test/rocprim/test_constant_iterator.cpp
@@ -51,7 +51,7 @@ typedef ::testing::Types<
     RocprimConstantIteratorParams<float>
 > RocprimConstantIteratorTestsParams;
 
-TYPED_TEST_CASE(RocprimConstantIteratorTests, RocprimConstantIteratorTestsParams);
+TYPED_TEST_SUITE(RocprimConstantIteratorTests, RocprimConstantIteratorTestsParams);
 
 template<class T>
 struct transform

--- a/test/rocprim/test_counting_iterator.cpp
+++ b/test/rocprim/test_counting_iterator.cpp
@@ -51,7 +51,7 @@ typedef ::testing::Types<
     RocprimCountingIteratorParams<size_t>
 > RocprimCountingIteratorTestsParams;
 
-TYPED_TEST_CASE(RocprimCountingIteratorTests, RocprimCountingIteratorTestsParams);
+TYPED_TEST_SUITE(RocprimCountingIteratorTests, RocprimCountingIteratorTestsParams);
 
 template<class T>
 struct transform

--- a/test/rocprim/test_device_binary_search.cpp
+++ b/test/rocprim/test_device_binary_search.cpp
@@ -64,7 +64,7 @@ typedef ::testing::Types<
     params<custom_double2, custom_double2, unsigned int, rocprim::greater<custom_double2> >
 > Params;
 
-TYPED_TEST_CASE(RocprimDeviceBinarySearch, Params);
+TYPED_TEST_SUITE(RocprimDeviceBinarySearch, Params);
 
 std::vector<size_t> get_sizes(int seed_value)
 {

--- a/test/rocprim/test_device_histogram.cpp
+++ b/test/rocprim/test_device_histogram.cpp
@@ -137,7 +137,7 @@ typedef ::testing::Types<
     params1<double, 55, -123, +123, double>
 > Params1;
 
-TYPED_TEST_CASE(RocprimDeviceHistogramEven, Params1);
+TYPED_TEST_SUITE(RocprimDeviceHistogramEven, Params1);
 
 TEST(RocprimDeviceHistogramEven, IncorrectInput)
 {
@@ -344,7 +344,7 @@ typedef ::testing::Types<
     params2<double, 3, 10000, 1000, 1000, double, unsigned int>
 > Params2;
 
-TYPED_TEST_CASE(RocprimDeviceHistogramRange, Params2);
+TYPED_TEST_SUITE(RocprimDeviceHistogramRange, Params2);
 
 TEST(RocprimDeviceHistogramRange, IncorrectInput)
 {
@@ -585,7 +585,7 @@ typedef ::testing::Types<
     params3<double, 4, 3, 55, -123, +123, double>
 > Params3;
 
-TYPED_TEST_CASE(RocprimDeviceHistogramMultiEven, Params3);
+TYPED_TEST_SUITE(RocprimDeviceHistogramMultiEven, Params3);
 
 TYPED_TEST(RocprimDeviceHistogramMultiEven, MultiEven)
 {
@@ -839,7 +839,7 @@ typedef ::testing::Types<
     params4<double, 3, 1, 3, 10000, 1000, 1000, double, unsigned int>
 > Params4;
 
-TYPED_TEST_CASE(RocprimDeviceHistogramMultiRange, Params4);
+TYPED_TEST_SUITE(RocprimDeviceHistogramMultiRange, Params4);
 
 TYPED_TEST(RocprimDeviceHistogramMultiRange, MultiRange)
 {

--- a/test/rocprim/test_device_merge.cpp
+++ b/test/rocprim/test_device_merge.cpp
@@ -88,7 +88,7 @@ std::vector<std::tuple<size_t, size_t>> get_sizes()
     return sizes;
 }
 
-TYPED_TEST_CASE(RocprimDeviceMergeTests, RocprimDeviceMergeTestsParams);
+TYPED_TEST_SUITE(RocprimDeviceMergeTests, RocprimDeviceMergeTestsParams);
 
 TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
 {

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -86,7 +86,7 @@ std::vector<size_t> get_sizes(int seed_value)
     return sizes;
 }
 
-TYPED_TEST_CASE(RocprimDeviceSortTests, RocprimDeviceSortTestsParams);
+TYPED_TEST_SUITE(RocprimDeviceSortTests, RocprimDeviceSortTestsParams);
 
 TYPED_TEST(RocprimDeviceSortTests, SortKey)
 {

--- a/test/rocprim/test_device_partition.cpp
+++ b/test/rocprim/test_device_partition.cpp
@@ -80,7 +80,7 @@ std::vector<size_t> get_sizes(int seed_value)
     return sizes;
 }
 
-TYPED_TEST_CASE(RocprimDevicePartitionTests, RocprimDevicePartitionTestsParams);
+TYPED_TEST_SUITE(RocprimDevicePartitionTests, RocprimDevicePartitionTestsParams);
 
 TYPED_TEST(RocprimDevicePartitionTests, Flagged)
 {

--- a/test/rocprim/test_device_radix_sort.cpp
+++ b/test/rocprim/test_device_radix_sort.cpp
@@ -82,7 +82,7 @@ typedef ::testing::Types<
     params<float, char, true, 0, 32, true>
 > Params;
 
-TYPED_TEST_CASE(RocprimDeviceRadixSort, Params);
+TYPED_TEST_SUITE(RocprimDeviceRadixSort, Params);
 
 template<class Key, bool Descending, unsigned int StartBit, unsigned int EndBit>
 struct key_comparator

--- a/test/rocprim/test_device_reduce.cpp
+++ b/test/rocprim/test_device_reduce.cpp
@@ -82,7 +82,7 @@ std::vector<size_t> get_sizes(int seed_value)
     return sizes;
 }
 
-TYPED_TEST_CASE(RocprimDeviceReduceTests, RocprimDeviceReduceTestsParams);
+TYPED_TEST_SUITE(RocprimDeviceReduceTests, RocprimDeviceReduceTestsParams);
 
 TYPED_TEST(RocprimDeviceReduceTests, ReduceEmptyInput)
 {

--- a/test/rocprim/test_device_reduce_by_key.cpp
+++ b/test/rocprim/test_device_reduce_by_key.cpp
@@ -101,7 +101,7 @@ typedef ::testing::Types<
     params<unsigned long long, unsigned long long, rocprim::plus<unsigned long long>, 100000, 100000>
 > Params;
 
-TYPED_TEST_CASE(RocprimDeviceReduceByKey, Params);
+TYPED_TEST_SUITE(RocprimDeviceReduceByKey, Params);
 
 std::vector<size_t> get_sizes(int seed_value)
 {

--- a/test/rocprim/test_device_run_length_encode.cpp
+++ b/test/rocprim/test_device_run_length_encode.cpp
@@ -76,7 +76,7 @@ typedef ::testing::Types<
     params<unsigned long long, custom_double2, 100000, 100000>
 > Params;
 
-TYPED_TEST_CASE(RocprimDeviceRunLengthEncode, Params);
+TYPED_TEST_SUITE(RocprimDeviceRunLengthEncode, Params);
 
 std::vector<size_t> get_sizes(int seed_value)
 {

--- a/test/rocprim/test_device_scan.cpp
+++ b/test/rocprim/test_device_scan.cpp
@@ -110,7 +110,7 @@ std::vector<size_t> get_sizes(int seed_value)
     return sizes;
 }
 
-TYPED_TEST_CASE(RocprimDeviceScanTests, RocprimDeviceScanTestsParams);
+TYPED_TEST_SUITE(RocprimDeviceScanTests, RocprimDeviceScanTestsParams);
 
 TYPED_TEST(RocprimDeviceScanTests, InclusiveScanEmptyInput)
 {

--- a/test/rocprim/test_device_segmented_radix_sort.cpp
+++ b/test/rocprim/test_device_segmented_radix_sort.cpp
@@ -81,7 +81,7 @@ typedef ::testing::Types<
     params<unsigned short, test_utils::custom_test_type<double>, false, 8, 11, 50, 200>
 > Params;
 
-TYPED_TEST_CASE(RocprimDeviceSegmentedRadixSort, Params);
+TYPED_TEST_SUITE(RocprimDeviceSegmentedRadixSort, Params);
 
 template<class Key, bool Descending, unsigned int StartBit, unsigned int EndBit>
 struct key_comparator

--- a/test/rocprim/test_device_segmented_reduce.cpp
+++ b/test/rocprim/test_device_segmented_reduce.cpp
@@ -79,7 +79,7 @@ typedef ::testing::Types<
     params<rocprim::half, rocprim::half, test_utils::half_minimum, 0, 1000, 30000>
 > Params;
 
-TYPED_TEST_CASE(RocprimDeviceSegmentedReduce, Params);
+TYPED_TEST_SUITE(RocprimDeviceSegmentedReduce, Params);
 
 std::vector<size_t> get_sizes(int seed_value)
 {

--- a/test/rocprim/test_device_segmented_scan.cpp
+++ b/test/rocprim/test_device_segmented_scan.cpp
@@ -77,7 +77,7 @@ typedef ::testing::Types<
     params<unsigned char, long long, rocprim::plus<int>, 10, 3000, 4000>
 > Params;
 
-TYPED_TEST_CASE(RocprimDeviceSegmentedScan, Params);
+TYPED_TEST_SUITE(RocprimDeviceSegmentedScan, Params);
 
 std::vector<size_t> get_sizes(int seed_value)
 {

--- a/test/rocprim/test_device_select.cpp
+++ b/test/rocprim/test_device_select.cpp
@@ -80,7 +80,7 @@ std::vector<size_t> get_sizes(int seed_value)
     return sizes;
 }
 
-TYPED_TEST_CASE(RocprimDeviceSelectTests, RocprimDeviceSelectTestsParams);
+TYPED_TEST_SUITE(RocprimDeviceSelectTests, RocprimDeviceSelectTestsParams);
 
 TYPED_TEST(RocprimDeviceSelectTests, Flagged)
 {

--- a/test/rocprim/test_device_transform.cpp
+++ b/test/rocprim/test_device_transform.cpp
@@ -84,7 +84,7 @@ std::vector<size_t> get_sizes(int seed_value)
     return sizes;
 }
 
-TYPED_TEST_CASE(RocprimDeviceTransformTests, RocprimDeviceTransformTestsParams);
+TYPED_TEST_SUITE(RocprimDeviceTransformTests, RocprimDeviceTransformTestsParams);
 
 template<class T>
 struct transform

--- a/test/rocprim/test_intrinsics.cpp
+++ b/test/rocprim/test_intrinsics.cpp
@@ -91,7 +91,7 @@ typedef ::testing::Types<
     params<unsigned char>
 > IntrinsicsTestParams;
 
-TYPED_TEST_CASE(RocprimIntrinsicsTests, IntrinsicsTestParams);
+TYPED_TEST_SUITE(RocprimIntrinsicsTests, IntrinsicsTestParams);
 
 template<class T>
 __global__

--- a/test/rocprim/test_intrinsics.cpp
+++ b/test/rocprim/test_intrinsics.cpp
@@ -111,7 +111,7 @@ TYPED_TEST(RocprimIntrinsicsTests, ShuffleUp)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::type;
-    const size_t hardware_warp_size = ::rocprim::warp_size();
+    const size_t hardware_warp_size = ::rocprim::host_warp_size();
     const size_t size = hardware_warp_size;
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -214,7 +214,7 @@ TYPED_TEST(RocprimIntrinsicsTests, ShuffleDown)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::type;
-    const size_t hardware_warp_size = ::rocprim::warp_size();
+    const size_t hardware_warp_size = ::rocprim::host_warp_size();
     const size_t size = hardware_warp_size;
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -319,7 +319,7 @@ TYPED_TEST(RocprimIntrinsicsTests, ShuffleIndex)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::type;
-    const size_t hardware_warp_size = ::rocprim::warp_size();
+    const size_t hardware_warp_size = ::rocprim::host_warp_size();
     const size_t size = hardware_warp_size;
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -422,7 +422,7 @@ TEST(RocprimIntrinsicsTests, ShuffleUpCustomStruct)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = custom_notaligned;
-    const size_t hardware_warp_size = ::rocprim::warp_size();
+    const size_t hardware_warp_size = ::rocprim::host_warp_size();
     const size_t size = hardware_warp_size;
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -522,7 +522,7 @@ TEST(RocprimIntrinsicsTests, ShuffleUpCustomAlignedStruct)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = custom_16aligned;
-    const size_t hardware_warp_size = ::rocprim::warp_size();
+    const size_t hardware_warp_size = ::rocprim::host_warp_size();
     const size_t size = hardware_warp_size;
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)

--- a/test/rocprim/test_texture_cache_iterator.cpp
+++ b/test/rocprim/test_texture_cache_iterator.cpp
@@ -54,7 +54,7 @@ typedef ::testing::Types<
     RocprimTextureCacheIteratorParams<test_utils::custom_test_type<float>>
 > RocprimTextureCacheIteratorTestsParams;
 
-TYPED_TEST_CASE(RocprimTextureCacheIteratorTests, RocprimTextureCacheIteratorTestsParams);
+TYPED_TEST_SUITE(RocprimTextureCacheIteratorTests, RocprimTextureCacheIteratorTestsParams);
 
 template<class T>
 struct transform

--- a/test/rocprim/test_thread.cpp
+++ b/test/rocprim/test_thread.cpp
@@ -68,7 +68,7 @@ typedef ::testing::Types<
     params<256, 2, 2>
 > Params;
 
-TYPED_TEST_CASE(RocprimThreadTests, Params);
+TYPED_TEST_SUITE(RocprimThreadTests, Params);
 
 template<
     unsigned int BlockSizeX,

--- a/test/rocprim/test_transform_iterator.cpp
+++ b/test/rocprim/test_transform_iterator.cpp
@@ -80,7 +80,7 @@ typedef ::testing::Types<
     RocprimTransformIteratorParams<float, plus_ten<double>, double>
 > RocprimTransformIteratorTestsParams;
 
-TYPED_TEST_CASE(RocprimTransformIteratorTests, RocprimTransformIteratorTestsParams);
+TYPED_TEST_SUITE(RocprimTransformIteratorTests, RocprimTransformIteratorTestsParams);
 
 TYPED_TEST(RocprimTransformIteratorTests, TransformReduce)
 {

--- a/test/rocprim/test_warp_reduce.cpp
+++ b/test/rocprim/test_warp_reduce.cpp
@@ -34,7 +34,7 @@ public:
     using params = Params;
 };
 
-TYPED_TEST_CASE(RocprimWarpReduceTests, WarpParams);
+TYPED_TEST_SUITE(RocprimWarpReduceTests, WarpParams);
 
 template<
     class T,

--- a/test/rocprim/test_warp_reduce.cpp
+++ b/test/rocprim/test_warp_reduce.cpp
@@ -73,8 +73,8 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSum)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -211,8 +211,8 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSum)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -356,8 +356,8 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumValid)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -495,8 +495,8 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSumValid)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -617,8 +617,8 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumCustomStruct)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -766,8 +766,8 @@ TYPED_TEST(RocprimWarpReduceTests, HeadSegmentedReduceSum)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -939,8 +939,8 @@ TYPED_TEST(RocprimWarpReduceTests, TailSegmentedReduceSum)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =

--- a/test/rocprim/test_warp_reduce.cpp
+++ b/test/rocprim/test_warp_reduce.cpp
@@ -98,7 +98,8 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -235,7 +236,8 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -380,7 +382,8 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumValid)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -518,7 +521,8 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSumValid)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -638,7 +642,8 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumCustomStruct)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -786,7 +791,8 @@ TYPED_TEST(RocprimWarpReduceTests, HeadSegmentedReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -958,7 +964,8 @@ TYPED_TEST(RocprimWarpReduceTests, TailSegmentedReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 

--- a/test/rocprim/test_warp_reduce.cpp
+++ b/test/rocprim/test_warp_reduce.cpp
@@ -42,7 +42,7 @@ template<
     unsigned int LogicalWarpSize
 >
 __global__
-__launch_bounds__(BlockSize, ROCPRIM_DEFAULT_MIN_WARPS_PER_EU)
+__launch_bounds__(BlockSize, 0)
 void warp_reduce_sum_kernel(T* device_input, T* device_output)
 {
     constexpr unsigned int warps_no = BlockSize / LogicalWarpSize;
@@ -74,7 +74,7 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSum)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
             ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-            : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+            : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     const size_t size = block_size * 4;
 
     // Given warp size not supported
@@ -153,7 +153,7 @@ template<
     unsigned int LogicalWarpSize
 >
 __global__
-__launch_bounds__(BlockSize, ROCPRIM_DEFAULT_MIN_WARPS_PER_EU)
+__launch_bounds__(BlockSize, 0)
 void warp_allreduce_sum_kernel(T* device_input, T* device_output)
 {
     constexpr unsigned int warps_no = BlockSize / LogicalWarpSize;
@@ -182,7 +182,7 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSum)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
             ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-            : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+            : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     const size_t size = block_size * 4;
 
     // Given warp size not supported
@@ -265,7 +265,7 @@ template<
     unsigned int LogicalWarpSize
 >
 __global__
-__launch_bounds__(BlockSize, ROCPRIM_DEFAULT_MIN_WARPS_PER_EU)
+__launch_bounds__(BlockSize, 0)
 void warp_reduce_sum_kernel(T* device_input, T* device_output, size_t valid)
 {
     constexpr unsigned int warps_no = BlockSize / LogicalWarpSize;
@@ -297,7 +297,7 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumValid)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
             ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-            : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+            : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     const size_t size = block_size * 4;
     const size_t valid = logical_warp_size - 1;
 
@@ -377,7 +377,7 @@ template<
     unsigned int LogicalWarpSize
 >
 __global__
-__launch_bounds__(BlockSize, ROCPRIM_DEFAULT_MIN_WARPS_PER_EU)
+__launch_bounds__(BlockSize, 0)
 void warp_allreduce_sum_kernel(T* device_input, T* device_output, size_t valid)
 {
     constexpr unsigned int warps_no = BlockSize / LogicalWarpSize;
@@ -406,7 +406,7 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSumValid)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
             ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-            : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+            : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     const size_t size = block_size * 4;
     const size_t valid = logical_warp_size - 1;
 
@@ -498,7 +498,7 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumCustomStruct)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
             ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-            : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+            : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     const size_t size = block_size * 4;
 
     // Given warp size not supported
@@ -586,7 +586,7 @@ template<
     unsigned int LogicalWarpSize
 >
 __global__
-__launch_bounds__(BlockSize, ROCPRIM_DEFAULT_MIN_WARPS_PER_EU)
+__launch_bounds__(BlockSize, 0)
 void head_segmented_warp_reduce_kernel(T* input, Flag* flags, T* output)
 {
     constexpr unsigned int warps_no = BlockSize / LogicalWarpSize;
@@ -617,7 +617,7 @@ TYPED_TEST(RocprimWarpReduceTests, HeadSegmentedReduceSum)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
             ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-            : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+            : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     const size_t size = block_size * 4;
 
     // Given warp size not supported
@@ -730,7 +730,7 @@ template<
     unsigned int LogicalWarpSize
 >
 __global__
-__launch_bounds__(BlockSize, ROCPRIM_DEFAULT_MIN_WARPS_PER_EU)
+__launch_bounds__(BlockSize, 0)
 void tail_segmented_warp_reduce_kernel(T* input, Flag* flags, T* output)
 {
     constexpr unsigned int warps_no = BlockSize / LogicalWarpSize;
@@ -761,7 +761,7 @@ TYPED_TEST(RocprimWarpReduceTests, TailSegmentedReduceSum)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
             ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-            : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+            : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     const size_t size = block_size * 4;
 
     // Given warp size not supported

--- a/test/rocprim/test_warp_reduce.cpp
+++ b/test/rocprim/test_warp_reduce.cpp
@@ -78,9 +78,10 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSum)
     const size_t size = block_size * 4;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -185,9 +186,10 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSum)
     const size_t size = block_size * 4;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -300,9 +302,10 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumValid)
     const size_t valid = logical_warp_size - 1;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -408,9 +411,10 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSumValid)
     const size_t valid = logical_warp_size - 1;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -498,9 +502,10 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumCustomStruct)
     const size_t size = block_size * 4;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -616,9 +621,10 @@ TYPED_TEST(RocprimWarpReduceTests, HeadSegmentedReduceSum)
     const size_t size = block_size * 4;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -759,9 +765,10 @@ TYPED_TEST(RocprimWarpReduceTests, TailSegmentedReduceSum)
     const size_t size = block_size * 4;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)

--- a/test/rocprim/test_warp_reduce.cpp
+++ b/test/rocprim/test_warp_reduce.cpp
@@ -96,7 +96,7 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSum)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -234,7 +234,7 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSum)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -380,7 +380,7 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumValid)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -519,7 +519,7 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSumValid)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -640,7 +640,7 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumCustomStruct)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -789,7 +789,7 @@ TYPED_TEST(RocprimWarpReduceTests, HeadSegmentedReduceSum)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -962,7 +962,7 @@ TYPED_TEST(RocprimWarpReduceTests, TailSegmentedReduceSum)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);

--- a/test/rocprim/test_warp_reduce.cpp
+++ b/test/rocprim/test_warp_reduce.cpp
@@ -98,7 +98,7 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -235,7 +235,7 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -375,12 +375,12 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumValid)
     constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
     const size_t valid = logical_warp_size - 1;
-    
+
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -518,7 +518,7 @@ TYPED_TEST(RocprimWarpReduceTests, AllReduceSumValid)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -638,7 +638,7 @@ TYPED_TEST(RocprimWarpReduceTests, ReduceSumCustomStruct)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -786,7 +786,7 @@ TYPED_TEST(RocprimWarpReduceTests, HeadSegmentedReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -958,7 +958,7 @@ TYPED_TEST(RocprimWarpReduceTests, TailSegmentedReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 

--- a/test/rocprim/test_warp_scan.cpp
+++ b/test/rocprim/test_warp_scan.cpp
@@ -38,7 +38,7 @@ public:
     using params = Params;
 };
 
-TYPED_TEST_CASE(RocprimWarpScanTests, WarpParams);
+TYPED_TEST_SUITE(RocprimWarpScanTests, WarpParams);
 
 template<
     class T,

--- a/test/rocprim/test_warp_scan.cpp
+++ b/test/rocprim/test_warp_scan.cpp
@@ -97,7 +97,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScan)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -148,7 +148,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScan)
                 device_input, device_output
             );
         }
-        else if (current_device_warp_size == ws32)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_kernel<T, block_size_ws64, logical_warp_size>),
@@ -243,7 +243,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanReduce)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -401,7 +401,7 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveScan)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -550,7 +550,7 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveReduceScan)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -721,7 +721,7 @@ TYPED_TEST(RocprimWarpScanTests, Scan)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -792,7 +792,7 @@ TYPED_TEST(RocprimWarpScanTests, Scan)
                 device_input, device_inclusive_output, device_exclusive_output, init
             );
         }
-        else if (current_device_warp_size == ws32)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_scan_kernel<T, block_size_ws64, logical_warp_size>),
@@ -900,7 +900,7 @@ TYPED_TEST(RocprimWarpScanTests, ScanReduce)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -982,7 +982,7 @@ TYPED_TEST(RocprimWarpScanTests, ScanReduce)
                 device_inclusive_output, device_exclusive_output, device_output_reductions, init
             );
         }
-        else if (current_device_warp_size == ws32)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_scan_reduce_kernel<T, block_size_ws64, logical_warp_size>),
@@ -1068,7 +1068,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanCustomType)
 
     // Check if warp size is supported
     if( (logical_warp_size > current_device_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -1128,7 +1128,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanCustomType)
                 device_input, device_output
             );
         }
-        else if (current_device_warp_size == ws32)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_kernel<T, block_size_ws64, logical_warp_size>),

--- a/test/rocprim/test_warp_scan.cpp
+++ b/test/rocprim/test_warp_scan.cpp
@@ -99,7 +99,8 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -244,7 +245,8 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanReduce)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -401,7 +403,8 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -549,7 +552,8 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveReduceScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -719,7 +723,8 @@ TYPED_TEST(RocprimWarpScanTests, Scan)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -897,7 +902,8 @@ TYPED_TEST(RocprimWarpScanTests, ScanReduce)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -1064,7 +1070,8 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanCustomType)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 

--- a/test/rocprim/test_warp_scan.cpp
+++ b/test/rocprim/test_warp_scan.cpp
@@ -75,7 +75,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScan)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
         ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-        : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+        : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
@@ -192,7 +192,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanReduce)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
             ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-            : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+            : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
@@ -321,7 +321,7 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveScan)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
         ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-        : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+        : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
@@ -441,7 +441,7 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveReduceScan)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
         ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-        : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+        : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size,  1);
     unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
@@ -584,7 +584,7 @@ TYPED_TEST(RocprimWarpScanTests, Scan)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
         ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-        : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+        : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
@@ -734,7 +734,7 @@ TYPED_TEST(RocprimWarpScanTests, ScanReduce)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
         ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-        : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+        : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
@@ -872,7 +872,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanCustomType)
     constexpr size_t block_size =
         rocprim::detail::is_power_of_two(logical_warp_size)
         ? rocprim::max<size_t>(rocprim::warp_size(), logical_warp_size * 4)
-        : (rocprim::warp_size()/logical_warp_size) * logical_warp_size;
+        : rocprim::max<size_t>((rocprim::warp_size()/logical_warp_size) * logical_warp_size, 1);
     unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 

--- a/test/rocprim/test_warp_scan.cpp
+++ b/test/rocprim/test_warp_scan.cpp
@@ -80,9 +80,10 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScan)
     const size_t size = block_size * grid_size;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -196,9 +197,10 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanReduce)
     const size_t size = block_size * grid_size;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -324,9 +326,10 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveScan)
     const size_t size = block_size * grid_size;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -443,9 +446,10 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveReduceScan)
     const size_t size = block_size * grid_size;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -585,9 +589,10 @@ TYPED_TEST(RocprimWarpScanTests, Scan)
     const size_t size = block_size * grid_size;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -734,9 +739,10 @@ TYPED_TEST(RocprimWarpScanTests, ScanReduce)
     const size_t size = block_size * grid_size;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -871,9 +877,10 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanCustomType)
     const size_t size = block_size * grid_size;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size())
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size)
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)

--- a/test/rocprim/test_warp_scan.cpp
+++ b/test/rocprim/test_warp_scan.cpp
@@ -74,8 +74,8 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScan)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -220,8 +220,8 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanReduce)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -378,8 +378,8 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveScan)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -527,8 +527,8 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveReduceScan)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -698,8 +698,8 @@ TYPED_TEST(RocprimWarpScanTests, Scan)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -877,8 +877,8 @@ TYPED_TEST(RocprimWarpScanTests, ScanReduce)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =
@@ -1045,8 +1045,8 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanCustomType)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     // Block size of warp size 32
     constexpr size_t block_size_ws32 =

--- a/test/rocprim/test_warp_scan.cpp
+++ b/test/rocprim/test_warp_scan.cpp
@@ -99,7 +99,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -244,7 +244,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanReduce)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -401,7 +401,7 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -549,7 +549,7 @@ TYPED_TEST(RocprimWarpScanTests, ExclusiveReduceScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -719,7 +719,7 @@ TYPED_TEST(RocprimWarpScanTests, Scan)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -897,7 +897,7 @@ TYPED_TEST(RocprimWarpScanTests, ScanReduce)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -1064,7 +1064,7 @@ TYPED_TEST(RocprimWarpScanTests, InclusiveScanCustomType)
     if( (logical_warp_size > current_device_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -58,7 +58,7 @@ typedef ::testing::Types<
     warp_sort_param_type(rocprim::half)
 > WarpSortParams;
 
-TYPED_TEST_CASE(RocprimWarpSortShuffleBasedTests, WarpSortParams);
+TYPED_TEST_SUITE(RocprimWarpSortShuffleBasedTests, WarpSortParams);
 
 template<
     class T,

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -79,8 +79,8 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, Sort)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     const unsigned int current_device_warp_size = rocprim::host_warp_size();
     const size_t block_size = std::max<size_t>(current_device_warp_size, logical_warp_size * 4);
@@ -186,8 +186,8 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, SortKeyInt)
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
     // The different warp sizes
-    constexpr size_t ws32 = 32;
-    constexpr size_t ws64 = 64;
+    constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
+    constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
     const unsigned int current_device_warp_size = rocprim::host_warp_size();
     const size_t block_size = std::max<size_t>(current_device_warp_size, logical_warp_size * 4);

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -90,15 +90,9 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, Sort)
     constexpr size_t ws32 = 32;
     constexpr size_t ws64 = 64;
 
-    // Block size of warp size 32
-    constexpr size_t block_size_ws32 = rocprim::max<size_t>(ws32, logical_warp_size * 4);
-
-    // Block size of warp size 64
-    constexpr size_t block_size_ws64 = rocprim::max<size_t>(ws64, logical_warp_size * 4);
-
     const unsigned int current_device_warp_size = rocprim::host_warp_size();
+    const size_t block_size = std::max<size_t>(ws32, logical_warp_size * 4);
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
@@ -107,7 +101,7 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, Sort)
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -202,15 +196,9 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, SortKeyInt)
     constexpr size_t ws32 = 32;
     constexpr size_t ws64 = 64;
 
-    // Block size of warp size 32
-    constexpr size_t block_size_ws32 = rocprim::max<size_t>(ws32, logical_warp_size * 4);
-
-    // Block size of warp size 64
-    constexpr size_t block_size_ws64 = rocprim::max<size_t>(ws64, logical_warp_size * 4);
-
     const unsigned int current_device_warp_size = rocprim::host_warp_size();
+    const size_t block_size = std::max<size_t>(ws32, logical_warp_size * 4);
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
@@ -219,7 +207,7 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, SortKeyInt)
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
+        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
         GTEST_SKIP();
     }
 

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -85,14 +85,29 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, Sort)
     using T = typename TestFixture::params::type;
     using binary_op_type = typename std::conditional<std::is_same<T, rocprim::half>::value, test_utils::half_less, rocprim::less<T>>::type;
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
-    const size_t block_size = std::max<size_t>(rocprim::warp_size(), 4 * logical_warp_size);
-    constexpr size_t grid_size = 4;
+
+    // The different warp sizes
+    constexpr size_t ws32 = 32;
+    constexpr size_t ws64 = 64;
+
+    // Block size of warp size 32
+    constexpr size_t block_size_ws32 = rocprim::max<size_t>(ws32, logical_warp_size * 4);
+
+    // Block size of warp size 64
+    constexpr size_t block_size_ws64 = rocprim::max<size_t>(ws64, logical_warp_size * 4);
+
+    const unsigned int current_device_warp_size = rocprim::host_warp_size();
+
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
-    // Given warp size not supported
-    unsigned int current_device_warp_size = rocprim::host_warp_size();
-    if(logical_warp_size > current_device_warp_size || !rocprim::detail::is_power_of_two(logical_warp_size))
+    // Check if warp size is supported
+    if( logical_warp_size > current_device_warp_size ||
+        !rocprim::detail::is_power_of_two(logical_warp_size) ||
+        (block_size != ws32 && block_size != ws64) )
     {
+        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
         GTEST_SKIP();
     }
 
@@ -182,14 +197,29 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, SortKeyInt)
     using value_op_type = typename std::conditional<std::is_same<T, rocprim::half>::value, test_utils::half_less, rocprim::less<T>>::type;
     using eq_op_type = typename std::conditional<std::is_same<T, rocprim::half>::value, test_utils::half_equal_to, rocprim::equal_to<T>>::type;
     constexpr size_t logical_warp_size = TestFixture::params::warp_size;
-    const size_t block_size = std::max<size_t>(rocprim::warp_size(), 4 * logical_warp_size);
-    constexpr size_t grid_size = 4;
+
+    // The different warp sizes
+    constexpr size_t ws32 = 32;
+    constexpr size_t ws64 = 64;
+
+    // Block size of warp size 32
+    constexpr size_t block_size_ws32 = rocprim::max<size_t>(ws32, logical_warp_size * 4);
+
+    // Block size of warp size 64
+    constexpr size_t block_size_ws64 = rocprim::max<size_t>(ws64, logical_warp_size * 4);
+
+    const unsigned int current_device_warp_size = rocprim::host_warp_size();
+
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
-    // Given warp size not supported
-    unsigned int current_device_warp_size = rocprim::host_warp_size();
-    if(logical_warp_size > current_device_warp_size || !rocprim::detail::is_power_of_two(logical_warp_size))
+    // Check if warp size is supported
+    if( logical_warp_size > current_device_warp_size ||
+        !rocprim::detail::is_power_of_two(logical_warp_size) ||
+        (block_size != ws32 && block_size != ws64) )
     {
+        printf("Unsupported warp size: %d.  Skipping test\n", rocprim::host_warp_size());
         GTEST_SKIP();
     }
 

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -34,22 +34,14 @@ public:
     using params = Params;
 };
 
-#if (defined(__gfx1030__))
-    #define warp_sort_param_type(type) \
-        warp_params<type, 2U>, \
-        warp_params<type, 4U>, \
-        warp_params<type, 8U>, \
-        warp_params<type, 16U>, \
-        warp_params<type, 32U>
-#else
-    #define warp_sort_param_type(type) \
-       warp_params<type, 2U>, \
-       warp_params<type, 4U>, \
-       warp_params<type, 8U>, \
-       warp_params<type, 16U>, \
-       warp_params<type, 32U>, \
-       warp_params<type, 64U>
-#endif
+#define warp_sort_param_type(type) \
+   warp_params<type, 2U>, \
+   warp_params<type, 4U>, \
+   warp_params<type, 8U>, \
+   warp_params<type, 16U>, \
+   warp_params<type, 32U>, \
+   warp_params<type, 64U>
+
 typedef ::testing::Types<
     warp_sort_param_type(int),
     warp_sort_param_type(test_utils::custom_test_type<int>),
@@ -101,7 +93,8 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, Sort)
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -207,7 +200,8 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, SortKeyInt)
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
         (block_size != ws32 && block_size != ws64) )
     {
-        printf("Unsupported warp size: %d.  Skipping test\n", current_device_warp_size);
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -90,9 +90,10 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, Sort)
     const size_t size = block_size * grid_size;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size() || !rocprim::detail::is_power_of_two(logical_warp_size))
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size || !rocprim::detail::is_power_of_two(logical_warp_size))
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -186,9 +187,10 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, SortKeyInt)
     const size_t size = block_size * grid_size;
 
     // Given warp size not supported
-    if(logical_warp_size > rocprim::warp_size() || !rocprim::detail::is_power_of_two(logical_warp_size))
+    unsigned int current_device_warp_size = rocprim::host_warp_size();
+    if(logical_warp_size > current_device_warp_size || !rocprim::detail::is_power_of_two(logical_warp_size))
     {
-        return;
+        GTEST_SKIP();
     }
 
     for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)

--- a/test/rocprim/test_warp_sort.cpp
+++ b/test/rocprim/test_warp_sort.cpp
@@ -83,7 +83,7 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, Sort)
     constexpr size_t ws64 = 64;
 
     const unsigned int current_device_warp_size = rocprim::host_warp_size();
-    const size_t block_size = std::max<size_t>(ws32, logical_warp_size * 4);
+    const size_t block_size = std::max<size_t>(current_device_warp_size, logical_warp_size * 4);
 
     constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
@@ -91,7 +91,7 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, Sort)
     // Check if warp size is supported
     if( logical_warp_size > current_device_warp_size ||
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
@@ -190,7 +190,7 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, SortKeyInt)
     constexpr size_t ws64 = 64;
 
     const unsigned int current_device_warp_size = rocprim::host_warp_size();
-    const size_t block_size = std::max<size_t>(ws32, logical_warp_size * 4);
+    const size_t block_size = std::max<size_t>(current_device_warp_size, logical_warp_size * 4);
 
     constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
@@ -198,7 +198,7 @@ TYPED_TEST(RocprimWarpSortShuffleBasedTests, SortKeyInt)
     // Check if warp size is supported
     if( logical_warp_size > current_device_warp_size ||
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
-        (block_size != ws32 && block_size != ws64) )
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);


### PR DESCRIPTION
Gfx 1030 & Gfx 1031 support:

The problem here, we need a library, which can handle multiple WarpSize values(32, 64) at the same compile time. Now we have a hybrid state, where we do not know at compile time the warp_size, we only know at device side. So we have two new warp_size() functions here:

```
/// \brief Returns a number of threads in a hardware warp for the actual device.
/// At host side this constant is available at runtime time only.
///
/// It is constant for a device.
ROCPRIM_HOST inline
unsigned int host_warp_size()
{
    unsigned int warp_size = -1;
    int default_hip_device;
    hipGetDevice(&default_hip_device);
    hipDeviceProp_t device_prop;
    hipGetDeviceProperties(&device_prop,default_hip_device);
    warp_size = device_prop.warpSize;
    return warp_size;
};

/// \brief Returns a number of threads in a hardware warp for the actual target.
/// At device side this constant is available at compile time.
///
/// It is constant for a device.
ROCPRIM_DEVICE inline
constexpr unsigned int device_warp_size()
{
    return warpSize;
}

```

That's why if we have a warp template parameter, which is comming from host side, we need a kernel selection like we have in the WARP primitives tests:

```
        if (current_device_warp_size == ws32)
        {
            hipLaunchKernelGGL(
                HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
                dim3(size/block_size_ws32), dim3(block_size_ws32), 0, 0,
                device_input, device_output
            );
        }
        else if (current_device_warp_size == ws64)
        {
            hipLaunchKernelGGL(
                HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
                dim3(size/block_size_ws64), dim3(block_size_ws64), 0, 0,
                device_input, device_output
            );
        }

```

If we have a hybrid class (whcih has host and device functions), we need to alter the class to use ```host_warp_size``` at ```host``` functions and ```device_warp_size``` at ```device``` functions.

Example: rocprim\include\rocprim\device\detail\lookback_scan_state.hpp