### PR TITLE
Coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,12 @@ option(BUILD_BENCHMARK "Build benchmarks" OFF)
 option(BUILD_EXAMPLE "Build examples" OFF)
 # Disables building tests, benchmarks, examples
 option(ONLY_INSTALL "Only install" OFF)
+option(BUILD_CODE_COVERAGE "Build with code coverage enabled" OFF)
+
+if(BUILD_CODE_COVERAGE)
+  add_compile_options(-g -fprofile-arcs -ftest-coverage)
+  add_link_options(-g --coverage)
+endif()
 
 # Set CXX flags
 set(CMAKE_CXX_STANDARD 14)
@@ -140,3 +146,46 @@ rocm_create_package(
   DESCRIPTION "Radeon Open Compute Parallel Primitives Library"
   MAINTAINER "rocPRIM Maintainer <rocprim-maintainer@amd.com>"
 )
+
+
+#
+# ADDITIONAL TARGETS FOR CODE COVERAGE
+#
+if(BUILD_CODE_COVERAGE)
+  #
+  # > make coverage_cleanup (clean coverage related files.)
+  # > # run your tests
+  #  > make coverage (generate html documentation)
+  #
+
+  #
+  # Prepare coverage output
+  # This little script is generated because the option '--gcov-tool <program name>' of lcov cannot take arguments.
+  #
+  add_custom_target(coverage
+    COMMAND mkdir -p lcoverage
+    COMMAND echo "\\#!/bin/bash" > llvm-gcov.sh
+    COMMAND echo "\\# THIS FILE HAS BEEN GENERATED" >> llvm-gcov.sh
+    COMMAND printf "exec /opt/rocm/llvm/bin/llvm-cov gcov $$\\@" >> llvm-gcov.sh
+    COMMAND chmod +x llvm-gcov.sh
+    )
+
+  #
+  # Generate coverage output.
+  #
+  add_custom_command(TARGET coverage
+    DEPENDS rocprim
+    COMMAND lcov --directory . --base-directory . --gcov-tool ${CMAKE_BINARY_DIR}/llvm-gcov.sh --capture -o lcoverage/raw_main_coverage.info
+    COMMAND lcov --remove lcoverage/raw_main_coverage.info "'/opt/*'" "'/usr/*'" -o lcoverage/main_coverage.info
+    COMMAND genhtml lcoverage/main_coverage.info --output-directory lcoverage
+    )
+
+  #
+  # Coverage cleanup
+  #
+  add_custom_target(coverage_cleanup
+    COMMAND find ${CMAKE_BINARY_DIR} -name *.gcda -delete
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ if(BUILD_CODE_COVERAGE)
   # This little script is generated because the option '--gcov-tool <program name>' of lcov cannot take arguments.
   #
   add_custom_target(coverage
+    DEPENDS rocprim
     COMMAND mkdir -p lcoverage
     COMMAND echo "\\#!/bin/bash" > llvm-gcov.sh
     COMMAND echo "\\# THIS FILE HAS BEEN GENERATED" >> llvm-gcov.sh
@@ -174,7 +175,6 @@ if(BUILD_CODE_COVERAGE)
   # Generate coverage output.
   #
   add_custom_command(TARGET coverage
-    DEPENDS rocprim
     COMMAND lcov --directory . --base-directory . --gcov-tool ${CMAKE_BINARY_DIR}/llvm-gcov.sh --capture -o lcoverage/raw_main_coverage.info
     COMMAND lcov --remove lcoverage/raw_main_coverage.info "'/opt/*'" "'/usr/*'" -o lcoverage/main_coverage.info
     COMMAND genhtml lcoverage/main_coverage.info --output-directory lcoverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,8 @@ option(ONLY_INSTALL "Only install" OFF)
 option(BUILD_CODE_COVERAGE "Build with code coverage enabled" OFF)
 
 if(BUILD_CODE_COVERAGE)
-  add_compile_options(-g -fprofile-arcs -ftest-coverage)
-  add_link_options(-g --coverage)
+  add_compile_options(-fprofile-arcs -ftest-coverage)
+  add_link_options(--coverage)
 endif()
 
 # Set CXX flags

--- a/install
+++ b/install
@@ -156,7 +156,7 @@ fi
 codecoverage="OFF"
 if [[ "${build_codecoverage}" == true ]]; then
     if [[ "${build_release}" == true ]]; then
-        echo "Code coverage is chosen to be disabled in Release mode, to enable code coverage select either Debug mode (-g | --debug) or RelWithDebInfo mode (-k | --relwithdebinfo); aborting";
+        echo "Code coverage is disabled in Release mode, to enable code coverage select either Debug mode (-g | --debug) or RelWithDebInfo mode (-k | --relwithdebinfo); aborting";
         exit 1
     fi
     codecoverage="ON"

--- a/install
+++ b/install
@@ -16,7 +16,9 @@ function display_help()
     #    echo "    [-d|--dependencies] install build dependencies"
     echo "    [-c|--clients] build library clients too (combines with -i & -d)"
     echo "    [-g|--debug] -DCMAKE_BUILD_TYPE=Debug (default is =Release)"
+    echo "    [-k|--relwithdebinfo] -DCMAKE_BUILD_TYPE=RelWithDebInfo"
     echo "    [-b|--benchmark] builds and runs benchmark"
+    echo "    [--coverage] build with code coverage profiling enabled"
     echo "    [--hip-clang] build library for amdgpu backend using hip-clang"
 }
 
@@ -28,6 +30,8 @@ install_package=false
 build_package=false
 build_clients=false
 build_release=true
+build_release_debug=false
+build_coverage=false
 build_type=Release
 build_hip_clang=false
 run_tests=false
@@ -42,7 +46,7 @@ build_relocatable=false
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,debug,hip-clang,test,benchmark,package,relocatable --options hicdtbpgr -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,debug,hip-clang,test,benchmark,package,relocatable,relwithdebinfo,coverage --options hicdtbpgrk -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -91,6 +95,14 @@ while true; do
         -b|--benchmark)
             build_benchmark=true
             shift ;;
+        --coverage)
+            build_coverage=true
+            shift ;;
+        -k|--relwithdebinfo)
+	    build_release=false
+	    build_release_debug=true
+            build_type=RelWithDebInfo
+            shift ;;
         --hip-clang)
             build_hip_clang=true
             shift ;;
@@ -109,9 +121,10 @@ fi
 
 # Go to rocPRIM directory, create and go to the build directory.
 mkdir -p build; cd build
-
-if ($build_release); then
+if [[ "${build_release}" == true ]]; then
     mkdir -p release; cd release
+elif [[ "${build_release_debug}" == true ]]; then
+    mkdir -p release-debug; cd release-debug
 else
     mkdir -p debug; cd debug
 fi
@@ -140,6 +153,11 @@ if [[ "${build_clients}" == true ]]; then
     clients="ON"
 fi
 
+coverage="OFF"
+if [[ "${build_coverage}" == true ]]; then
+    coverage="ON"
+fi
+
 
 if [[ "${build_relocatable}" == true ]]; then
     CXX=${rocm_path}/bin/${compiler} ${cmake_executable} -DCMAKE_INSTALL_PREFIX=${rocm_path} -DBUILD_BENCHMARK=${benchmark} \
@@ -147,7 +165,7 @@ if [[ "${build_relocatable}" == true ]]; then
        -DBUILD_BENCHMARK=${benchmark} -DBUILD_TEST=${clients} \
        -DCMAKE_MODULE_PATH="${rocm_path}/hip/cmake" ../../.     # or cmake-gui ../.
 else
-    CXX=${rocm_path}/bin/${compiler} ${cmake_executable} -DBUILD_BENCHMARK=${benchmark} -DBUILD_TEST=${clients} -DCMAKE_BUILD_TYPE=${build_type} ../../. # or cmake-gui ../.
+    CXX=${rocm_path}/bin/${compiler} ${cmake_executable} -DBUILD_BENCHMARK=${benchmark} -DBUILD_TEST=${clients} -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_CODE_COVERAGE=${coverage}  ../../. # or cmake-gui ../.
 fi
 
 # Build

--- a/install
+++ b/install
@@ -18,7 +18,7 @@ function display_help()
     echo "    [-g|--debug] -DCMAKE_BUILD_TYPE=Debug (default is =Release)"
     echo "    [-k|--relwithdebinfo] -DCMAKE_BUILD_TYPE=RelWithDebInfo"
     echo "    [-b|--benchmark] builds and runs benchmark"
-    echo "    [--coverage] build with code coverage profiling enabled"
+    echo "    [--codecoverage] build with code coverage profiling enabled"
     echo "    [--hip-clang] build library for amdgpu backend using hip-clang"
 }
 
@@ -31,7 +31,7 @@ build_package=false
 build_clients=false
 build_release=true
 build_release_debug=false
-build_coverage=false
+build_codecoverage=false
 build_type=Release
 build_hip_clang=false
 run_tests=false
@@ -46,7 +46,7 @@ build_relocatable=false
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,debug,hip-clang,test,benchmark,package,relocatable,relwithdebinfo,coverage --options hicdtbpgrk -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,debug,hip-clang,test,benchmark,package,relocatable,relwithdebinfo,codecoverage --options hicdtbpgrk -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -95,8 +95,8 @@ while true; do
         -b|--benchmark)
             build_benchmark=true
             shift ;;
-        --coverage)
-            build_coverage=true
+        --codecoverage)
+            build_codecoverage=true
             shift ;;
         -k|--relwithdebinfo)
 	    build_release=false
@@ -153,13 +153,13 @@ if [[ "${build_clients}" == true ]]; then
     clients="ON"
 fi
 
-coverage="OFF"
-if [[ "${build_coverage}" == true ]]; then
+codecoverage="OFF"
+if [[ "${build_codecoverage}" == true ]]; then
     if [[ "${build_release}" == true ]]; then
         echo "Code coverage is chosen to be disabled in Release mode, to enable code coverage select either Debug mode (-g | --debug) or RelWithDebInfo mode (-k | --relwithdebinfo); aborting";
         exit 1
     fi
-    coverage="ON"
+    codecoverage="ON"
 fi
 
 
@@ -169,7 +169,7 @@ if [[ "${build_relocatable}" == true ]]; then
        -DBUILD_BENCHMARK=${benchmark} -DBUILD_TEST=${clients} \
        -DCMAKE_MODULE_PATH="${rocm_path}/hip/cmake" ../../.     # or cmake-gui ../.
 else
-    CXX=${rocm_path}/bin/${compiler} ${cmake_executable} -DBUILD_BENCHMARK=${benchmark} -DBUILD_TEST=${clients} -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_CODE_COVERAGE=${coverage}  ../../. # or cmake-gui ../.
+    CXX=${rocm_path}/bin/${compiler} ${cmake_executable} -DBUILD_BENCHMARK=${benchmark} -DBUILD_TEST=${clients} -DCMAKE_BUILD_TYPE=${build_type} -DBUILD_CODE_COVERAGE=${codecoverage}  ../../. # or cmake-gui ../.
 fi
 
 # Build

--- a/install
+++ b/install
@@ -155,6 +155,10 @@ fi
 
 coverage="OFF"
 if [[ "${build_coverage}" == true ]]; then
+    if [[ "${build_release}" == true ]]; then
+        echo "Code coverage is chosen to be disabled in Release mode, to enable code coverage select either Debug mode (-g | --debug) or RelWithDebInfo mode (-k | --relwithdebinfo); aborting";
+        exit 1
+    fi
     coverage="ON"
 fi
 


### PR DESCRIPTION
using code coverage tools.

'--codecoverage' option in install, cannot be enabled in release mode.

I added an option for release debug mode '-k | --relwithdebInfo'

example:
./install -kc --codecoverage
or
./install -gc --codecoverage

once compilation is done

# go to the build directory
cd build/release-debug

# run you tests

# Generate html output
make coverage
it takes longer than the normal mode to run the tests.

when finished, open index.html in the lcoverage/ directory.