### PR TITLE
Merge sort improvement at bigger value sizes

### DIFF
--- a/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
@@ -221,12 +221,11 @@ private:
     void warp_swap(Key& k, Value& v, int mask, bool dir, BinaryFunction compare_function)
     {
         Key k1    = warp_shuffle_xor(k, mask);
-        Value v1  = warp_shuffle_xor(v, mask);
         bool swap = compare_function(dir ? k : k1, dir ? k1 : k);
         if (swap)
         {
             k = k1;
-            v = v1;
+            v = warp_shuffle_xor(v, mask);
         }
     }
 

--- a/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
@@ -216,6 +216,32 @@ private:
         wsort.sort(kv..., compare_function);
     }
 
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE inline
+    void warp_swap(Key& k, Value& v, int mask, bool dir, BinaryFunction compare_function)
+    {
+        Key k1    = warp_shuffle_xor(k, mask);
+        Value v1  = warp_shuffle_xor(v, mask);
+        bool swap = compare_function(dir ? k : k1, dir ? k1 : k);
+        if (swap)
+        {
+            k = k1;
+            v = v1;
+        }
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE inline
+    void warp_swap(Key& k, int mask, bool dir, BinaryFunction compare_function)
+    {
+        Key k1    = warp_shuffle_xor(k, mask);
+        bool swap = compare_function(dir ? k : k1, dir ? k1 : k);
+        if (swap)
+        {
+            k = k1;
+        }
+    }
+
     template<
         unsigned int Size,
         class BinaryFunction,
@@ -243,13 +269,21 @@ private:
         ROCPRIM_UNROLL
         for(unsigned int length = ::rocprim::device_warp_size(); length < Size; length *= 2)
         {
-            bool dir = (flat_tid & (length * 2)) != 0;
+            const bool dir = (flat_tid & (length * 2)) != 0;
             ROCPRIM_UNROLL
-            for(unsigned int k = length; k > 0; k /= 2)
+            for(unsigned int k = length; k > ::rocprim::device_warp_size() / 2; k /= 2)
             {
                 copy_to_shared(kv..., flat_tid, storage);
                 swap(kv..., flat_tid, flat_tid ^ k, dir, storage, compare_function);
                 ::rocprim::syncthreads();
+            }
+
+            ROCPRIM_UNROLL
+            for(unsigned int k = ::rocprim::device_warp_size() / 2; k > 0;  k /= 2)
+            {
+                const bool length_even = ((detail::logical_lane_id<::rocprim::device_warp_size()>() / k ) % 2 ) == 0;
+                const bool local_dir = length_even ? dir : !dir;
+                warp_swap(kv..., k, local_dir, compare_function);
             }
         }
     }

--- a/rocprim/include/rocprim/device/detail/device_merge_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge_sort.hpp
@@ -346,6 +346,7 @@ void block_sort_kernel_impl(KeysInputIterator keys_input,
 }
 
 template<
+    unsigned int BlockSize,
     class KeysInputIterator,
     class KeysOutputIterator,
     class ValuesInputIterator,
@@ -367,8 +368,7 @@ void block_merge_kernel_impl(KeysInputIterator keys_input,
 
     const unsigned int flat_id = ::rocprim::detail::block_thread_id<0>();
     const unsigned int flat_block_id = ::rocprim::detail::block_id<0>();
-    const unsigned int flat_block_size = ::rocprim::detail::block_size<0>();
-    unsigned int id = (flat_block_id * flat_block_size) + flat_id;
+    unsigned int id = (flat_block_id * BlockSize) + flat_id;
 
     if (id >= input_size)
     {

--- a/rocprim/include/rocprim/device/device_merge_sort_config.hpp
+++ b/rocprim/include/rocprim/device/device_merge_sort_config.hpp
@@ -45,51 +45,184 @@ namespace detail
 template<class Key, class Value>
 struct merge_sort_config_803
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_64>::value>;
+    using type = select_type<
+        select_type_case<
+            (sizeof(Key) == 1 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<64U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 2 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 4 && sizeof(Value) <= 8 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<512U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 8 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<1024U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        merge_sort_config<limit_block_size<1024U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+    >;
+};
+
+template<>
+struct merge_sort_config_803<rocprim::half, rocprim::half>
+{
+    using type = merge_sort_config<limit_block_size<256U, sizeof(rocprim::half), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 template<class Key>
 struct merge_sort_config_803<Key, empty_type>
+    : select_type<
+        select_type_case<sizeof(Key) == 1, merge_sort_config<limit_block_size<64U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 2, merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 4, merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 8, merge_sort_config<limit_block_size<512U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >
+    > { };
+
+template<>
+struct merge_sort_config_803<rocprim::half, empty_type>
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>;
+    using type = merge_sort_config<limit_block_size<256U, sizeof(rocprim::half), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 template<class Key, class Value>
 struct merge_sort_config_900
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_64>::value>;
+    using type = select_type<
+        select_type_case<
+            (sizeof(Key) == 1 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<64U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 2 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 4 && sizeof(Value) <= 8 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<512U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 8 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<1024U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        merge_sort_config<limit_block_size<1024U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+    >;
+};
+
+template<>
+struct merge_sort_config_900<rocprim::half, rocprim::half>
+{
+    using type = merge_sort_config<limit_block_size<256U, sizeof(rocprim::half), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 template<class Key>
 struct merge_sort_config_900<Key, empty_type>
+    : select_type<
+        select_type_case<sizeof(Key) == 1, merge_sort_config<limit_block_size<64U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 2, merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 4, merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 8, merge_sort_config<limit_block_size<512U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >
+    > { };
+
+template<>
+struct merge_sort_config_900<rocprim::half, empty_type>
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>;
+    using type = merge_sort_config<limit_block_size<256U, sizeof(rocprim::half), ROCPRIM_WARP_SIZE_64>::value>;
 };
+
 
 // TODO: We need to update these parameters
 template<class Key, class Value>
 struct merge_sort_config_90a
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_64>::value>;
+    using type = select_type<
+        select_type_case<
+            (sizeof(Key) == 1 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<64U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 2 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 4 && sizeof(Value) <= 8 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<512U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 8 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<1024U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        merge_sort_config<limit_block_size<1024U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+    >;
+};
+
+template<>
+struct merge_sort_config_90a<rocprim::half, rocprim::half>
+{
+    using type = merge_sort_config<limit_block_size<256U, sizeof(rocprim::half), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 template<class Key>
 struct merge_sort_config_90a<Key, empty_type>
+    : select_type<
+        select_type_case<sizeof(Key) == 1, merge_sort_config<limit_block_size<64U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 2, merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 4, merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 8, merge_sort_config<limit_block_size<512U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >
+    > { };
+
+template<>
+struct merge_sort_config_90a<rocprim::half, empty_type>
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>;
+    using type = merge_sort_config<limit_block_size<256U, sizeof(rocprim::half), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 // TODO: We need to update these parameters
 template<class Key, class Value>
 struct merge_sort_config_1030
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key) + sizeof(Value), ROCPRIM_WARP_SIZE_32>::value>;
+    using type = select_type<
+        select_type_case<
+            (sizeof(Key) == 1 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<64U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 2 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 4 && sizeof(Value) <= 8 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<512U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        select_type_case<
+            (sizeof(Key) == 8 && sizeof(Value) <= 8),
+            merge_sort_config<limit_block_size<1024U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+        >,
+        merge_sort_config<limit_block_size<1024U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value>
+    >;
+};
+
+template<>
+struct merge_sort_config_1030<rocprim::half, rocprim::half>
+{
+    using type = merge_sort_config<limit_block_size<256U, sizeof(rocprim::half), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 template<class Key>
 struct merge_sort_config_1030<Key, empty_type>
+    : select_type<
+        select_type_case<sizeof(Key) == 1, merge_sort_config<limit_block_size<64U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 2, merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 4, merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >,
+        select_type_case<sizeof(Key) == 8, merge_sort_config<limit_block_size<512U, sizeof(Key), ROCPRIM_WARP_SIZE_64>::value> >
+    > { };
+
+template<>
+struct merge_sort_config_1030<rocprim::half, empty_type>
 {
-    using type = merge_sort_config<limit_block_size<256U, sizeof(Key), ROCPRIM_WARP_SIZE_32>::value>;
+    using type = merge_sort_config<limit_block_size<256U, sizeof(rocprim::half), ROCPRIM_WARP_SIZE_64>::value>;
 };
 
 template<unsigned int TargetArch, class Key, class Value>

--- a/rocprim/include/rocprim/warp/detail/warp_sort_shuffle.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_sort_shuffle.hpp
@@ -60,12 +60,12 @@ private:
     swap(Key& k, V& v, int mask, bool dir, BinaryFunction compare_function)
     {
         Key k1 = warp_shuffle_xor(k, mask, WarpSize);
-        V v1 = warp_shuffle_xor(v, mask, WarpSize);
+        //V v1 = warp_shuffle_xor(v, mask, WarpSize);
         bool swap = compare_function(dir ? k : k1, dir ? k1 : k);
         if (swap)
         {
             k = k1;
-            v = v1;
+            v = warp_shuffle_xor(v, mask, WarpSize);
         }
     }
 

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -360,6 +360,7 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
                 expected_key[i] = expected[i].first;
                 expected_value[i] = expected[i].second;
             }
+
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected_key));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, expected_value));
 


### PR DESCRIPTION
rocm 4.2 mi25 merge sort improvement

```
sort_pairs<int, custom_float2>/manual_time                         749 ms        749 ms          1   5.00862 GB/s   427.402 M items/s
sort_pairs<long long, custom_double2>/manual_time                 1294 ms       1294 ms          1   5.79821 GB/s    247.39 M items/s
sort_pairs<custom_double2, custom_double2>/manual_time            2384 ms       2384 ms          1   4.19383 GB/s   134.202 M items/s
sort_pairs<custom_int2, custom_double2>/manual_time               1091 ms       1091 ms          1   6.87163 GB/s    293.19 M items/s
sort_pairs<custom_int2, custom_char_double>/manual_time           1230 ms       1230 ms          1   6.09692 GB/s   260.135 M items/s
sort_pairs<custom_int2, custom_longlong_double>/manual_time       1092 ms       1092 ms          1    6.8697 GB/s   293.107 M items/s
```

rocm 4.2 mi25 default branch

```
sort_pairs<int, custom_float2>/manual_time                         766 ms        766 ms          1   4.89801GB/s   417.963M items/s
sort_pairs<long long, custom_double2>/manual_time                 1374 ms       1374 ms          1   5.45893GB/s   232.914M items/s
sort_pairs<custom_double2, custom_double2>/manual_time            2430 ms       2430 ms          1   4.11505GB/s   131.682M items/s
sort_pairs<custom_int2, custom_double2>/manual_time               1295 ms       1295 ms          1   5.79177GB/s   247.116M items/s
sort_pairs<custom_int2, custom_char_double>/manual_time           1488 ms       1488 ms          1   5.04071GB/s    215.07M items/s
sort_pairs<custom_int2, custom_longlong_double>/manual_time       1295 ms       1295 ms          1   5.79197GB/s   247.124M items/s
```