### PR TITLE
Fixing cmake dependency include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ endif()
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker search and installed rpath")
 
 if(NOT USE_HIP_CPU)
+  # Get dependencies (required here to get rocm-cmake)
+  include(cmake/Dependencies.cmake)
   # Set the AMDGPU_TARGETS with backward compatiblity
   # Use target ID syntax if supported for AMDGPU_TARGETS
   if(COMMAND rocm_check_target_ids)
@@ -105,8 +107,10 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Get dependencies
-include(cmake/Dependencies.cmake)
+if(USE_HIP_CPU)
+  # Get dependencies
+  include(cmake/Dependencies.cmake)
+endif()
 
 # Setup VERSION
 set(VERSION_STRING "2.10.9")


### PR DESCRIPTION
 include(cmake/Dependencies.cmake) got moved around for the hip-cpu support, causing rocm_check_target_ids to fail.  Manually adding it back in to the appropriate spot when not building for hip-cpu mode so that gfx90a target is built.