### PR TITLE
Remove runtime package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ rocm_create_package(
   NAME rocprim
   DESCRIPTION "Radeon Open Compute Parallel Primitives Library"
   MAINTAINER "rocPRIM Maintainer <rocprim-maintainer@amd.com>"
+  HEADER_ONLY
 )
 
 


### PR DESCRIPTION
As rocPRIM is a header-only library, use the `HEADER_ONLY` option to `rocm_create_package` in the latest version of `rocm-cmake` to prevent generation of an empty runtime package.