### PR TITLE
Removing top level directory from ZIP package

### DIFF
--- a/rmake.py
+++ b/rmake.py
@@ -138,6 +138,10 @@ def config_cmd():
     create_dir( os.path.join(build_path, "clients") )
     os.chdir( build_path )
 
+    # packaging options
+    cmake_pack_options = f"-DCPACK_SET_DESTDIR=OFF -DCPACK_INCLUDE_TOPLEVEL_DIRECTORY=OFF"
+    cmake_options.append( cmake_pack_options )
+
     if args.static_lib:
         cmake_options.append( f"-DBUILD_SHARED_LIBS=OFF" )
 


### PR DESCRIPTION
Removing the top level directory from the zip package so that it is consistent with other math libraries for windows.