### PR TITLE
Update config parameter and enable ROCPRIM_DETAIL_USE_DPP for gfx90a

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ stages:
   - build:cmake_latest   # Tests if builds succeed (CMake)
   - build:cmake_minimum  # Tests if builds succeed (CMake)
   - test    # Tests if unit tests are passing (CTest)
+  - benchmark
 
 variables:
   # Tested CMake versions
@@ -40,7 +41,7 @@ variables:
   BUILD_DIR: $CI_PROJECT_DIR/build
   CMAKE_MINIMUM_URL: "https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz"
   CMAKE_MINIMUM_PATH: "$CI_PROJECT_DIR/deps/cmake-3.10.2"
-  CMAKE_LATEST_URL: "https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz"
+  CMAKE_LATEST_URL: "https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.tar.gz"
   CMAKE_LATEST_PATH: "$CI_PROJECT_DIR/deps/cmake-3.17.0"
   BUILD_MINIMUM_DIR: $CI_PROJECT_DIR/build/cmake-3.10.2
   BUILD_LATEST_DIR: $CI_PROJECT_DIR/build/cmake-3.17.0
@@ -181,7 +182,107 @@ build:package:
       - $PACKAGE_DIR/rocprim*.zip
     expire_in: 2 weeks
 
+build:benchmark:
+  extends:
+    - .deps:cmake-latest
+  tags:
+    - mi25
+    - rocm
+  only:
+    - ci-benchmark-extend
+    - internal_benchmark
+    - develop_stream
+    - develop
+    - master
+  script:
+    - mkdir build
+    - cd build
+    # Build hipCUB benchmark
+    - cmake
+      -G Ninja
+      -D CMAKE_CXX_COMPILER=hipcc
+      -D CMAKE_BUILD_TYPE=Release
+      -D BUILD_TEST=OFF
+      -D BUILD_EXAMPLE=OFF
+      -D BUILD_BENCHMARK=ON
+      -D DISABLE_WERROR=OFF
+      -D AMDGPU_TARGETS="gfx803;gfx900;gfx906"
+      ..
+    - cmake
+      --build .
+  artifacts:
+    paths:
+      - build/benchmark/*
+      - build/googlebenchmark/
+    expire_in: 2 weeks
+
 include: '.gitlab-ci-gputest.yml'
+
+benchmark_view:rocm_mi25:
+  extends:
+    - .deps:cmake-latest
+  stage: benchmark
+  when: manual
+  only:
+    - ci-benchmark-extend
+    - internal_benchmark
+    - develop_stream
+    - develop
+    - master
+  needs:
+    - build:benchmark
+  tags:
+    - mi25
+    - rocm
+  script:
+    - $SUDO_CMD cmake
+      -D BENCHMARK_BINARY_DIR=build/benchmark
+      -D BENCHMARK_OUTPUT_DIR=.
+      -P ${CI_PROJECT_DIR}/.gitlab/RunBenchmarks.cmake
+
+benchmark_view:rocm_s9300:
+  extends:
+    - .deps:cmake-latest
+  stage: benchmark
+  when: manual
+  only:
+    - ci-benchmark-extend
+    - internal_benchmark
+    - develop_stream
+    - develop
+    - master
+  needs:
+    - build:benchmark
+  tags:
+    - s9300
+    - rocm
+  script:
+    - $SUDO_CMD cmake
+      -D BENCHMARK_BINARY_DIR=build/benchmark
+      -D BENCHMARK_OUTPUT_DIR=.
+      -P ${CI_PROJECT_DIR}/.gitlab/RunBenchmarks.cmake
+
+benchmark_view:rocm_vega20:
+  extends:
+    - .deps:cmake-latest
+  stage: benchmark
+  when: manual
+  only:
+    - ci-benchmark-extend
+    - internal_benchmark
+    - develop_stream
+    - develop
+    - master
+  needs:
+    - build:benchmark
+  tags:
+    - vega20
+    - rocm
+  script:
+    - $SUDO_CMD cmake
+      -D BENCHMARK_BINARY_DIR=build/benchmark
+      -D BENCHMARK_OUTPUT_DIR=.
+      -P ${CI_PROJECT_DIR}/.gitlab/RunBenchmarks.cmake
 
 test:deb:
   stage: test

--- a/.gitlab/RunBenchmarks.cmake
+++ b/.gitlab/RunBenchmarks.cmake
@@ -1,0 +1,125 @@
+# Command-line argument processing
+if(NOT BENCHMARK_BINARY_DIR)
+  message(STATUS "BENCHMARK_BINARY_DIR not provided, defaulting to working directory")
+  set(BENCHMARK_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+if(NOT BENCHMARK_OUTPUT_DIR)
+  message(STATUS "BENCHMARK_OUTPUT_DIR not provided, defaulting to BENCHMARK_BINARY_DIR")
+  set(BENCHMARK_OUTPUT_DIR ${BENCHMARK_BINARY_DIR})
+endif()
+if(NOT BENCHMARK_QUIET)
+  set(OUTPUT_QUIET OUTPUT_QUIET)
+else()
+  set(OUTPUT_QUIET)
+endif()
+
+# Search for command-line tools
+find_program(CURL_EXECUTABLE
+  NAMES curl
+)
+if(NOT CURL_EXECUTABLE)
+  message(FATAL_ERROR "curl executable not found. Please provide a path to it via CMAKE_PREFIX_PATH")
+endif()
+
+if(DEFINED ENV{CI_COMMIT_SHA})
+  set(GIT_HASH $ENV{CI_COMMIT_SHA})
+  message(STATUS "Environment has CI_COMMIT_SHA: $ENV{CI_COMMIT_SHA}")
+else()
+  find_package(Git
+    REQUIRED
+  )
+  if(NOT GIT_FOUND)
+    message(FATAL_ERROR "git executable not found. Please provide a path to it via CMAKE_PREFIX_PATH")
+  endif()
+
+  execute_process(
+      COMMAND ${GIT_EXECUTABLE}
+        rev-parse HEAD
+      RESULT_VARIABLE GIT_EXIT_CODE
+      OUTPUT_VARIABLE GIT_HASH
+      ERROR_VARIABLE GIT_STDERR
+    )
+  if(NOT GIT_EXIT_CODE EQUAL 0)
+    message(FATAL_ERROR "git rev-parse HEAD returned exit code ${GIT_EXIT_CODE}")
+  else()
+    message(STATUS "git rev-parse HEAD reported hash: ${GIT_HASH}")
+  endif()
+endif()
+
+string(STRIP ${GIT_HASH} GIT_HASH)
+
+# Benchmark processing
+file(GLOB BENCHMARKS "${BENCHMARK_BINARY_DIR}/benchmark_*")
+foreach(BENCHMARK IN LISTS BENCHMARKS)
+  get_filename_component(BENCHMARK_NAME "${BENCHMARK}" NAME_WE)
+
+  if(BENCHMARK_REST_ENDPOINT) # else() not needed, as default is console dump.
+    set(BENCHMARK_ARGS "--benchmark_format=json --benchmark_out=${BENCHMARK_OUTPUT_DIR}/${BENCHMARK_NAME}.json")
+  endif()
+
+  message(STATUS "Running ${BENCHMARK}")
+  execute_process(
+    COMMAND ${BENCHMARK}
+      ${BENCHMARK_ARGS}
+    RESULT_VARIABLE BENCHMARK_EXIT_CODE
+    OUTPUT_VARIABLE BENCHMARK_STDOUT
+    ERROR_VARIABLE BENCHMARK_STDERR
+  )
+  if(NOT BENCHMARK_EXIT_CODE EQUAL 0)
+    message(FATAL_ERROR "${BENCHMARK_NAME} returned exit code ${BENCHMARK_EXIT_CODE}" "Stdout:\n${BENCHMARK_STDOUT}" "Stderr:\n${BENCHMARK_STDERR}")
+  endif()
+  if(NOT BENCHMARK_QUIET)
+    message(STATUS "${BENCHMARK_STDOUT}")
+  endif()
+
+  if(NOT BENCHMARK_REST_ENDPOINT)
+    continue() # If we're not submitting, no need to enrich and send over the wire.
+  endif()
+
+  # Enrich data
+  #
+  # NOTE: regex matching first line instead of entire BENCHMARK_STDOUT
+  #       because searching up until the first newline character in any
+  #       way is borked.
+  string(FIND "${BENCHMARK_STDOUT}" "\n" FIRST_NEWLINE)
+  string(SUBSTRING "${BENCHMARK_STDOUT}" 0 ${FIRST_NEWLINE} FIRST_LINE)
+  string(REGEX MATCH
+    [[^\[(HIP|CUDA)\] Device name: (.*)$]]
+    DEVICE_MATCH
+    "${FIRST_LINE}"
+  )
+  if(CMAKE_MATCH_0)
+    set(DEVICE_NAME "${CMAKE_MATCH_2}")
+  else()
+    message(FATAL_ERROR "Device name not found on console output of ${BENCHMARK_NAME}. Output was:" "${BENCHMARK_STDOUT}")
+  endif()
+
+  file(READ
+    ${BENCHMARK_OUTPUT_DIR}/${BENCHMARK_NAME}.json
+    BENCHMARK_FILEOUT
+  )
+  string(REGEX REPLACE
+    [[("context": {)]]
+    "\"context\": {\n    \"device\": \"${DEVICE_NAME}\",\n    \"hash\": \"${GIT_HASH}\"," JSON_PAYLOAD
+    "${BENCHMARK_FILEOUT}"
+  )
+  file(WRITE
+    ${BENCHMARK_OUTPUT_DIR}/${BENCHMARK_NAME}.json
+    "${JSON_PAYLOAD}"
+  )
+
+  # Submit data
+  execute_process(
+    COMMAND ${CURL_EXECUTABLE}
+      --header "Content-Type: application/json"
+      --request POST
+      --data-binary "@${BENCHMARK_OUTPUT_DIR}/${BENCHMARK_NAME}.json"
+      ${BENCHMARK_REST_ENDPOINT}
+    RESULT_VARIABLE CURL_EXIT_CODE
+    OUTPUT_VARIABLE CURL_STDOUT
+    ERROR_VARIABLE CURL_STDERR
+  )
+  if(NOT CURL_EXIT_CODE EQUAL 0)
+    message(FATAL_ERROR "curl returned exit code ${CURL_EXIT_CODE}")
+  endif()
+endforeach()

--- a/rocprim/include/rocprim/config.hpp
+++ b/rocprim/include/rocprim/config.hpp
@@ -53,7 +53,8 @@
       defined(__gfx904__) || \
       defined(__gfx906__) || \
       defined(__gfx908__) || \
-      defined(__gfx909__) ) && \
+      defined(__gfx909__) || \
+      defined(__gfx90a__) ) && \
       !defined(ROCPRIM_DISABLE_DPP)
     #define ROCPRIM_DETAIL_USE_DPP true
 #else

--- a/rocprim/include/rocprim/config.hpp
+++ b/rocprim/include/rocprim/config.hpp
@@ -79,9 +79,14 @@
 // Defines targeted AMD architecture. Supported values:
 // * 803 (gfx803)
 // * 900 (gfx900)
+// * 906 (gfx906)C
+// * 908 (gfx908)C
+// * 910 (gfx90a)C
 #ifndef ROCPRIM_TARGET_ARCH
     #define ROCPRIM_TARGET_ARCH 0
 #endif
+
+#define ROCPRIM_ARCH_90a 910
 
 /// Supported warp sizes
 #define ROCPRIM_WARP_SIZE_32 32u

--- a/rocprim/include/rocprim/device/device_histogram_config.hpp
+++ b/rocprim/include/rocprim/device/device_histogram_config.hpp
@@ -89,12 +89,32 @@ struct histogram_config_900
     using type = histogram_config<kernel_config<256, ::rocprim::max(8u / Channels / item_scale, 1u)>>;
 };
 
+// TODO: We need to update these parameters
+template<class Sample, unsigned int Channels, unsigned int ActiveChannels>
+struct histogram_config_910
+{
+    static constexpr unsigned int item_scale = ::rocprim::detail::ceiling_div(sizeof(Sample), sizeof(int));
+
+    using type = histogram_config<kernel_config<256, ::rocprim::max(8u / Channels / item_scale, 1u)>>;
+};
+
+// TODO: We need to update these parameters
+template<class Sample, unsigned int Channels, unsigned int ActiveChannels>
+struct histogram_config_1031
+{
+    static constexpr unsigned int item_scale = ::rocprim::detail::ceiling_div(sizeof(Sample), sizeof(int));
+
+    using type = histogram_config<kernel_config<256, ::rocprim::max(8u / Channels / item_scale, 1u)>>;
+};
+
 template<unsigned int TargetArch, class Sample, unsigned int Channels, unsigned int ActiveChannels>
 struct default_histogram_config
     : select_arch<
         TargetArch,
         select_arch_case<803, histogram_config_803<Sample, Channels, ActiveChannels> >,
         select_arch_case<900, histogram_config_900<Sample, Channels, ActiveChannels> >,
+        select_arch_case<910, histogram_config_910<Sample, Channels, ActiveChannels> >,
+        select_arch_case<1031, histogram_config_1031<Sample, Channels, ActiveChannels> >,
         histogram_config_900<Sample, Channels, ActiveChannels>
     > { };
 

--- a/rocprim/include/rocprim/device/device_histogram_config.hpp
+++ b/rocprim/include/rocprim/device/device_histogram_config.hpp
@@ -91,7 +91,7 @@ struct histogram_config_900
 
 // TODO: We need to update these parameters
 template<class Sample, unsigned int Channels, unsigned int ActiveChannels>
-struct histogram_config_910
+struct histogram_config_90a
 {
     static constexpr unsigned int item_scale = ::rocprim::detail::ceiling_div(sizeof(Sample), sizeof(int));
 
@@ -100,7 +100,7 @@ struct histogram_config_910
 
 // TODO: We need to update these parameters
 template<class Sample, unsigned int Channels, unsigned int ActiveChannels>
-struct histogram_config_1031
+struct histogram_config_1030
 {
     static constexpr unsigned int item_scale = ::rocprim::detail::ceiling_div(sizeof(Sample), sizeof(int));
 
@@ -113,8 +113,8 @@ struct default_histogram_config
         TargetArch,
         select_arch_case<803, histogram_config_803<Sample, Channels, ActiveChannels> >,
         select_arch_case<900, histogram_config_900<Sample, Channels, ActiveChannels> >,
-        select_arch_case<910, histogram_config_910<Sample, Channels, ActiveChannels> >,
-        select_arch_case<1031, histogram_config_1031<Sample, Channels, ActiveChannels> >,
+        select_arch_case<ROCPRIM_ARCH_90a, histogram_config_90a<Sample, Channels, ActiveChannels> >,
+        select_arch_case<1030, histogram_config_1030<Sample, Channels, ActiveChannels> >,
         histogram_config_900<Sample, Channels, ActiveChannels>
     > { };
 

--- a/rocprim/include/rocprim/device/device_merge_config.hpp
+++ b/rocprim/include/rocprim/device/device_merge_config.hpp
@@ -88,12 +88,64 @@ struct merge_config_900<Key, empty_type>
     >;
 };
 
+// TODO: We need to update these parameters
+template<class Key, class Value>
+struct merge_config_910
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
+
+    // TODO Tune when merge-by-key is ready
+    using type = merge_config<256, ::rocprim::max(1u, 10u / item_scale)>;
+};
+
+template<class Key>
+struct merge_config_910<Key, empty_type>
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Key), sizeof(int));
+
+    using type = select_type<
+        select_type_case<sizeof(Key) <= 2, merge_config<256, 11> >,
+        select_type_case<sizeof(Key) <= 4, merge_config<256, 10> >,
+        select_type_case<sizeof(Key) <= 8, merge_config<256, 7> >,
+        merge_config<256, ::rocprim::max(1u, 10u / item_scale)>
+    >;
+};
+
+// TODO: We need to update these parameters
+template<class Key, class Value>
+struct merge_config_1031
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
+
+    // TODO Tune when merge-by-key is ready
+    using type = merge_config<256, ::rocprim::max(1u, 10u / item_scale)>;
+};
+
+template<class Key>
+struct merge_config_1031<Key, empty_type>
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Key), sizeof(int));
+
+    using type = select_type<
+        select_type_case<sizeof(Key) <= 2, merge_config<256, 11> >,
+        select_type_case<sizeof(Key) <= 4, merge_config<256, 10> >,
+        select_type_case<sizeof(Key) <= 8, merge_config<256, 7> >,
+        merge_config<256, ::rocprim::max(1u, 10u / item_scale)>
+    >;
+};
+
 template<unsigned int TargetArch, class Key, class Value>
 struct default_merge_config
     : select_arch<
         TargetArch,
         select_arch_case<803, merge_config_803<Key, Value>>,
         select_arch_case<900, merge_config_900<Key, Value>>,
+        select_arch_case<910, merge_config_910<Key, Value>>,
+        select_arch_case<1031, merge_config_1031<Key, Value>>,
         merge_config_900<Key, Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_merge_config.hpp
+++ b/rocprim/include/rocprim/device/device_merge_config.hpp
@@ -90,7 +90,7 @@ struct merge_config_900<Key, empty_type>
 
 // TODO: We need to update these parameters
 template<class Key, class Value>
-struct merge_config_910
+struct merge_config_90a
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
@@ -100,7 +100,7 @@ struct merge_config_910
 };
 
 template<class Key>
-struct merge_config_910<Key, empty_type>
+struct merge_config_90a<Key, empty_type>
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Key), sizeof(int));
@@ -115,7 +115,7 @@ struct merge_config_910<Key, empty_type>
 
 // TODO: We need to update these parameters
 template<class Key, class Value>
-struct merge_config_1031
+struct merge_config_1030
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
@@ -125,7 +125,7 @@ struct merge_config_1031
 };
 
 template<class Key>
-struct merge_config_1031<Key, empty_type>
+struct merge_config_1030<Key, empty_type>
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Key), sizeof(int));
@@ -144,8 +144,8 @@ struct default_merge_config
         TargetArch,
         select_arch_case<803, merge_config_803<Key, Value>>,
         select_arch_case<900, merge_config_900<Key, Value>>,
-        select_arch_case<910, merge_config_910<Key, Value>>,
-        select_arch_case<1031, merge_config_1031<Key, Value>>,
+        select_arch_case<ROCPRIM_ARCH_90a, merge_config_90a<Key, Value>>,
+        select_arch_case<1030, merge_config_1030<Key, Value>>,
         merge_config_900<Key, Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_merge_sort_config.hpp
+++ b/rocprim/include/rocprim/device/device_merge_sort_config.hpp
@@ -66,6 +66,20 @@ struct merge_sort_config_900<Key, empty_type>
     using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
+// TODO: We need to update these parameters
+template<class Key, class Value>
+struct merge_sort_config_910
+{
+    using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_64>::value>;
+};
+
+template<class Key>
+struct merge_sort_config_910<Key, empty_type>
+{
+    using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>;
+};
+
+// TODO: We need to update these parameters
 template<class Key, class Value>
 struct merge_sort_config_1031
 {
@@ -84,6 +98,7 @@ struct default_merge_sort_config
         TargetArch,
         select_arch_case<803, merge_sort_config_803<Key, Value>>,
         select_arch_case<900, merge_sort_config_900<Key, Value>>,
+        select_arch_case<910, merge_sort_config_910<Key, Value>>,
         select_arch_case<1031, merge_sort_config_1031<Key, Value>>,
         merge_sort_config_900<Key, Value>
     > { };

--- a/rocprim/include/rocprim/device/device_merge_sort_config.hpp
+++ b/rocprim/include/rocprim/device/device_merge_sort_config.hpp
@@ -68,26 +68,26 @@ struct merge_sort_config_900<Key, empty_type>
 
 // TODO: We need to update these parameters
 template<class Key, class Value>
-struct merge_sort_config_910
+struct merge_sort_config_90a
 {
     using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 template<class Key>
-struct merge_sort_config_910<Key, empty_type>
+struct merge_sort_config_90a<Key, empty_type>
 {
     using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 // TODO: We need to update these parameters
 template<class Key, class Value>
-struct merge_sort_config_1031
+struct merge_sort_config_1030
 {
     using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_32>::value>;
 };
 
 template<class Key>
-struct merge_sort_config_1031<Key, empty_type>
+struct merge_sort_config_1030<Key, empty_type>
 {
     using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_32>::value>;
 };
@@ -98,8 +98,8 @@ struct default_merge_sort_config
         TargetArch,
         select_arch_case<803, merge_sort_config_803<Key, Value>>,
         select_arch_case<900, merge_sort_config_900<Key, Value>>,
-        select_arch_case<910, merge_sort_config_910<Key, Value>>,
-        select_arch_case<1031, merge_sort_config_1031<Key, Value>>,
+        select_arch_case<ROCPRIM_ARCH_90a, merge_sort_config_90a<Key, Value>>,
+        select_arch_case<1030, merge_sort_config_1030<Key, Value>>,
         merge_sort_config_900<Key, Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_radix_sort_config.hpp
+++ b/rocprim/include/rocprim/device/device_radix_sort_config.hpp
@@ -157,7 +157,7 @@ struct radix_sort_config_900<Key, empty_type>
 
 // TODO: We need to update these parameters
 template<class Key, class Value>
-struct radix_sort_config_910
+struct radix_sort_config_90a
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
@@ -192,7 +192,7 @@ struct radix_sort_config_910
 };
 
 template<class Key>
-struct radix_sort_config_910<Key, empty_type>
+struct radix_sort_config_90a<Key, empty_type>
     : select_type<
         select_type_case<sizeof(Key) == 1, radix_sort_config<4, 3, kernel_config<256, 1>, kernel_config<256, 5> > >,
         select_type_case<sizeof(Key) == 2, radix_sort_config<6, 5, kernel_config<256, 1>, kernel_config<256, 5> > >,
@@ -202,7 +202,7 @@ struct radix_sort_config_910<Key, empty_type>
 
 // TODO: We need to update these parameters
 template<class Key, class Value>
-struct radix_sort_config_1031
+struct radix_sort_config_1030
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
@@ -237,7 +237,7 @@ struct radix_sort_config_1031
 };
 
 template<class Key>
-struct radix_sort_config_1031<Key, empty_type>
+struct radix_sort_config_1030<Key, empty_type>
     : select_type<
         select_type_case<sizeof(Key) == 1, radix_sort_config<4, 3, kernel_config<256, 2>, kernel_config<256, 10> > >,
         select_type_case<sizeof(Key) == 2, radix_sort_config<6, 5, kernel_config<256, 2>, kernel_config<256, 10> > >,
@@ -251,8 +251,8 @@ struct default_radix_sort_config
         TargetArch,
         select_arch_case<803, radix_sort_config_803<Key, Value> >,
         select_arch_case<900, radix_sort_config_900<Key, Value> >,
-        select_arch_case<910, radix_sort_config_900<Key, Value> >,
-        select_arch_case<1031, radix_sort_config_1031<Key, Value> >,
+        select_arch_case<ROCPRIM_ARCH_90a, radix_sort_config_90a<Key, Value> >,
+        select_arch_case<1030, radix_sort_config_1030<Key, Value> >,
         radix_sort_config_900<Key, Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_reduce_by_key_config.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_by_key_config.hpp
@@ -86,7 +86,25 @@ struct reduce_by_key_config_900
     >;
 };
 
-// TODO: Need to update
+// TODO: We need to update these parameters
+template<class Key, class Value>
+struct reduce_by_key_config_910
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Key) + sizeof(Value), 2 * sizeof(int));
+
+    using scan = kernel_config<256, 2>;
+
+    using type = select_type<
+        select_type_case<
+            (sizeof(Key) <= 8 && sizeof(Value) <= 8),
+            reduce_by_key_config<scan, kernel_config<256, 10> >
+        >,
+        reduce_by_key_config<scan, kernel_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_64>::value, ::rocprim::max(1u, 15u / item_scale)> >
+    >;
+};
+
+// TODO: We need to update these parameters
 template<class Key, class Value>
 struct reduce_by_key_config_1031
 {
@@ -110,6 +128,7 @@ struct default_reduce_by_key_config
         TargetArch,
         select_arch_case<803, reduce_by_key_config_803<Key, Value> >,
         select_arch_case<900, reduce_by_key_config_900<Key, Value> >,
+        select_arch_case<910, reduce_by_key_config_910<Key, Value> >,
         select_arch_case<1031, reduce_by_key_config_1031<Key, Value> >,
         reduce_by_key_config_900<Key, Value>
     > { };

--- a/rocprim/include/rocprim/device/device_reduce_by_key_config.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_by_key_config.hpp
@@ -88,7 +88,7 @@ struct reduce_by_key_config_900
 
 // TODO: We need to update these parameters
 template<class Key, class Value>
-struct reduce_by_key_config_910
+struct reduce_by_key_config_90a
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Key) + sizeof(Value), 2 * sizeof(int));
@@ -106,7 +106,7 @@ struct reduce_by_key_config_910
 
 // TODO: We need to update these parameters
 template<class Key, class Value>
-struct reduce_by_key_config_1031
+struct reduce_by_key_config_1030
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Key) + sizeof(Value), 2 * sizeof(int));
@@ -128,8 +128,8 @@ struct default_reduce_by_key_config
         TargetArch,
         select_arch_case<803, reduce_by_key_config_803<Key, Value> >,
         select_arch_case<900, reduce_by_key_config_900<Key, Value> >,
-        select_arch_case<910, reduce_by_key_config_910<Key, Value> >,
-        select_arch_case<1031, reduce_by_key_config_1031<Key, Value> >,
+        select_arch_case<ROCPRIM_ARCH_90a, reduce_by_key_config_90a<Key, Value> >,
+        select_arch_case<1030, reduce_by_key_config_1030<Key, Value> >,
         reduce_by_key_config_900<Key, Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_reduce_config.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_config.hpp
@@ -84,6 +84,21 @@ struct reduce_config_900
     >;
 };
 
+// TODO: We need to update these parameters
+template<class Value>
+struct reduce_config_910
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
+
+    using type = reduce_config<
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
+        ::rocprim::max(1u, 16u / item_scale),
+        ::rocprim::block_reduce_algorithm::using_warp_reduce
+    >;
+};
+
+// TODO: We need to update these parameters
 template<class Value>
 struct reduce_config_1031
 {
@@ -103,6 +118,7 @@ struct default_reduce_config
         TargetArch,
         select_arch_case<803, reduce_config_803<Value>>,
         select_arch_case<900, reduce_config_900<Value>>,
+        select_arch_case<910, reduce_config_910<Value>>,
         select_arch_case<1031, reduce_config_1031<Value>>,
         reduce_config_900<Value>
     > { };

--- a/rocprim/include/rocprim/device/device_reduce_config.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_config.hpp
@@ -86,7 +86,7 @@ struct reduce_config_900
 
 // TODO: We need to update these parameters
 template<class Value>
-struct reduce_config_910
+struct reduce_config_90a
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
@@ -100,7 +100,7 @@ struct reduce_config_910
 
 // TODO: We need to update these parameters
 template<class Value>
-struct reduce_config_1031
+struct reduce_config_1030
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
@@ -118,8 +118,8 @@ struct default_reduce_config
         TargetArch,
         select_arch_case<803, reduce_config_803<Value>>,
         select_arch_case<900, reduce_config_900<Value>>,
-        select_arch_case<910, reduce_config_910<Value>>,
-        select_arch_case<1031, reduce_config_1031<Value>>,
+        select_arch_case<ROCPRIM_ARCH_90a, reduce_config_90a<Value>>,
+        select_arch_case<1030, reduce_config_1030<Value>>,
         reduce_config_900<Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_scan_config.hpp
+++ b/rocprim/include/rocprim/device/device_scan_config.hpp
@@ -106,7 +106,7 @@ struct scan_config_900
 
 // TODO: We need to update these parameters
 template<class Value>
-struct scan_config_910
+struct scan_config_90a
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
@@ -123,7 +123,7 @@ struct scan_config_910
 
 // TODO: We need to update these parameters
 template<class Value>
-struct scan_config_1031
+struct scan_config_1030
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
@@ -144,8 +144,8 @@ struct default_scan_config
         TargetArch,
         select_arch_case<803, scan_config_803<Value>>,
         select_arch_case<900, scan_config_900<Value>>,
-        select_arch_case<910, scan_config_910<Value>>,
-        select_arch_case<1031, scan_config_1031<Value>>,
+        select_arch_case<ROCPRIM_ARCH_90a, scan_config_90a<Value>>,
+        select_arch_case<1030, scan_config_1030<Value>>,
         scan_config_900<Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_scan_config.hpp
+++ b/rocprim/include/rocprim/device/device_scan_config.hpp
@@ -104,6 +104,24 @@ struct scan_config_900
     >;
 };
 
+// TODO: We need to update these parameters
+template<class Value>
+struct scan_config_910
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
+
+    using type = scan_config<
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
+        ::rocprim::max(1u, 16u / item_scale),
+        ROCPRIM_DETAIL_USE_LOOKBACK_SCAN,
+        ::rocprim::block_load_method::block_load_transpose,
+        ::rocprim::block_store_method::block_store_transpose,
+        ::rocprim::block_scan_algorithm::using_warp_scan
+    >;
+};
+
+// TODO: We need to update these parameters
 template<class Value>
 struct scan_config_1031
 {
@@ -126,6 +144,7 @@ struct default_scan_config
         TargetArch,
         select_arch_case<803, scan_config_803<Value>>,
         select_arch_case<900, scan_config_900<Value>>,
+        select_arch_case<910, scan_config_910<Value>>,
         select_arch_case<1031, scan_config_1031<Value>>,
         scan_config_900<Value>
     > { };

--- a/rocprim/include/rocprim/device/device_segmented_radix_sort_config.hpp
+++ b/rocprim/include/rocprim/device/device_segmented_radix_sort_config.hpp
@@ -135,12 +135,86 @@ struct segmented_radix_sort_config_900<Key, empty_type>
         select_type_case<sizeof(Key) == 8, segmented_radix_sort_config<7, 6, kernel_config<256, 15> > >
     > { };
 
+template<class Key, class Value>
+struct segmented_radix_sort_config_910
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
+
+    using type = select_type<
+        select_type_case<
+            (sizeof(Key) == 1 && sizeof(Value) <= 8),
+            segmented_radix_sort_config<4, 4, kernel_config<256, 10> >
+        >,
+        select_type_case<
+            (sizeof(Key) == 2 && sizeof(Value) <= 8),
+            segmented_radix_sort_config<6, 5, kernel_config<256, 10> >
+        >,
+        select_type_case<
+            (sizeof(Key) == 4 && sizeof(Value) <= 8),
+            segmented_radix_sort_config<7, 6, kernel_config<256, 15> >
+        >,
+        select_type_case<
+            (sizeof(Key) == 8 && sizeof(Value) <= 8),
+            segmented_radix_sort_config<7, 6, kernel_config<256, 15> >
+        >,
+        segmented_radix_sort_config<7, 6, kernel_config<256, ::rocprim::max(1u, 15u / item_scale)> >
+    >;
+};
+
+template<class Key>
+struct segmented_radix_sort_config_910<Key, empty_type>
+    : select_type<
+        select_type_case<sizeof(Key) == 1, segmented_radix_sort_config<4, 3, kernel_config<256, 10> > >,
+        select_type_case<sizeof(Key) == 2, segmented_radix_sort_config<6, 5, kernel_config<256, 10> > >,
+        select_type_case<sizeof(Key) == 4, segmented_radix_sort_config<7, 6, kernel_config<256, 17> > >,
+        select_type_case<sizeof(Key) == 8, segmented_radix_sort_config<7, 6, kernel_config<256, 15> > >
+    > { };
+
+template<class Key, class Value>
+struct segmented_radix_sort_config_1031
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
+
+    using type = select_type<
+        select_type_case<
+            (sizeof(Key) == 1 && sizeof(Value) <= 8),
+            segmented_radix_sort_config<4, 4, kernel_config<256, 10> >
+        >,
+        select_type_case<
+            (sizeof(Key) == 2 && sizeof(Value) <= 8),
+            segmented_radix_sort_config<6, 5, kernel_config<256, 10> >
+        >,
+        select_type_case<
+            (sizeof(Key) == 4 && sizeof(Value) <= 8),
+            segmented_radix_sort_config<7, 6, kernel_config<256, 15> >
+        >,
+        select_type_case<
+            (sizeof(Key) == 8 && sizeof(Value) <= 8),
+            segmented_radix_sort_config<7, 6, kernel_config<256, 15> >
+        >,
+        segmented_radix_sort_config<7, 6, kernel_config<256, ::rocprim::max(1u, 15u / item_scale)> >
+    >;
+};
+
+template<class Key>
+struct segmented_radix_sort_config_1031<Key, empty_type>
+    : select_type<
+        select_type_case<sizeof(Key) == 1, segmented_radix_sort_config<4, 3, kernel_config<256, 10> > >,
+        select_type_case<sizeof(Key) == 2, segmented_radix_sort_config<6, 5, kernel_config<256, 10> > >,
+        select_type_case<sizeof(Key) == 4, segmented_radix_sort_config<7, 6, kernel_config<256, 17> > >,
+        select_type_case<sizeof(Key) == 8, segmented_radix_sort_config<7, 6, kernel_config<256, 15> > >
+    > { };
+
 template<unsigned int TargetArch, class Key, class Value>
 struct default_segmented_radix_sort_config
     : select_arch<
         TargetArch,
         select_arch_case<803, detail::segmented_radix_sort_config_803<Key, Value> >,
         select_arch_case<900, detail::segmented_radix_sort_config_900<Key, Value> >,
+        select_arch_case<910, detail::segmented_radix_sort_config_900<Key, Value> >,
+        select_arch_case<1031, detail::segmented_radix_sort_config_900<Key, Value> >,
         detail::segmented_radix_sort_config_900<Key, Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_segmented_radix_sort_config.hpp
+++ b/rocprim/include/rocprim/device/device_segmented_radix_sort_config.hpp
@@ -136,7 +136,7 @@ struct segmented_radix_sort_config_900<Key, empty_type>
     > { };
 
 template<class Key, class Value>
-struct segmented_radix_sort_config_910
+struct segmented_radix_sort_config_90a
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
@@ -163,7 +163,7 @@ struct segmented_radix_sort_config_910
 };
 
 template<class Key>
-struct segmented_radix_sort_config_910<Key, empty_type>
+struct segmented_radix_sort_config_90a<Key, empty_type>
     : select_type<
         select_type_case<sizeof(Key) == 1, segmented_radix_sort_config<4, 3, kernel_config<256, 10> > >,
         select_type_case<sizeof(Key) == 2, segmented_radix_sort_config<6, 5, kernel_config<256, 10> > >,
@@ -172,7 +172,7 @@ struct segmented_radix_sort_config_910<Key, empty_type>
     > { };
 
 template<class Key, class Value>
-struct segmented_radix_sort_config_1031
+struct segmented_radix_sort_config_1030
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(::rocprim::max(sizeof(Key), sizeof(Value)), sizeof(int));
@@ -199,7 +199,7 @@ struct segmented_radix_sort_config_1031
 };
 
 template<class Key>
-struct segmented_radix_sort_config_1031<Key, empty_type>
+struct segmented_radix_sort_config_1030<Key, empty_type>
     : select_type<
         select_type_case<sizeof(Key) == 1, segmented_radix_sort_config<4, 3, kernel_config<256, 10> > >,
         select_type_case<sizeof(Key) == 2, segmented_radix_sort_config<6, 5, kernel_config<256, 10> > >,
@@ -213,8 +213,8 @@ struct default_segmented_radix_sort_config
         TargetArch,
         select_arch_case<803, detail::segmented_radix_sort_config_803<Key, Value> >,
         select_arch_case<900, detail::segmented_radix_sort_config_900<Key, Value> >,
-        select_arch_case<910, detail::segmented_radix_sort_config_900<Key, Value> >,
-        select_arch_case<1031, detail::segmented_radix_sort_config_900<Key, Value> >,
+        select_arch_case<ROCPRIM_ARCH_90a, detail::segmented_radix_sort_config_90a<Key, Value> >,
+        select_arch_case<1030, detail::segmented_radix_sort_config_900<Key, Value> >,
         detail::segmented_radix_sort_config_900<Key, Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_select_config.hpp
+++ b/rocprim/include/rocprim/device/device_select_config.hpp
@@ -98,6 +98,21 @@ struct select_config_900
 };
 
 template<class Value>
+struct select_config_910
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
+
+    using type = select_config<
+        limit_block_size<256U, sizeof(Value), ROCPRIM_WARP_SIZE_64>::value,
+        ::rocprim::max(1u, 15u / item_scale),
+        ::rocprim::block_load_method::block_load_transpose,
+        ::rocprim::block_load_method::block_load_transpose,
+        ::rocprim::block_scan_algorithm::using_warp_scan
+    >;
+};
+
+template<class Value>
 struct select_config_1031
 {
     static constexpr unsigned int item_scale =
@@ -119,6 +134,7 @@ struct default_select_config
         TargetArch,
         select_arch_case<803, select_config_803<Value>>,
         select_arch_case<900, select_config_900<Value>>,
+        select_arch_case<910, select_config_900<Value>>,
         select_arch_case<1031, select_config_1031<Value>>,
         select_config_803<Value>
     > { };

--- a/rocprim/include/rocprim/device/device_select_config.hpp
+++ b/rocprim/include/rocprim/device/device_select_config.hpp
@@ -98,7 +98,7 @@ struct select_config_900
 };
 
 template<class Value>
-struct select_config_910
+struct select_config_90a
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
@@ -113,7 +113,7 @@ struct select_config_910
 };
 
 template<class Value>
-struct select_config_1031
+struct select_config_1030
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
@@ -134,8 +134,8 @@ struct default_select_config
         TargetArch,
         select_arch_case<803, select_config_803<Value>>,
         select_arch_case<900, select_config_900<Value>>,
-        select_arch_case<910, select_config_900<Value>>,
-        select_arch_case<1031, select_config_1031<Value>>,
+        select_arch_case<ROCPRIM_ARCH_90a, select_config_90a<Value>>,
+        select_arch_case<1030, select_config_1030<Value>>,
         select_config_803<Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_transform_config.hpp
+++ b/rocprim/include/rocprim/device/device_transform_config.hpp
@@ -59,12 +59,32 @@ struct transform_config_900
     using type = transform_config<256, ::rocprim::max(1u, 16u / item_scale)>;
 };
 
+template<class Value>
+struct transform_config_910
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
+
+    using type = transform_config<256, ::rocprim::max(1u, 16u / item_scale)>;
+};
+
+template<class Value>
+struct transform_config_1031
+{
+    static constexpr unsigned int item_scale =
+        ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
+
+    using type = transform_config<256, ::rocprim::max(1u, 16u / item_scale)>;
+};
+
 template<unsigned int TargetArch, class Value>
 struct default_transform_config
     : select_arch<
         TargetArch,
         select_arch_case<803, transform_config_803<Value>>,
         select_arch_case<900, transform_config_900<Value>>,
+        select_arch_case<910, transform_config_910<Value>>,
+        select_arch_case<1031, transform_config_1031<Value>>,
         transform_config_900<Value>
     > { };
 

--- a/rocprim/include/rocprim/device/device_transform_config.hpp
+++ b/rocprim/include/rocprim/device/device_transform_config.hpp
@@ -60,7 +60,7 @@ struct transform_config_900
 };
 
 template<class Value>
-struct transform_config_910
+struct transform_config_90a
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
@@ -69,7 +69,7 @@ struct transform_config_910
 };
 
 template<class Value>
-struct transform_config_1031
+struct transform_config_1030
 {
     static constexpr unsigned int item_scale =
         ::rocprim::detail::ceiling_div<unsigned int>(sizeof(Value), sizeof(int));
@@ -83,8 +83,8 @@ struct default_transform_config
         TargetArch,
         select_arch_case<803, transform_config_803<Value>>,
         select_arch_case<900, transform_config_900<Value>>,
-        select_arch_case<910, transform_config_910<Value>>,
-        select_arch_case<1031, transform_config_1031<Value>>,
+        select_arch_case<ROCPRIM_ARCH_90a, transform_config_90a<Value>>,
+        select_arch_case<1030, transform_config_1030<Value>>,
         transform_config_900<Value>
     > { };
 


### PR DESCRIPTION
- Update config parameter and enable ROCPRIM_DETAIL_USE_DPP for gfx90a
- Replace 1031 target with 1030
- Add gitlab ci extend with benchmarks
