### PR TITLE
Temporarily disabling failing HMM unit tests on CI

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -32,7 +32,7 @@ def runTestCommand (platform, project)
     def testCommand = "ctest${centos} --output-on-failure "
     def hmmTestCommand = ''
     def testCommandExclude = "--exclude-regex rocprim.device_scan"
-    def hmmExcludeRegex = /(rocprim.device_merge|rocprim.device_scan|rocprim.device_run_length_encode|rocprim.device_segmented_radix_sort)/
+    def hmmExcludeRegex = /(rocprim.device_merge|rocprim.device_scan|rocprim.device_run_length_encode|rocprim.device_segmented_radix_sort|rocprim.device_partition|rocprim.device_radix_sort)/
     def hmmTestCommandExclude = "--exclude-regex \"${hmmExcludeRegex}\""
     if (platform.jenkinsLabel.contains('gfx90a'))
     {

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -29,8 +29,10 @@ def runTestCommand (platform, project)
     String sudo = auxiliary.sudo(platform.jenkinsLabel)
     String centos = platform.jenkinsLabel.contains('centos') ? '3' : ''
 
-    def testCommand = "ctest${centos} --output-on-failure --exclude-regex rocprim.device_scan"
+    def testCommand = "ctest${centos} --output-on-failure "
     def hmmTestCommand = ''
+    def testCommandExclude = "--exclude-regex rocprim.device_scan"
+    def hmmTestCommandExclude = "--exclude-regex "(rocprim.device_merge|rocprim.device_scan|rocprim.device_run_length_encode|rocprim.device_segmented_radix_sort)"
     if (platform.jenkinsLabel.contains('gfx90a'))
     {
         hmmTestCommand = """
@@ -43,8 +45,8 @@ def runTestCommand (platform, project)
                 set -x
                 cd ${project.paths.project_build_prefix}
                 cd ${project.testDirectory}
-                ${testCommand}
-                ${hmmTestCommand}
+                ${testCommand} ${testCommandExclude}
+                ${hmmTestCommand} ${hmmTestCommandExclude}
             """
 
     platform.runCommand(this, command)

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -39,7 +39,7 @@ def runTestCommand (platform, project)
         hmmTestCommand = """
                             export HSA_XNACK=1
                             export ROCPRIM_USE_HMM=1
-                            ${testCommand}
+                            ${testCommand} ${hmmTestCommandExclude}
                          """
     }
     def command = """#!/usr/bin/env bash
@@ -47,7 +47,7 @@ def runTestCommand (platform, project)
                 cd ${project.paths.project_build_prefix}
                 cd ${project.testDirectory}
                 ${testCommand} ${testCommandExclude}
-                ${hmmTestCommand} ${hmmTestCommandExclude}
+                ${hmmTestCommand}
             """
 
     platform.runCommand(this, command)

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -32,7 +32,8 @@ def runTestCommand (platform, project)
     def testCommand = "ctest${centos} --output-on-failure "
     def hmmTestCommand = ''
     def testCommandExclude = "--exclude-regex rocprim.device_scan"
-    def hmmTestCommandExclude = "--exclude-regex "(rocprim.device_merge|rocprim.device_scan|rocprim.device_run_length_encode|rocprim.device_segmented_radix_sort)"
+    def hmmExcludeRegex = /(rocprim.device_merge|rocprim.device_scan|rocprim.device_run_length_encode|rocprim.device_segmented_radix_sort)/
+    def hmmTestCommandExclude = "--exclude-regex \"${hmmExcludeRegex}\""
     if (platform.jenkinsLabel.contains('gfx90a'))
     {
         hmmTestCommand = """


### PR DESCRIPTION
We have 3-6 unit tests failing on gfx90a + HMM.  The number of tests that fail seem to change depending on the machine, and whether or not the entire test suite is being run.  I am currently investigating the failures.  Until a fix is found I think we should disable these as we haven't had a successful artifact in rocPRIM for quite some time, which affects rocThrust and hipCUB CI.