### PR TITLE
Changing inline to __attribute__((always_inline)) for device functions for HIP on windows

### DIFF
--- a/rocprim/include/rocprim/block/block_adjacent_difference.hpp
+++ b/rocprim/include/rocprim/block/block_adjacent_difference.hpp
@@ -69,7 +69,7 @@ struct with_b_index_arg<
 // Wrapping function that allows to call FlagOp of any of these signatures:
 // with b_index (a, b, b_index) or without it (a, b).
 template<class T, class FlagType, class FlagOp>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<with_b_index_arg<T, FlagOp>::value, FlagType>::type
 apply(FlagOp flag_op, const T& a, const T& b, unsigned int index)
 {
@@ -77,7 +77,7 @@ apply(FlagOp flag_op, const T& a, const T& b, unsigned int index)
 }
 
 template<class T, class FlagType, class FlagOp>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<!with_b_index_arg<T, FlagOp>::value, FlagType>::type
 apply(FlagOp flag_op, const T& a, const T& b, unsigned int)
 {
@@ -199,7 +199,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads(Flag (&head_flags)[ItemsPerThread],
                     const T (&input)[ItemsPerThread],
                     FlagOp flag_op,
@@ -228,7 +228,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads(Flag (&head_flags)[ItemsPerThread],
                     const T (&input)[ItemsPerThread],
                     FlagOp flag_op)
@@ -287,7 +287,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads(Flag (&head_flags)[ItemsPerThread],
                     T tile_predecessor_item,
                     const T (&input)[ItemsPerThread],
@@ -319,7 +319,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads(Flag (&head_flags)[ItemsPerThread],
                     T tile_predecessor_item,
                     const T (&input)[ItemsPerThread],
@@ -371,7 +371,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_tails(Flag (&tail_flags)[ItemsPerThread],
                     const T (&input)[ItemsPerThread],
                     FlagOp flag_op,
@@ -400,7 +400,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_tails(Flag (&tail_flags)[ItemsPerThread],
                     const T (&input)[ItemsPerThread],
                     FlagOp flag_op)
@@ -459,7 +459,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_tails(Flag (&tail_flags)[ItemsPerThread],
                     T tile_successor_item,
                     const T (&input)[ItemsPerThread],
@@ -491,7 +491,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_tails(Flag (&tail_flags)[ItemsPerThread],
                     T tile_successor_item,
                     const T (&input)[ItemsPerThread],
@@ -545,7 +545,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               Flag (&tail_flags)[ItemsPerThread],
                               const T (&input)[ItemsPerThread],
@@ -575,7 +575,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               Flag (&tail_flags)[ItemsPerThread],
                               const T (&input)[ItemsPerThread],
@@ -638,7 +638,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               Flag (&tail_flags)[ItemsPerThread],
                               T tile_successor_item,
@@ -672,7 +672,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               Flag (&tail_flags)[ItemsPerThread],
                               T tile_successor_item,
@@ -736,7 +736,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               T tile_predecessor_item,
                               Flag (&tail_flags)[ItemsPerThread],
@@ -770,7 +770,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               T tile_predecessor_item,
                               Flag (&tail_flags)[ItemsPerThread],
@@ -840,7 +840,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               T tile_predecessor_item,
                               Flag (&tail_flags)[ItemsPerThread],
@@ -878,7 +878,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               T tile_predecessor_item,
                               Flag (&tail_flags)[ItemsPerThread],
@@ -904,7 +904,7 @@ private:
         class Flag,
         class FlagOp
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_impl(Flag (&head_flags)[ItemsPerThread],
                    T tile_predecessor_item,
                    Flag (&tail_flags)[ItemsPerThread],

--- a/rocprim/include/rocprim/block/block_discontinuity.hpp
+++ b/rocprim/include/rocprim/block/block_discontinuity.hpp
@@ -60,7 +60,7 @@ struct with_b_index_arg<
 // Wrapping function that allows to call FlagOp of any of these signatures:
 // with b_index (a, b, b_index) or without it (a, b).
 template<class T, class FlagOp>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<with_b_index_arg<T, FlagOp>::value, bool>::type
 apply(FlagOp flag_op, const T& a, const T& b, unsigned int b_index)
 {
@@ -68,7 +68,7 @@ apply(FlagOp flag_op, const T& a, const T& b, unsigned int b_index)
 }
 
 template<class T, class FlagOp>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<!with_b_index_arg<T, FlagOp>::value, bool>::type
 apply(FlagOp flag_op, const T& a, const T& b, unsigned int)
 {
@@ -190,7 +190,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads(Flag (&head_flags)[ItemsPerThread],
                     const T (&input)[ItemsPerThread],
                     FlagOp flag_op,
@@ -219,7 +219,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads(Flag (&head_flags)[ItemsPerThread],
                     const T (&input)[ItemsPerThread],
                     FlagOp flag_op)
@@ -278,7 +278,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads(Flag (&head_flags)[ItemsPerThread],
                     T tile_predecessor_item,
                     const T (&input)[ItemsPerThread],
@@ -310,7 +310,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads(Flag (&head_flags)[ItemsPerThread],
                     T tile_predecessor_item,
                     const T (&input)[ItemsPerThread],
@@ -362,7 +362,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_tails(Flag (&tail_flags)[ItemsPerThread],
                     const T (&input)[ItemsPerThread],
                     FlagOp flag_op,
@@ -391,7 +391,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_tails(Flag (&tail_flags)[ItemsPerThread],
                     const T (&input)[ItemsPerThread],
                     FlagOp flag_op)
@@ -450,7 +450,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_tails(Flag (&tail_flags)[ItemsPerThread],
                     T tile_successor_item,
                     const T (&input)[ItemsPerThread],
@@ -482,7 +482,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_tails(Flag (&tail_flags)[ItemsPerThread],
                     T tile_successor_item,
                     const T (&input)[ItemsPerThread],
@@ -536,7 +536,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               Flag (&tail_flags)[ItemsPerThread],
                               const T (&input)[ItemsPerThread],
@@ -566,7 +566,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               Flag (&tail_flags)[ItemsPerThread],
                               const T (&input)[ItemsPerThread],
@@ -629,7 +629,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               Flag (&tail_flags)[ItemsPerThread],
                               T tile_successor_item,
@@ -663,7 +663,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               Flag (&tail_flags)[ItemsPerThread],
                               T tile_successor_item,
@@ -727,7 +727,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               T tile_predecessor_item,
                               Flag (&tail_flags)[ItemsPerThread],
@@ -761,7 +761,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               T tile_predecessor_item,
                               Flag (&tail_flags)[ItemsPerThread],
@@ -831,7 +831,7 @@ public:
     /// }
     /// \endcode
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               T tile_predecessor_item,
                               Flag (&tail_flags)[ItemsPerThread],
@@ -869,7 +869,7 @@ public:
     /// The signature does not need to have <tt>const &</tt>, but function object
     /// must not modify the objects passed to it.
     template<unsigned int ItemsPerThread, class Flag, class FlagOp>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_heads_and_tails(Flag (&head_flags)[ItemsPerThread],
                               T tile_predecessor_item,
                               Flag (&tail_flags)[ItemsPerThread],
@@ -895,7 +895,7 @@ private:
         class Flag,
         class FlagOp
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void flag_impl(Flag (&head_flags)[ItemsPerThread],
                    T tile_predecessor_item,
                    Flag (&tail_flags)[ItemsPerThread],

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -126,7 +126,7 @@ public:
     /// \param [in] input - array that data is loaded from.
     /// \param [out] output - array that data is loaded to.
     template<class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void blocked_to_striped(const T (&input)[ItemsPerThread],
                             U (&output)[ItemsPerThread])
     {
@@ -164,7 +164,7 @@ public:
     /// }
     /// \endcode
     template<class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void blocked_to_striped(const T (&input)[ItemsPerThread],
                             U (&output)[ItemsPerThread],
                             storage_type& storage)
@@ -192,7 +192,7 @@ public:
     /// \param [in] input - array that data is loaded from.
     /// \param [out] output - array that data is loaded to.
     template<class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void striped_to_blocked(const T (&input)[ItemsPerThread],
                             U (&output)[ItemsPerThread])
     {
@@ -230,7 +230,7 @@ public:
     /// }
     /// \endcode
     template<class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void striped_to_blocked(const T (&input)[ItemsPerThread],
                             U (&output)[ItemsPerThread],
                             storage_type& storage)
@@ -258,7 +258,7 @@ public:
     /// \param [in] input - array that data is loaded from.
     /// \param [out] output - array that data is loaded to.
     template<class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void blocked_to_warp_striped(const T (&input)[ItemsPerThread],
                                  U (&output)[ItemsPerThread])
     {
@@ -296,7 +296,7 @@ public:
     /// }
     /// \endcode
     template<class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void blocked_to_warp_striped(const T (&input)[ItemsPerThread],
                                  U (&output)[ItemsPerThread],
                                  storage_type& storage)
@@ -329,7 +329,7 @@ public:
     /// \param [in] input - array that data is loaded from.
     /// \param [out] output - array that data is loaded to.
     template<class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void warp_striped_to_blocked(const T (&input)[ItemsPerThread],
                                  U (&output)[ItemsPerThread])
     {
@@ -367,7 +367,7 @@ public:
     /// }
     /// \endcode
     template<class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void warp_striped_to_blocked(const T (&input)[ItemsPerThread],
                                  U (&output)[ItemsPerThread],
                                  storage_type& storage)
@@ -402,7 +402,7 @@ public:
     /// \param [out] output - array that data is loaded to.
     /// \param [out] ranks - array that has rank of data.
     template<class U, class Offset>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scatter_to_blocked(const T (&input)[ItemsPerThread],
                             U (&output)[ItemsPerThread],
                             const Offset (&ranks)[ItemsPerThread])
@@ -444,7 +444,7 @@ public:
     /// }
     /// \endcode
     template<class U, class Offset>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scatter_to_blocked(const T (&input)[ItemsPerThread],
                             U (&output)[ItemsPerThread],
                             const Offset (&ranks)[ItemsPerThread],
@@ -476,7 +476,7 @@ public:
     /// \param [out] output - array that data is loaded to.
     /// \param [out] ranks - array that has rank of data.
     template<class U, class Offset>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scatter_to_striped(const T (&input)[ItemsPerThread],
                             U (&output)[ItemsPerThread],
                             const Offset (&ranks)[ItemsPerThread])
@@ -518,7 +518,7 @@ public:
     /// }
     /// \endcode
     template<class U, class Offset>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scatter_to_striped(const T (&input)[ItemsPerThread],
                             U (&output)[ItemsPerThread],
                             const Offset (&ranks)[ItemsPerThread],
@@ -553,7 +553,7 @@ public:
     /// \param [out] output - array that data is loaded to.
     /// \param [in] ranks - array that has rank of data.
     template<class U, class Offset>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scatter_to_striped_guarded(const T (&input)[ItemsPerThread],
                                     U (&output)[ItemsPerThread],
                                     const Offset (&ranks)[ItemsPerThread])
@@ -598,7 +598,7 @@ public:
     /// }
     /// \endcode
     template<class U, class Offset>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scatter_to_striped_guarded(const T (&input)[ItemsPerThread],
                                     U (&output)[ItemsPerThread],
                                     const Offset (&ranks)[ItemsPerThread],
@@ -635,7 +635,7 @@ public:
     /// \param [in] ranks - array that has rank of data.
     /// \param [in] is_valid - array that has flags to denote validity.
     template<class U, class Offset, class ValidFlag>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scatter_to_striped_flagged(const T (&input)[ItemsPerThread],
                                     U (&output)[ItemsPerThread],
                                     const Offset (&ranks)[ItemsPerThread],
@@ -682,7 +682,7 @@ public:
     /// }
     /// \endcode
     template<class U, class Offset, class ValidFlag>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scatter_to_striped_flagged(const T (&input)[ItemsPerThread],
                                     U (&output)[ItemsPerThread],
                                     const Offset (&ranks)[ItemsPerThread],
@@ -710,7 +710,7 @@ public:
 
 private:
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int get_current_warp_size() const
     {
         const unsigned int warp_id = ::rocprim::warp_id<BlockSizeX, BlockSizeY, BlockSizeZ>();
@@ -720,7 +720,7 @@ private:
     }
 
     // Change index to minimize LDS bank conflicts if necessary
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int index(unsigned int n)
     {
         // Move every 32-bank wide "row" (32 banks * 4 bytes) by one item

--- a/rocprim/include/rocprim/block/block_histogram.hpp
+++ b/rocprim/include/rocprim/block/block_histogram.hpp
@@ -156,7 +156,7 @@ public:
     ///
     /// \param [out] hist - histogram bin count.
     template<class Counter>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void init_histogram(Counter hist[Bins])
     {
         const auto flat_tid = ::rocprim::flat_block_thread_id<BlockSizeX, BlockSizeY, BlockSizeZ>();
@@ -220,7 +220,7 @@ public:
     /// \endcode
     /// \endparblock
     template<class Counter>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void composite(T (&input)[ItemsPerThread],
                    Counter hist[Bins],
                    storage_type& storage)
@@ -240,7 +240,7 @@ public:
     /// \param [in] input - reference to an array containing thread input values.
     /// \param [out] hist - histogram bin count.
     template<class Counter>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void composite(T (&input)[ItemsPerThread],
                    Counter hist[Bins])
     {
@@ -288,7 +288,7 @@ public:
     /// \endcode
     /// \endparblock
     template<class Counter>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void histogram(T (&input)[ItemsPerThread],
                    Counter hist[Bins],
                    storage_type& storage)
@@ -310,7 +310,7 @@ public:
     /// \param [in] input - reference to an array containing thread input values.
     /// \param [out] hist - histogram bin count.
     template<class Counter>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void histogram(T (&input)[ItemsPerThread],
                    Counter hist[Bins])
     {

--- a/rocprim/include/rocprim/block/block_load.hpp
+++ b/rocprim/include/rocprim/block/block_load.hpp
@@ -159,7 +159,7 @@ public:
     /// * The type \p T must be such that an object of type \p InputIterator
     /// can be dereferenced and then implicitly converted to \p T.
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread])
     {
@@ -185,7 +185,7 @@ public:
     /// * The type \p T must be such that an object of type \p InputIterator
     /// can be dereferenced and then implicitly converted to \p T.
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid)
@@ -218,7 +218,7 @@ public:
         class InputIterator,
         class Default
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -264,7 +264,7 @@ public:
     /// }
     /// \endcode
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               storage_type& storage)
@@ -309,7 +309,7 @@ public:
     /// }
     /// \endcode
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -361,7 +361,7 @@ public:
         class InputIterator,
         class Default
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -401,7 +401,7 @@ public:
     using storage_type = storage_type_; // only for Doxygen
     #endif
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(T* block_input,
               T (&_items)[ItemsPerThread])
     {
@@ -410,7 +410,7 @@ public:
     }
 
     template<class InputIterator, class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               U (&items)[ItemsPerThread])
     {
@@ -423,7 +423,7 @@ public:
     }
 
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid)
@@ -440,7 +440,7 @@ public:
         class InputIterator,
         class Default
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -455,7 +455,7 @@ public:
                                   out_of_bounds);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(T* block_input,
               T (&items)[ItemsPerThread],
               storage_type& storage)
@@ -465,7 +465,7 @@ public:
     }
 
     template<class InputIterator, class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               U (&items)[ItemsPerThread],
               storage_type& storage)
@@ -479,7 +479,7 @@ public:
     }
 
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -497,7 +497,7 @@ public:
         class InputIterator,
         class Default
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -531,7 +531,7 @@ public:
     using storage_type = typename block_exchange_type::storage_type;
 
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread])
     {
@@ -546,7 +546,7 @@ public:
     }
 
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid)
@@ -565,7 +565,7 @@ public:
         class InputIterator,
         class Default
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -583,7 +583,7 @@ public:
     }
 
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               storage_type& storage)
@@ -598,7 +598,7 @@ public:
     }
 
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -617,7 +617,7 @@ public:
         class InputIterator,
         class Default
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -655,7 +655,7 @@ public:
     using storage_type = typename block_exchange_type::storage_type;
 
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread])
     {
@@ -670,7 +670,7 @@ public:
     }
 
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid)
@@ -690,7 +690,7 @@ public:
         class InputIterator,
         class Default
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -708,7 +708,7 @@ public:
     }
 
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               storage_type& storage)
@@ -723,7 +723,7 @@ public:
     }
 
     template<class InputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,
@@ -742,7 +742,7 @@ public:
         class InputIterator,
         class Default
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void load(InputIterator block_input,
               T (&items)[ItemsPerThread],
               unsigned int valid,

--- a/rocprim/include/rocprim/block/block_load_func.hpp
+++ b/rocprim/include/rocprim/block/block_load_func.hpp
@@ -54,7 +54,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_load_direct_blocked(unsigned int flat_id,
                                InputIterator block_input,
                                T (&items)[ItemsPerThread])
@@ -90,7 +90,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_load_direct_blocked(unsigned int flat_id,
                                InputIterator block_input,
                                T (&items)[ItemsPerThread],
@@ -134,7 +134,7 @@ template<
     unsigned int ItemsPerThread,
     class Default
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_load_direct_blocked(unsigned int flat_id,
                                InputIterator block_input,
                                T (&items)[ItemsPerThread],
@@ -181,7 +181,7 @@ template<
     class U,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto
 block_load_direct_blocked_vectorized(unsigned int flat_id,
                                      T* block_input,
@@ -212,7 +212,7 @@ template<
     class U,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto
 block_load_direct_blocked_vectorized(unsigned int flat_id,
                                      T* block_input,
@@ -244,7 +244,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_load_direct_striped(unsigned int flat_id,
                                InputIterator block_input,
                                T (&items)[ItemsPerThread])
@@ -281,7 +281,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_load_direct_striped(unsigned int flat_id,
                                InputIterator block_input,
                                T (&items)[ItemsPerThread],
@@ -327,7 +327,7 @@ template<
     unsigned int ItemsPerThread,
     class Default
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_load_direct_striped(unsigned int flat_id,
                                InputIterator block_input,
                                T (&items)[ItemsPerThread],
@@ -373,7 +373,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_load_direct_warp_striped(unsigned int flat_id,
                                     InputIterator block_input,
                                     T (&items)[ItemsPerThread])
@@ -424,7 +424,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_load_direct_warp_striped(unsigned int flat_id,
                                     InputIterator block_input,
                                     T (&items)[ItemsPerThread],
@@ -484,7 +484,7 @@ template<
     unsigned int ItemsPerThread,
     class Default
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_load_direct_warp_striped(unsigned int flat_id,
                                     InputIterator block_input,
                                     T (&items)[ItemsPerThread],

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -80,7 +80,7 @@ public:
     using storage_type = detail::raw_storage<storage_type_>;
 
     template<unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(const unsigned int (&input)[ItemsPerThread],
                         unsigned int (&output)[ItemsPerThread],
                         unsigned int& reduction,
@@ -275,7 +275,7 @@ public:
     /// If the \p input values across threads in a block are <tt>{[256, 255], ..., [4, 3], [2, 1]}}</tt>, then
     /// then after sort they will be equal <tt>{[1, 2], [3, 4]  ..., [255, 256]}</tt>.
     /// \endparblock
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key (&keys)[ItemsPerThread],
               storage_type& storage,
               unsigned int begin_bit = 0,
@@ -297,7 +297,7 @@ public:
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
     /// value: \p <tt>8 * sizeof(Key)</tt>.
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key (&keys)[ItemsPerThread],
               unsigned int begin_bit = 0,
               unsigned int end_bit = 8 * sizeof(Key))
@@ -347,7 +347,7 @@ public:
     /// If the \p input values across threads in a block are <tt>{[1, 2], [3, 4]  ..., [255, 256]}</tt>,
     /// then after sort they will be equal <tt>{[256, 255], ..., [4, 3], [2, 1]}</tt>.
     /// \endparblock
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc(Key (&keys)[ItemsPerThread],
                    storage_type& storage,
                    unsigned int begin_bit = 0,
@@ -369,7 +369,7 @@ public:
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
     /// value: \p <tt>8 * sizeof(Key)</tt>.
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc(Key (&keys)[ItemsPerThread],
                    unsigned int begin_bit = 0,
                    unsigned int end_bit = 8 * sizeof(Key))
@@ -428,7 +428,7 @@ public:
     /// equal <tt>{[128, 128], [127, 127]  ..., [2, 2], [1, 1]}</tt>.
     /// \endparblock
     template<bool WithValues = with_values>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key (&keys)[ItemsPerThread],
               typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
               storage_type& storage,
@@ -455,7 +455,7 @@ public:
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
     /// value: \p <tt>8 * sizeof(Key)</tt>.
     template<bool WithValues = with_values>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key (&keys)[ItemsPerThread],
               typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
               unsigned int begin_bit = 0,
@@ -515,7 +515,7 @@ public:
     /// will be equal <tt>{[1, 1], [2, 2]  ..., [128, 128]}</tt>.
     /// \endparblock
     template<bool WithValues = with_values>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc(Key (&keys)[ItemsPerThread],
                    typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
                    storage_type& storage,
@@ -542,7 +542,7 @@ public:
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
     /// value: \p <tt>8 * sizeof(Key)</tt>.
     template<bool WithValues = with_values>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc(Key (&keys)[ItemsPerThread],
                    typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
                    unsigned int begin_bit = 0,
@@ -594,7 +594,7 @@ public:
     /// If the \p input values across threads in a block are <tt>{[256, 255], ..., [4, 3], [2, 1]}}</tt>, then
     /// then after sort they will be equal <tt>{[1, 129], [2, 130]  ..., [128, 256]}</tt>.
     /// \endparblock
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_to_striped(Key (&keys)[ItemsPerThread],
                          storage_type& storage,
                          unsigned int begin_bit = 0,
@@ -617,7 +617,7 @@ public:
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
     /// value: \p <tt>8 * sizeof(Key)</tt>.
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_to_striped(Key (&keys)[ItemsPerThread],
                          unsigned int begin_bit = 0,
                          unsigned int end_bit = 8 * sizeof(Key))
@@ -668,7 +668,7 @@ public:
     /// If the \p input values across threads in a block are <tt>{[1, 2], [3, 4]  ..., [255, 256]}</tt>,
     /// then after sort they will be equal <tt>{[256, 128], ..., [130, 2], [129, 1]}</tt>.
     /// \endparblock
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc_to_striped(Key (&keys)[ItemsPerThread],
                               storage_type& storage,
                               unsigned int begin_bit = 0,
@@ -691,7 +691,7 @@ public:
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
     /// value: \p <tt>8 * sizeof(Key)</tt>.
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc_to_striped(Key (&keys)[ItemsPerThread],
                               unsigned int begin_bit = 0,
                               unsigned int end_bit = 8 * sizeof(Key))
@@ -750,7 +750,7 @@ public:
     /// equal <tt>{[-8, -4], [-7, -3], [-6, -2], [-5, -1]}</tt>.
     /// \endparblock
     template<bool WithValues = with_values>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_to_striped(Key (&keys)[ItemsPerThread],
                          typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
                          storage_type& storage,
@@ -775,7 +775,7 @@ public:
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
     /// value: \p <tt>8 * sizeof(Key)</tt>.
     template<bool WithValues = with_values>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_to_striped(Key (&keys)[ItemsPerThread],
                          typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
                          unsigned int begin_bit = 0,
@@ -835,7 +835,7 @@ public:
     /// equal <tt>{[10, 50], [20, 60], [30, 70], [40, 80]}</tt>.
     /// \endparblock
     template<bool WithValues = with_values>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc_to_striped(Key (&keys)[ItemsPerThread],
                               typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
                               storage_type& storage,
@@ -860,7 +860,7 @@ public:
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
     /// value: \p <tt>8 * sizeof(Key)</tt>.
     template<bool WithValues = with_values>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc_to_striped(Key (&keys)[ItemsPerThread],
                               typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
                               unsigned int begin_bit = 0,
@@ -873,7 +873,7 @@ public:
 private:
 
     template<bool Descending, bool ToStriped = false, class SortedValue>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_impl(Key (&keys)[ItemsPerThread],
                    SortedValue (&values)[ItemsPerThread],
                    storage_type& storage,
@@ -934,7 +934,7 @@ private:
         }
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exchange_keys(storage_type& storage,
                        bit_key_type (&bit_keys)[ItemsPerThread],
                        const unsigned int (&ranks)[ItemsPerThread])
@@ -945,7 +945,7 @@ private:
     }
 
     template<class SortedValue>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exchange_values(storage_type& storage,
                          SortedValue (&values)[ItemsPerThread],
                          const unsigned int (&ranks)[ItemsPerThread])
@@ -955,7 +955,7 @@ private:
         values_exchange_type().scatter_to_blocked(values, values, ranks, storage_.values_exchange);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exchange_values(storage_type& storage,
                          empty_type (&values)[ItemsPerThread],
                          const unsigned int (&ranks)[ItemsPerThread])
@@ -965,7 +965,7 @@ private:
         (void) ranks;
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_striped_keys(storage_type& storage,
                          bit_key_type (&bit_keys)[ItemsPerThread])
     {
@@ -975,7 +975,7 @@ private:
     }
 
     template<class SortedValue>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_striped_values(storage_type& storage,
                            SortedValue (&values)[ItemsPerThread])
     {
@@ -984,7 +984,7 @@ private:
         values_exchange_type().blocked_to_striped(values, values, storage_.values_exchange);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_striped_values(storage_type& storage,
                            empty_type * values)
     {

--- a/rocprim/include/rocprim/block/block_reduce.hpp
+++ b/rocprim/include/rocprim/block/block_reduce.hpp
@@ -200,7 +200,7 @@ public:
     /// \p output value will be <tt>{-256}</tt>.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 storage_type& storage,
@@ -225,7 +225,7 @@ public:
     /// <tt>T f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 BinaryFunction reduce_op = BinaryFunction())
@@ -284,7 +284,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T (&input)[ItemsPerThread],
                 T& output,
                 storage_type& storage,
@@ -313,7 +313,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T (&input)[ItemsPerThread],
                 T& output,
                 BinaryFunction reduce_op = BinaryFunction())
@@ -368,7 +368,7 @@ public:
     /// \endcode
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 unsigned int valid_items,
@@ -396,7 +396,7 @@ public:
     /// <tt>T f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 unsigned int valid_items,

--- a/rocprim/include/rocprim/block/block_scan.hpp
+++ b/rocprim/include/rocprim/block/block_scan.hpp
@@ -195,7 +195,7 @@ public:
     /// \p output values in will be <tt>{1, -2, -2, -4, ..., -254, -256}</tt>.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         storage_type& storage,
@@ -220,7 +220,7 @@ public:
     /// <tt>T f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         BinaryFunction scan_op = BinaryFunction())
@@ -279,7 +279,7 @@ public:
     /// be <tt>-256</tt>.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         T& reduction,
@@ -306,7 +306,7 @@ public:
     /// <tt>T f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         T& reduction,
@@ -395,7 +395,7 @@ public:
         class PrefixCallback,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         storage_type& storage,
@@ -456,7 +456,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         storage_type& storage,
@@ -492,7 +492,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         BinaryFunction scan_op = BinaryFunction())
@@ -561,7 +561,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T& reduction,
@@ -599,7 +599,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T& reduction,
@@ -697,7 +697,7 @@ public:
         class PrefixCallback,
         class BinaryFunction
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         storage_type& storage,
@@ -765,7 +765,7 @@ public:
     /// and \p init is \p 0, then \p output values in will be <tt>{0, 0, -2, -2, -4, ..., -254, -254}</tt>.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -793,7 +793,7 @@ public:
     /// <tt>T f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -857,7 +857,7 @@ public:
     /// and the \p reduction will be \p -256.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -887,7 +887,7 @@ public:
     /// <tt>T f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::plus<T>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -977,7 +977,7 @@ public:
         class PrefixCallback,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         storage_type& storage,
@@ -1042,7 +1042,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -1081,7 +1081,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -1156,7 +1156,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -1197,7 +1197,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction = ::rocprim::plus<T>
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -1296,7 +1296,7 @@ public:
         class PrefixCallback,
         class BinaryFunction
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         storage_type& storage,

--- a/rocprim/include/rocprim/block/block_shuffle.hpp
+++ b/rocprim/include/rocprim/block/block_shuffle.hpp
@@ -145,7 +145,7 @@ public:
     ///     ...
     /// }
     /// \endcode
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void offset(T input,
                 T& output,
                 int distance = 1)
@@ -156,7 +156,7 @@ public:
         );
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void offset(const size_t& flat_id,
                 T input,
                 T& output,
@@ -166,7 +166,7 @@ public:
         offset(flat_id, input, output, distance, storage);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void offset(const size_t& flat_id,
                 T input,
                 T& output,
@@ -211,7 +211,7 @@ public:
     ///     ...
     /// }
     /// \endcode
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void rotate(T input,
                 T& output,
                 unsigned int distance = 1)
@@ -222,7 +222,7 @@ public:
         );
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void rotate(const size_t& flat_id,
                 T input,
                 T& output,
@@ -232,7 +232,7 @@ public:
         rotate(flat_id, input, output, distance, storage);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void rotate(const size_t& flat_id,
                 T input,
                 T& output,
@@ -276,7 +276,7 @@ public:
     /// }
     /// \endcode
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void up(T (&input)[ItemsPerThread],
             T (&prev)[ItemsPerThread])
     {
@@ -287,7 +287,7 @@ public:
     }
 
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void up(const size_t& flat_id,
             T (&input)[ItemsPerThread],
             T (&prev)[ItemsPerThread])
@@ -298,7 +298,7 @@ public:
 
 
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void up(const size_t& flat_id,
             T (&input)[ItemsPerThread],
             T (&prev)[ItemsPerThread],
@@ -332,7 +332,7 @@ public:
     /// \param [out] block_suffix - The item \p input[ItemsPerThread-1] from
     /// <em>thread</em><sub><tt>BlockSize-1</tt></sub>, provided to all threads
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void up(T (&input)[ItemsPerThread],
             T (&prev)[ItemsPerThread],
             T &block_suffix)
@@ -344,7 +344,7 @@ public:
     }
 
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void up(const size_t& flat_id,
             T (&input)[ItemsPerThread],
             T (&prev)[ItemsPerThread],
@@ -355,7 +355,7 @@ public:
     }
 
     template <int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void up(const size_t& flat_id,
             T (&input)[ItemsPerThread],
             T (&prev)[ItemsPerThread],
@@ -392,7 +392,7 @@ public:
     /// }
     /// \endcode
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void down(T (&input)[ItemsPerThread],
               T (&next)[ItemsPerThread])
     {
@@ -403,7 +403,7 @@ public:
     }
 
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void down(const size_t& flat_id,
               T (&input)[ItemsPerThread],
               T (&next)[ItemsPerThread])
@@ -413,7 +413,7 @@ public:
     }
 
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void down(const size_t& flat_id,
               T (&input)[ItemsPerThread],
               T (&next)[ItemsPerThread],
@@ -444,7 +444,7 @@ public:
     /// The item \p prev[0] is not updated for <em>thread</em><sub>BlockSize - 1</sub>.
     /// \param [out] block_prefix -  The item \p input[0] from <em>thread</em><sub><tt>0</tt></sub>, provided to all threads
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void down(T (&input)[ItemsPerThread],
               T (&next)[ItemsPerThread],
               T &block_prefix)
@@ -456,7 +456,7 @@ public:
     }
 
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void down(const size_t& flat_id,
               T (&input)[ItemsPerThread],
               T (&next)[ItemsPerThread],
@@ -467,7 +467,7 @@ public:
     }
 
     template <unsigned int ItemsPerThread>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void down(const size_t& flat_id,
               T (&input)[ItemsPerThread],
               T (&next)[ItemsPerThread],

--- a/rocprim/include/rocprim/block/block_sort.hpp
+++ b/rocprim/include/rocprim/block/block_sort.hpp
@@ -140,7 +140,7 @@ public:
     /// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::less<Key>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               BinaryFunction compare_function = BinaryFunction())
     {
@@ -189,7 +189,7 @@ public:
     /// \endcode
     /// \endparblock
     template<class BinaryFunction = ::rocprim::less<Key>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               storage_type& storage,
               BinaryFunction compare_function = BinaryFunction())
@@ -210,7 +210,7 @@ public:
     /// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::less<Key>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               Value& thread_value,
               BinaryFunction compare_function = BinaryFunction())
@@ -261,7 +261,7 @@ public:
     /// \endcode
     /// \endparblock
     template<class BinaryFunction = ::rocprim::less<Key>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               Value& thread_value,
               storage_type& storage,
@@ -285,7 +285,7 @@ public:
     /// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::less<Key>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               storage_type& storage,
               const unsigned int size,
@@ -310,7 +310,7 @@ public:
     /// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::less<Key>>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               Value& thread_value,
               storage_type& storage,

--- a/rocprim/include/rocprim/block/block_store.hpp
+++ b/rocprim/include/rocprim/block/block_store.hpp
@@ -159,7 +159,7 @@ public:
     /// * The type \p T must be such that an object of type \p InputIterator
     /// can be dereferenced and then implicitly converted to \p T.
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread])
     {
@@ -181,7 +181,7 @@ public:
     /// * The type \p T must be such that an object of type \p InputIterator
     /// can be dereferenced and then implicitly converted to \p T.
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                unsigned int valid)
@@ -221,7 +221,7 @@ public:
     /// }
     /// \endcode
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                storage_type& storage)
@@ -263,7 +263,7 @@ public:
     /// }
     /// \endcode
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                unsigned int valid,
@@ -298,7 +298,7 @@ public:
     using storage_type = storage_type_; // only for Doxygen
     #endif
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(T* block_output,
                T (&_items)[ItemsPerThread])
     {
@@ -307,7 +307,7 @@ public:
     }
 
     template<class OutputIterator, class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                U (&items)[ItemsPerThread])
     {
@@ -316,7 +316,7 @@ public:
     }
 
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                unsigned int valid)
@@ -325,7 +325,7 @@ public:
         block_store_direct_blocked(flat_id, block_output, items, valid);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(T* block_output,
                T (&items)[ItemsPerThread],
                storage_type& storage)
@@ -335,7 +335,7 @@ public:
     }
 
     template<class OutputIterator, class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                U (&items)[ItemsPerThread],
                storage_type& storage)
@@ -345,7 +345,7 @@ public:
     }
 
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                unsigned int valid,
@@ -373,7 +373,7 @@ public:
     using storage_type = typename block_exchange_type::storage_type;
 
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread])
     {
@@ -384,7 +384,7 @@ public:
     }
 
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                unsigned int valid)
@@ -396,7 +396,7 @@ public:
     }
 
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                storage_type& storage)
@@ -407,7 +407,7 @@ public:
     }
 
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                unsigned int valid,
@@ -439,7 +439,7 @@ public:
     using storage_type = typename block_exchange_type::storage_type;
 
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread])
     {
@@ -450,7 +450,7 @@ public:
     }
 
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                unsigned int valid)
@@ -462,7 +462,7 @@ public:
     }
 
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                storage_type& storage)
@@ -473,7 +473,7 @@ public:
     }
 
     template<class OutputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void store(OutputIterator block_output,
                T (&items)[ItemsPerThread],
                unsigned int valid,

--- a/rocprim/include/rocprim/block/block_store_func.hpp
+++ b/rocprim/include/rocprim/block/block_store_func.hpp
@@ -54,7 +54,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_store_direct_blocked(unsigned int flat_id,
                                 OutputIterator block_output,
                                 T (&items)[ItemsPerThread])
@@ -94,7 +94,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_store_direct_blocked(unsigned int flat_id,
                                 OutputIterator block_output,
                                 T (&items)[ItemsPerThread],
@@ -146,7 +146,7 @@ template<
     class U,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto
 block_store_direct_blocked_vectorized(unsigned int flat_id,
                                       T* block_output,
@@ -176,7 +176,7 @@ template<
     class U,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto
 block_store_direct_blocked_vectorized(unsigned int flat_id,
                                       T* block_output,
@@ -208,7 +208,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_store_direct_striped(unsigned int flat_id,
                                 OutputIterator block_output,
                                 T (&items)[ItemsPerThread])
@@ -249,7 +249,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_store_direct_striped(unsigned int flat_id,
                                 OutputIterator block_output,
                                 T (&items)[ItemsPerThread],
@@ -301,7 +301,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_store_direct_warp_striped(unsigned int flat_id,
                                      OutputIterator block_output,
                                      T (&items)[ItemsPerThread])
@@ -356,7 +356,7 @@ template<
     class T,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_store_direct_warp_striped(unsigned int flat_id,
                                      OutputIterator block_output,
                                      T (&items)[ItemsPerThread],

--- a/rocprim/include/rocprim/block/detail/block_histogram_atomic.hpp
+++ b/rocprim/include/rocprim/block/detail/block_histogram_atomic.hpp
@@ -54,7 +54,7 @@ public:
     using storage_type = typename ::rocprim::detail::empty_storage_type;
 
     template<class Counter>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void composite(T (&input)[ItemsPerThread],
                    Counter hist[Bins])
     {
@@ -72,7 +72,7 @@ public:
     }
 
     template<class Counter>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void composite(T (&input)[ItemsPerThread],
                    Counter hist[Bins],
                    storage_type& storage)

--- a/rocprim/include/rocprim/block/detail/block_histogram_sort.hpp
+++ b/rocprim/include/rocprim/block/detail/block_histogram_sort.hpp
@@ -72,7 +72,7 @@ public:
     using storage_type = detail::raw_storage<storage_type_>;
 
     template<class Counter>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void composite(T (&input)[ItemsPerThread],
                    Counter hist[Bins])
     {
@@ -81,7 +81,7 @@ public:
     }
 
     template<class Counter>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void composite(T (&input)[ItemsPerThread],
                    Counter hist[Bins],
                    storage_type& storage)
@@ -139,12 +139,12 @@ private:
     {
         storage_type &storage;
 
-        ROCPRIM_DEVICE inline
+        ROCPRIM_DEVICE ROCPRIM_INLINE
         discontinuity_op(storage_type &storage) : storage(storage)
         {
         }
 
-        ROCPRIM_DEVICE inline
+        ROCPRIM_DEVICE ROCPRIM_INLINE
         bool operator()(const T& a, const T& b, unsigned int b_index) const
         {
             storage_type_& storage_ = storage.get();

--- a/rocprim/include/rocprim/block/detail/block_reduce_raking_reduce.hpp
+++ b/rocprim/include/rocprim/block/detail/block_reduce_raking_reduce.hpp
@@ -77,7 +77,7 @@ public:
     /// \param storage  [in] Temporary Storage used for the Reduction
     /// \param reduce_op [in] Binary reduction operator
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 storage_type& storage,
@@ -94,7 +94,7 @@ public:
     /// \param output   [out] Variable containing reduction output
     /// \param reduce_op [in] Binary reduction operator
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 BinaryFunction reduce_op)
@@ -109,7 +109,7 @@ public:
     /// \param storage  [in] Temporary Storage used for the Reduction
     /// \param reduce_op [in] Binary reduction operator
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T (&input)[ItemsPerThread],
                 T& output,
                 storage_type& storage,
@@ -138,7 +138,7 @@ public:
     /// \param output   [out] Variable containing reduction output
     /// \param reduce_op [in] Binary reduction operator
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T (&input)[ItemsPerThread],
                 T& output,
                 BinaryFunction reduce_op)
@@ -154,7 +154,7 @@ public:
     /// \param storage [in] Temporary Storage used for reduction
     /// \param reduce_op [in] Binary reduction operator
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 unsigned int valid_items,
@@ -174,7 +174,7 @@ public:
     /// \param valid_items [in] Number of valid elements (may be less than BlockSize)
     /// \param reduce_op [in] Binary reduction operator
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 unsigned int valid_items,
@@ -187,7 +187,7 @@ public:
 private:
 
     template<class BinaryFunction, bool FunctionCommutativeOnly = commutative_only_>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto reduce_impl(const unsigned int flat_tid,
                      T input,
                      T& output,
@@ -215,7 +215,7 @@ private:
     }
 
     template<class BinaryFunction, bool FunctionCommutativeOnly = commutative_only_>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto reduce_impl(const unsigned int flat_tid,
                      T input,
                      T& output,
@@ -248,7 +248,7 @@ private:
     }
 
     template<bool UseValid, class WarpReduce, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto warp_reduce(T input,
                      T& output,
                      const unsigned int valid_items,
@@ -261,7 +261,7 @@ private:
     }
 
     template<bool UseValid, class WarpReduce, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto warp_reduce(T input,
                      T& output,
                      const unsigned int valid_items,
@@ -275,7 +275,7 @@ private:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce_impl(const unsigned int flat_tid,
                      T input,
                      T& output,

--- a/rocprim/include/rocprim/block/detail/block_reduce_warp_reduce.hpp
+++ b/rocprim/include/rocprim/block/detail/block_reduce_warp_reduce.hpp
@@ -75,7 +75,7 @@ public:
     using storage_type = detail::raw_storage<storage_type_>;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 storage_type& storage,
@@ -88,7 +88,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 BinaryFunction reduce_op)
@@ -98,7 +98,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T (&input)[ItemsPerThread],
                 T& output,
                 storage_type& storage,
@@ -123,7 +123,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T (&input)[ItemsPerThread],
                 T& output,
                 BinaryFunction reduce_op)
@@ -133,7 +133,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 unsigned int valid_items,
@@ -147,7 +147,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input,
                 T& output,
                 unsigned int valid_items,
@@ -159,7 +159,7 @@ public:
 
 private:
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce_impl(const unsigned int flat_tid,
                      T input,
                      T& output,
@@ -197,7 +197,7 @@ private:
     }
 
     template<bool UseValid, class WarpReduce, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto warp_reduce(T input,
                      T& output,
                      const unsigned int valid_items,
@@ -210,7 +210,7 @@ private:
     }
 
     template<bool UseValid, class WarpReduce, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto warp_reduce(T input,
                      T& output,
                      const unsigned int valid_items,
@@ -224,7 +224,7 @@ private:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce_impl(const unsigned int flat_tid,
                      T input,
                      T& output,

--- a/rocprim/include/rocprim/block/detail/block_scan_reduce_then_scan.hpp
+++ b/rocprim/include/rocprim/block/detail/block_scan_reduce_then_scan.hpp
@@ -71,7 +71,7 @@ public:
     using storage_type = detail::raw_storage<storage_type_>;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         storage_type& storage,
@@ -82,7 +82,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         BinaryFunction scan_op)
@@ -92,7 +92,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         T& reduction,
@@ -105,7 +105,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         T& reduction,
@@ -116,7 +116,7 @@ public:
     }
 
     template<class PrefixCallback, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         storage_type& storage,
@@ -137,7 +137,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         storage_type& storage,
@@ -172,7 +172,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         BinaryFunction scan_op)
@@ -182,7 +182,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T& reduction,
@@ -196,7 +196,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T& reduction,
@@ -211,7 +211,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         storage_type& storage,
@@ -257,7 +257,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -269,7 +269,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -280,7 +280,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -298,7 +298,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -310,7 +310,7 @@ public:
     }
 
     template<class PrefixCallback, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         storage_type& storage,
@@ -335,7 +335,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -378,7 +378,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -389,7 +389,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -404,7 +404,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -420,7 +420,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         storage_type& storage,
@@ -475,7 +475,7 @@ private:
     // result for each thread is stored in storage_.threads[flat_tid], and sets
     // output to storage_.threads[flat_tid]
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan_impl(const unsigned int flat_tid,
                              T input,
                              T& output,
@@ -492,7 +492,7 @@ private:
     // Calculates inclusive scan results and stores them in storage_.threads,
     // result for each thread is stored in storage_.threads[flat_tid]
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan_base(const unsigned int flat_tid,
                              T input,
                              storage_type& storage,
@@ -540,7 +540,7 @@ private:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan_impl(const unsigned int flat_tid,
                              T input,
                              T& output,
@@ -556,7 +556,7 @@ private:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan_impl(const unsigned int flat_tid,
                              T input,
                              T& output,
@@ -574,7 +574,7 @@ private:
 
     // OVERWRITES storage_.threads[0]
     template<class PrefixCallback, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void include_block_prefix(const unsigned int flat_tid,
                               const unsigned int warp_id,
                               const T input,
@@ -593,7 +593,7 @@ private:
 
     // OVERWRITES storage_.threads[0]
     template<class PrefixCallback>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     T get_block_prefix(const unsigned int flat_tid,
                        const unsigned int warp_id,
                        const T reduction,
@@ -616,7 +616,7 @@ private:
     }
 
     // Change index to minimize LDS bank conflicts if necessary
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int index(unsigned int n) const
     {
         // Move every 32-bank wide "row" (32 banks * 4 bytes) by one item

--- a/rocprim/include/rocprim/block/detail/block_scan_warp_scan.hpp
+++ b/rocprim/include/rocprim/block/detail/block_scan_warp_scan.hpp
@@ -80,7 +80,7 @@ public:
     using storage_type = detail::raw_storage<storage_type_>;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         storage_type& storage,
@@ -93,7 +93,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         BinaryFunction scan_op)
@@ -103,7 +103,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         T& reduction,
@@ -117,7 +117,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         T& reduction,
@@ -128,7 +128,7 @@ public:
     }
 
     template<class PrefixCallback, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input,
                         T& output,
                         storage_type& storage,
@@ -149,7 +149,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         storage_type& storage,
@@ -187,7 +187,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         BinaryFunction scan_op)
@@ -197,7 +197,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T& reduction,
@@ -211,7 +211,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T& reduction,
@@ -226,7 +226,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         storage_type& storage,
@@ -275,7 +275,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -289,7 +289,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -302,7 +302,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -319,7 +319,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         T init,
@@ -333,7 +333,7 @@ public:
     }
 
     template<class PrefixCallback, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input,
                         T& output,
                         storage_type& storage,
@@ -357,7 +357,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -401,7 +401,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -412,7 +412,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -427,7 +427,7 @@ public:
     }
 
     template<unsigned int ItemsPerThread, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         T init,
@@ -443,7 +443,7 @@ public:
         unsigned int ItemsPerThread,
         class BinaryFunction
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T (&input)[ItemsPerThread],
                         T (&output)[ItemsPerThread],
                         storage_type& storage,
@@ -495,7 +495,7 @@ public:
 
 private:
     template<class BinaryFunction, unsigned int BlockSize_ = BlockSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto inclusive_scan_impl(const unsigned int flat_tid,
                              T input,
                              T& output,
@@ -524,7 +524,7 @@ private:
 
     // When BlockSize is less than warp_size we dont need the extra prefix calculations.
     template<class BinaryFunction, unsigned int BlockSize_ = BlockSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto inclusive_scan_impl(unsigned int flat_tid,
                              T input,
                              T& output,
@@ -550,7 +550,7 @@ private:
 
     // Exclusive scan with initial value when BlockSize is bigger than warp_size
     template<class BinaryFunction, unsigned int BlockSize_ = BlockSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto exclusive_scan_impl(const unsigned int flat_tid,
                              T input,
                              T& output,
@@ -590,7 +590,7 @@ private:
     // Exclusive scan with initial value when BlockSize is less than warp_size.
     // When BlockSize is less than warp_size we dont need the extra prefix calculations.
     template<class BinaryFunction, unsigned int BlockSize_ = BlockSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto exclusive_scan_impl(const unsigned int flat_tid,
                              T input,
                              T& output,
@@ -626,7 +626,7 @@ private:
 
     // Exclusive scan with unknown initial value
     template<class BinaryFunction, unsigned int BlockSize_ = BlockSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto exclusive_scan_impl(const unsigned int flat_tid,
                              T input,
                              T& output,
@@ -662,7 +662,7 @@ private:
     // Exclusive scan with unknown initial value, when BlockSize less than warp_size.
     // When BlockSize is less than warp_size we dont need the extra prefix calculations.
     template<class BinaryFunction, unsigned int BlockSize_ = BlockSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto exclusive_scan_impl(const unsigned int flat_tid,
                              T input,
                              T& output,
@@ -689,7 +689,7 @@ private:
 
     // i-th warp will have its prefix stored in storage_.warp_prefixes[i-1]
     template<class BinaryFunction, unsigned int BlockSize_ = BlockSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void calculate_warp_prefixes(const unsigned int flat_tid,
                                  const unsigned int warp_id,
                                  T inclusive_input,
@@ -720,7 +720,7 @@ private:
 
     // THIS OVERWRITES storage_.warp_prefixes[warps_no_ - 1]
     template<class PrefixCallback>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     T get_block_prefix(const unsigned int flat_tid,
                        const unsigned int warp_id,
                        const T reduction,

--- a/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
@@ -64,7 +64,7 @@ public:
     using storage_type = detail::raw_storage<storage_type_<Key, Value>>;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               storage_type& storage,
               BinaryFunction compare_function)
@@ -77,7 +77,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               BinaryFunction compare_function)
     {
@@ -86,7 +86,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               Value& thread_value,
               storage_type& storage,
@@ -100,7 +100,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               Value& thread_value,
               BinaryFunction compare_function)
@@ -110,7 +110,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               storage_type& storage,
               const unsigned int size,
@@ -124,7 +124,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key,
               Value& thread_value,
               storage_type& storage,
@@ -139,7 +139,7 @@ public:
     }
 
 private:
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void copy_to_shared(Key& k, const unsigned int flat_tid, storage_type& storage)
     {
         storage_type_<Key, Value>& storage_ = storage.get();
@@ -147,7 +147,7 @@ private:
         ::rocprim::syncthreads();
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void copy_to_shared(Key& k, Value& v, const unsigned int flat_tid, storage_type& storage)
     {
         storage_type_<Key, Value>& storage_ = storage.get();
@@ -157,7 +157,7 @@ private:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void swap(Key& key,
               const unsigned int flat_tid,
               const unsigned int next_id,
@@ -176,7 +176,7 @@ private:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void swap(Key& key,
               Value& value,
               const unsigned int flat_tid,
@@ -202,7 +202,7 @@ private:
         class BinaryFunction,
         class... KeyValue
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<(Size <= ::rocprim::device_warp_size())>::type
     sort_power_two(const unsigned int flat_tid,
                    storage_type& storage,
@@ -217,7 +217,7 @@ private:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void warp_swap(Key& k, Value& v, int mask, bool dir, BinaryFunction compare_function)
     {
         Key k1    = warp_shuffle_xor(k, mask);
@@ -230,7 +230,7 @@ private:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void warp_swap(Key& k, int mask, bool dir, BinaryFunction compare_function)
     {
         Key k1    = warp_shuffle_xor(k, mask);
@@ -246,7 +246,7 @@ private:
         class BinaryFunction,
         class... KeyValue
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<(Size > ::rocprim::device_warp_size())>::type
     sort_power_two(const unsigned int flat_tid,
                    storage_type& storage,
@@ -292,7 +292,7 @@ private:
         class BinaryFunction,
         class... KeyValue
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<detail::is_power_of_two(Size)>::type
     sort_impl(const unsigned int flat_tid,
               storage_type& storage,
@@ -315,7 +315,7 @@ private:
         class BinaryFunction,
         class... KeyValue
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<!detail::is_power_of_two(Size)>::type
     sort_impl(const unsigned int flat_tid,
               storage_type& storage,
@@ -348,7 +348,7 @@ private:
         class BinaryFunction,
         class... KeyValue
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_impl(const unsigned int flat_tid,
                    const unsigned int size,
                    storage_type& storage,

--- a/rocprim/include/rocprim/config.hpp
+++ b/rocprim/include/rocprim/config.hpp
@@ -48,6 +48,14 @@
     #ifndef ROCPRIM_DEFAULT_MIN_WARPS_PER_EU
         #define ROCPRIM_DEFAULT_MIN_WARPS_PER_EU 1
     #endif
+    // Currently HIP on Windows has a bug involving inline device functions generating
+    // local memory/register allocation errors during compilation.  Current workaround is to
+    // use __attribute__((always_inline)) for the affected functions
+    #ifdef WIN32
+      #define ROCPRIM_INLINE inline __attribute__((always_inline))
+    #else
+      #define ROCPRIM_INLINE inline
+    #endif    
 #endif
 
 #if ( defined(__gfx801__) || \

--- a/rocprim/include/rocprim/detail/binary_op_wrappers.hpp
+++ b/rocprim/include/rocprim/detail/binary_op_wrappers.hpp
@@ -120,7 +120,7 @@ struct inequality_wrapper
     {}
 
     template<class T, class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const T &a, const U &b)
     {
         return !equality_op(a, b);

--- a/rocprim/include/rocprim/detail/radix_sort.hpp
+++ b/rocprim/include/rocprim/detail/radix_sort.hpp
@@ -42,13 +42,13 @@ struct radix_key_codec_integral<Key, BitKey, typename std::enable_if<::rocprim::
 {
     using bit_key_type = BitKey;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     static bit_key_type encode(Key key)
     {
         return *reinterpret_cast<bit_key_type *>(&key);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     static Key decode(bit_key_type bit_key)
     {
         return *reinterpret_cast<Key *>(&bit_key);
@@ -62,13 +62,13 @@ struct radix_key_codec_integral<Key, BitKey, typename std::enable_if<::rocprim::
 
     static constexpr bit_key_type sign_bit = bit_key_type(1) << (sizeof(bit_key_type) * 8 - 1);
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     static bit_key_type encode(Key key)
     {
         return sign_bit ^ *reinterpret_cast<bit_key_type *>(&key);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     static Key decode(bit_key_type bit_key)
     {
         bit_key ^= sign_bit;
@@ -83,7 +83,7 @@ struct radix_key_codec_floating
 
     static constexpr bit_key_type sign_bit = bit_key_type(1) << (sizeof(bit_key_type) * 8 - 1);
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     static bit_key_type encode(Key key)
     {
         bit_key_type bit_key = *reinterpret_cast<bit_key_type *>(&key);
@@ -91,7 +91,7 @@ struct radix_key_codec_floating
         return bit_key;
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     static Key decode(bit_key_type bit_key)
     {
         bit_key ^= (sign_bit & bit_key) == 0 ? bit_key_type(-1) : sign_bit;
@@ -117,13 +117,13 @@ struct radix_key_codec_base<bool>
 {
     using bit_key_type = unsigned char;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     static bit_key_type encode(bool key)
     {
         return static_cast<bit_key_type>(key);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     static bool decode(bit_key_type bit_key)
     {
         return static_cast<bool>(bit_key);
@@ -150,14 +150,14 @@ class radix_key_codec : protected radix_key_codec_base<Key>
 public:
     using bit_key_type = typename base_type::bit_key_type;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     static bit_key_type encode(Key key)
     {
         bit_key_type bit_key = base_type::encode(key);
         return (Descending ? ~bit_key : bit_key);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     static Key decode(bit_key_type bit_key)
     {
         bit_key = (Descending ? ~bit_key : bit_key);

--- a/rocprim/include/rocprim/detail/various.hpp
+++ b/rocprim/include/rocprim/detail/various.hpp
@@ -159,7 +159,7 @@ struct match_fundamental_type
 };
 
 template<class T>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto store_volatile(T * output, T value)
     -> typename std::enable_if<std::is_fundamental<T>::value>::type
 {
@@ -173,7 +173,7 @@ auto store_volatile(T * output, T value)
 }
 
 template<class T>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto store_volatile(T * output, T value)
     -> typename std::enable_if<!std::is_fundamental<T>::value>::type
 {
@@ -191,7 +191,7 @@ auto store_volatile(T * output, T value)
 }
 
 template<class T>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto load_volatile(T * input)
     -> typename std::enable_if<std::is_fundamental<T>::value, T>::type
 {
@@ -206,7 +206,7 @@ auto load_volatile(T * input)
 }
 
 template<class T>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto load_volatile(T * input)
     -> typename std::enable_if<!std::is_fundamental<T>::value, T>::type
 {

--- a/rocprim/include/rocprim/device/detail/device_binary_search.hpp
+++ b/rocprim/include/rocprim/device/detail/device_binary_search.hpp
@@ -27,7 +27,7 @@ namespace detail
 {
 
 template<class Size>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 Size get_binary_search_middle(Size left, Size right)
 {
     // Instead of `/ 2` we use `* 33 / 64`, i.e. the middle is slightly moved.
@@ -41,7 +41,7 @@ Size get_binary_search_middle(Size left, Size right)
 }
 
 template<class RandomAccessIterator, class Size, class T, class BinaryPredicate>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 Size lower_bound_n(RandomAccessIterator first,
                    Size size,
                    const T& value,
@@ -65,7 +65,7 @@ Size lower_bound_n(RandomAccessIterator first,
 }
 
 template<class RandomAccessIterator, class Size, class T, class BinaryPredicate>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 Size upper_bound_n(RandomAccessIterator first,
                    Size size,
                    const T& value,
@@ -91,7 +91,7 @@ Size upper_bound_n(RandomAccessIterator first,
 struct lower_bound_search_op
 {
     template<class HaystackIterator, class CompareOp, class Size, class T>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     Size operator()(HaystackIterator haystack, Size size, const T& value, CompareOp compare_op) const
     {
         return lower_bound_n(haystack, size, value, compare_op);
@@ -101,7 +101,7 @@ struct lower_bound_search_op
 struct upper_bound_search_op
 {
     template<class HaystackIterator, class CompareOp, class Size, class T>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     Size operator()(HaystackIterator haystack, Size size, const T& value, CompareOp compare_op) const
     {
         return upper_bound_n(haystack, size, value, compare_op);
@@ -111,7 +111,7 @@ struct upper_bound_search_op
 struct binary_search_op
 {
     template<class HaystackIterator, class CompareOp, class Size, class T>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(HaystackIterator haystack, Size size, const T& value, CompareOp compare_op) const
     {
         const Size n = lower_bound_n(haystack, size, value, compare_op);

--- a/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -245,7 +245,7 @@ template<
     unsigned int Channels,
     class Sample
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<is_sample_vectorizable<ItemsPerThread, Channels, Sample>::value>::type
 load_samples(unsigned int flat_id,
              Sample * samples,
@@ -278,7 +278,7 @@ template<
     unsigned int Channels,
     class Sample
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<!is_sample_vectorizable<ItemsPerThread, Channels, Sample>::value>::type
 load_samples(unsigned int flat_id,
              Sample * samples,
@@ -298,7 +298,7 @@ template<
     class Sample,
     class SampleIterator
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void load_samples(unsigned int flat_id,
                   SampleIterator samples,
                   sample_vector<Sample, Channels> (&values)[ItemsPerThread])
@@ -325,7 +325,7 @@ template<
     class Sample,
     class SampleIterator
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void load_samples(unsigned int flat_id,
                   SampleIterator samples,
                   sample_vector<Sample, Channels> (&values)[ItemsPerThread],
@@ -352,7 +352,7 @@ template<
     unsigned int ActiveChannels,
     class Counter
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void init_histogram(fixed_array<Counter *, ActiveChannels> histogram,
                     fixed_array<unsigned int, ActiveChannels> bins)
 {
@@ -378,7 +378,7 @@ template<
     class Counter,
     class SampleToBinOp
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void histogram_shared(SampleIterator samples,
                       unsigned int columns,
                       unsigned int rows,
@@ -485,7 +485,7 @@ template<
     class Counter,
     class SampleToBinOp
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void histogram_global(SampleIterator samples,
                       unsigned int columns,
                       unsigned int row_stride,

--- a/rocprim/include/rocprim/device/detail/device_merge.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge.hpp
@@ -45,20 +45,20 @@ struct range_t
     unsigned int begin2;
     unsigned int end2;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int count1()
     {
         return end1 - begin1;
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int count2()
     {
         return end2 - begin2;
     }
 };
 
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 range_t compute_range(const unsigned int id,
                       const unsigned int size1,
                       const unsigned int size2,
@@ -77,7 +77,7 @@ template<
     class KeysInputIterator2,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int merge_path(KeysInputIterator1 keys_input1,
                         KeysInputIterator2 keys_input2,
                         const size_t input1_size,
@@ -115,7 +115,7 @@ template<
     class KeysInputIterator2,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void partition_kernel_impl(IndexIterator indices,
                            KeysInputIterator1 keys_input1,
                            KeysInputIterator2 keys_input2,
@@ -153,7 +153,7 @@ template<
     class KeysInputIterator2,
     class KeyType
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void load(unsigned int flat_id,
           KeysInputIterator1 keys_input1,
           KeysInputIterator2 keys_input2,
@@ -183,7 +183,7 @@ template<
     unsigned int ItemsPerThread,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void serial_merge(KeyType * keys_shared,
                   KeyType (&inputs)[ItemsPerThread],
                   unsigned int (&index)[ItemsPerThread],
@@ -226,7 +226,7 @@ template<
     unsigned int ItemsPerThread,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void merge_keys(unsigned int flat_id,
                 KeysInputIterator1 keys_input1,
                 KeysInputIterator2 keys_input2,
@@ -280,7 +280,7 @@ template<
     class ValuesOutputIterator,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<WithValues>::type
 merge_values(unsigned int flat_id,
              ValuesInputIterator1 values_input1,
@@ -336,7 +336,7 @@ template<
     class ValuesOutputIterator,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<!WithValues>::type
 merge_values(unsigned int flat_id,
              ValuesInputIterator1 values_input1,
@@ -367,7 +367,7 @@ template<
     class ValuesOutputIterator,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void merge_kernel_impl(IndexIterator indices,
                        KeysInputIterator1 keys_input1,
                        KeysInputIterator2 keys_input2,

--- a/rocprim/include/rocprim/device/detail/device_merge_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge_sort.hpp
@@ -46,7 +46,7 @@ template<
     class Key,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_load_keys_impl(const unsigned int flat_id,
                           const unsigned int block_offset,
                           const unsigned int valid_in_last_block,
@@ -81,7 +81,7 @@ template<
     class Value,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<!WithValues>::type
 block_load_values_impl(const unsigned int flat_id,
                        const unsigned int block_offset,
@@ -105,7 +105,7 @@ template<
     class Value,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<WithValues>::type
 block_load_values_impl(const unsigned int flat_id,
                        const unsigned int block_offset,
@@ -143,7 +143,7 @@ template<
     class Value,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<!WithValues>::type
 block_store_impl(const unsigned int flat_id,
                  const unsigned int block_offset,
@@ -185,7 +185,7 @@ template<
     class Value,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<WithValues>::type
 block_store_impl(const unsigned int flat_id,
                  const unsigned int block_offset,
@@ -233,7 +233,7 @@ template<
     class Key,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_sort_impl(Key& key,
                      const unsigned int valid_in_last_block,
                      const bool last_block,
@@ -274,7 +274,7 @@ template<
     class ValuesOutputIterator,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_sort_kernel_impl(KeysInputIterator keys_input,
                             KeysOutputIterator keys_output,
                             ValuesInputIterator values_input,
@@ -353,7 +353,7 @@ template<
     class ValuesOutputIterator,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_merge_kernel_impl(KeysInputIterator keys_input,
                              KeysOutputIterator keys_output,
                              ValuesInputIterator values_input,

--- a/rocprim/include/rocprim/device/detail/device_partition.hpp
+++ b/rocprim/include/rocprim/device/detail/device_partition.hpp
@@ -56,7 +56,7 @@ public:
         T exclusive_prefix;
     };
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     offset_lookback_scan_prefix_op(unsigned int block_id,
                                    LookbackScanState &state,
                                    storage_type& storage)
@@ -64,10 +64,10 @@ public:
     {
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     ~offset_lookback_scan_prefix_op() = default;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     T operator()(T reduction)
     {
         auto prefix = base_type::operator()(reduction);
@@ -79,13 +79,13 @@ public:
         return prefix;
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     T get_reduction() const
     {
         return storage_.block_reduction;
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     T get_exclusive_prefix() const
     {
         return storage_.exclusive_prefix;
@@ -115,7 +115,7 @@ template<
     class InequalityOp,
     class StorageType
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto partition_block_load_flags(InputIterator /* block_predecessor */,
                                 FlagIterator block_flags,
                                 ValueType (&/* values */)[ItemsPerThread],
@@ -165,7 +165,7 @@ template<
     class InequalityOp,
     class StorageType
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto partition_block_load_flags(InputIterator /* block_predecessor */,
                                 FlagIterator /* block_flags */,
                                 ValueType (&values)[ItemsPerThread],
@@ -213,13 +213,13 @@ struct guarded_inequality_op
     InequalityOp inequality_op;
     unsigned int valid_count;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     guarded_inequality_op(InequalityOp inequality_op, unsigned int valid_count)
         : inequality_op(inequality_op), valid_count(valid_count)
     {}
 
     template<class T, class U>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const T& a, const U& b, unsigned int b_index)
     {
         return (b_index < valid_count && inequality_op(a, b));
@@ -239,7 +239,7 @@ template<
     class InequalityOp,
     class StorageType
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto partition_block_load_flags(InputIterator block_predecessor,
                                 FlagIterator /* block_flags */,
                                 ValueType (&values)[ItemsPerThread],
@@ -335,7 +335,7 @@ template<
     class OutputIterator,
     class ScatterStorageType
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto partition_scatter(ValueType (&values)[ItemsPerThread],
                        bool (&is_selected)[ItemsPerThread],
                        OffsetType (&output_indices)[ItemsPerThread],
@@ -396,7 +396,7 @@ template<
     class OutputIterator,
     class ScatterStorageType
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto partition_scatter(ValueType (&values)[ItemsPerThread],
                        bool (&is_selected)[ItemsPerThread],
                        OffsetType (&output_indices)[ItemsPerThread],
@@ -466,7 +466,7 @@ template<
     class InequalityOp,
     class OffsetLookbackScanState
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void partition_kernel_impl(InputIterator input,
                            FlagIterator flags,
                            OutputIterator output,

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -47,7 +47,7 @@ namespace detail
 // Wrapping functions that allow to call proper methods (with or without values)
 // (a variant with values is enabled only when Value is not empty_type)
 template<bool Descending = false, class SortType, class SortKey, class SortValue, unsigned int ItemsPerThread>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void sort_block(SortType sorter,
                 SortKey (&keys)[ItemsPerThread],
                 SortValue (&values)[ItemsPerThread],
@@ -66,7 +66,7 @@ void sort_block(SortType sorter,
 }
 
 template<bool Descending = false, class SortType, class SortKey, unsigned int ItemsPerThread>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void sort_block(SortType sorter,
                 SortKey (&keys)[ItemsPerThread],
                 ::rocprim::empty_type (&values)[ItemsPerThread],
@@ -107,7 +107,7 @@ struct radix_digit_count_helper
     };
 
     template<bool IsFull = false, class KeysInputIterator>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void count_digits(KeysInputIterator keys_input,
                       unsigned int begin_offset,
                       unsigned int end_offset,
@@ -231,7 +231,7 @@ struct radix_sort_single_helper
         class ValuesInputIterator,
         class ValuesOutputIterator
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_single(KeysInputIterator keys_input,
                      KeysOutputIterator keys_output,
                      ValuesInputIterator values_input,
@@ -352,7 +352,7 @@ struct radix_sort_and_scatter_helper
         class ValuesInputIterator,
         class ValuesOutputIterator
     >
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_and_scatter(KeysInputIterator keys_input,
                           KeysOutputIterator keys_output,
                           ValuesInputIterator values_input,
@@ -492,7 +492,7 @@ template<
     bool Descending,
     class KeysInputIterator
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void fill_digit_counts(KeysInputIterator keys_input,
                        unsigned int size,
                        unsigned int * batch_digit_counts,
@@ -558,7 +558,7 @@ template<
     unsigned int ItemsPerThread,
     unsigned int RadixBits
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void scan_batches(unsigned int * batch_digit_counts,
                   unsigned int * digit_counts,
                   unsigned int batches)
@@ -596,7 +596,7 @@ void scan_batches(unsigned int * batch_digit_counts,
 }
 
 template<unsigned int RadixBits>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void scan_digits(unsigned int * digit_counts)
 {
     constexpr unsigned int radix_size = 1 << RadixBits;
@@ -619,7 +619,7 @@ template<
     class ValuesInputIterator,
     class ValuesOutputIterator
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void sort_single(KeysInputIterator keys_input,
                  KeysOutputIterator keys_output,
                  ValuesInputIterator values_input,
@@ -655,7 +655,7 @@ template<
     class ValuesInputIterator,
     class ValuesOutputIterator
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void sort_and_scatter(KeysInputIterator keys_input,
                       KeysOutputIterator keys_output,
                       ValuesInputIterator values_input,
@@ -734,7 +734,7 @@ template<
     class Value,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<!WithValues>::type
 block_load_radix_impl(const unsigned int flat_id,
                       const unsigned int block_offset,
@@ -775,7 +775,7 @@ template<
     class Value,
     unsigned int ItemsPerThread
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<WithValues>::type
 block_load_radix_impl(const unsigned int flat_id,
                  const unsigned int block_offset,
@@ -828,7 +828,7 @@ struct radix_merge_compare;
 template<class T>
 struct radix_merge_compare<false, false, T>
 {
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const T& a, const T& b) const
     {
         return b > a;
@@ -838,7 +838,7 @@ struct radix_merge_compare<false, false, T>
 template<class T>
 struct radix_merge_compare<true, false, T>
 {
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const T& a, const T& b) const
     {
         return a > b;
@@ -860,7 +860,7 @@ struct radix_merge_compare<false, true, T>
         radix_mask = radix_mask_upper ^ radix_mask_bottom;
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const T& a, const T& b) const
     {
         const bit_key_type encoded_key_a = key_codec::encode(a);
@@ -889,7 +889,7 @@ struct radix_merge_compare<true, true, T>
     }
 
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const T& a, const T& b) const
     {
         const bit_key_type encoded_key_a = key_codec::encode(a);
@@ -905,7 +905,7 @@ struct radix_merge_compare<true, true, T>
 template<>
 struct radix_merge_compare<false, false, rocprim::half>
 {
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const rocprim::half& a, const rocprim::half& b) const
     {
         return __hgt(b, a);
@@ -915,7 +915,7 @@ struct radix_merge_compare<false, false, rocprim::half>
 template<>
 struct radix_merge_compare<true, false, rocprim::half>
 {
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const rocprim::half& a, const rocprim::half& b) const
     {
         return __hgt(a, b);
@@ -937,7 +937,7 @@ struct radix_merge_compare<false, true, rocprim::half>
         radix_mask = radix_mask_upper ^ radix_mask_bottom;
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const rocprim::half& a, const rocprim::half& b) const
     {
         const bit_key_type encoded_key_a = key_codec::encode(a);
@@ -966,7 +966,7 @@ struct radix_merge_compare<true, true, rocprim::half>
     }
 
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const rocprim::half& a, const rocprim::half& b) const
     {
         const bit_key_type encoded_key_a = key_codec::encode(a);
@@ -988,7 +988,7 @@ template<
     class ValuesOutputIterator,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void radix_block_merge_impl(KeysInputIterator keys_input,
                             KeysOutputIterator keys_output,
                             ValuesInputIterator values_input,

--- a/rocprim/include/rocprim/device/detail/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/detail/device_reduce.hpp
@@ -46,7 +46,7 @@ template<
     class T,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto reduce_with_initial(T output,
                          T initial_value,
                          BinaryFunction reduce_op)
@@ -60,7 +60,7 @@ template<
     class T,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto reduce_with_initial(T output,
                          T initial_value,
                          BinaryFunction reduce_op)
@@ -80,7 +80,7 @@ template<
     class InitValueType,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_reduce_kernel_impl(InputIterator input,
                               const size_t input_size,
                               OutputIterator output,

--- a/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
+++ b/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
@@ -44,13 +44,13 @@ namespace detail
 template<class Value>
 struct carry_out
 {
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     carry_out() = default;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     carry_out(const carry_out& rhs) = default;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     carry_out& operator=(const carry_out& rhs)
     {
         value = rhs.value;
@@ -67,13 +67,13 @@ struct carry_out
 template<class Value>
 struct scan_by_key_pair
 {
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     scan_by_key_pair() = default;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     scan_by_key_pair(const scan_by_key_pair& rhs) = default;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     scan_by_key_pair& operator=(const scan_by_key_pair& rhs)
     {
         key = rhs.key;
@@ -94,12 +94,12 @@ struct scan_by_key_op
 {
     BinaryFunction reduce_op;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     scan_by_key_op(BinaryFunction reduce_op)
         : reduce_op(reduce_op)
     {}
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     Pair operator()(const Pair& a, const Pair& b)
     {
         Pair c;
@@ -118,12 +118,12 @@ struct key_flag_op
 {
     KeyCompareFunction key_compare_op;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     key_flag_op(KeyCompareFunction key_compare_op)
         : key_compare_op(key_compare_op)
     {}
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const Key& a, const Key& b)
     {
         return !key_compare_op(a, b);
@@ -138,12 +138,12 @@ struct guarded_key_flag_op
     KeyCompareFunction key_compare_op;
     unsigned int valid_count;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     guarded_key_flag_op(KeyCompareFunction key_compare_op, unsigned int valid_count)
         : key_compare_op(key_compare_op), valid_count(valid_count)
     {}
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const Key& a, const Key& b, unsigned int b_index)
     {
         return (b_index < valid_count && !key_compare_op(a, b)) || b_index == valid_count;
@@ -156,7 +156,7 @@ template<
     class KeysInputIterator,
     class KeyCompareFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void fill_unique_counts(KeysInputIterator keys_input,
                         unsigned int size,
                         unsigned int * unique_counts,
@@ -278,7 +278,7 @@ template<
     unsigned int ItemsPerThread,
     class UniqueCountOutputIterator
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void scan_unique_counts(unsigned int * unique_counts,
                         UniqueCountOutputIterator unique_count_output,
                         unsigned int batches)
@@ -327,7 +327,7 @@ template<
     class KeyCompareFunction,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void reduce_by_key(KeysInputIterator keys_input,
                    ValuesInputIterator values_input,
                    unsigned int size,
@@ -561,7 +561,7 @@ template<
     class AggregatesOutputIterator,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void scan_and_scatter_carry_outs(const carry_out<Result> * carry_outs,
                                  const Result * leading_aggregates,
                                  AggregatesOutputIterator aggregates_output,

--- a/rocprim/include/rocprim/device/detail/device_scan_lookback.hpp
+++ b/rocprim/include/rocprim/device/detail/device_scan_lookback.hpp
@@ -46,7 +46,7 @@ namespace detail
 {
 
 template<class LookBackScanState>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void init_lookback_scan_state_kernel_impl(LookBackScanState lookback_scan_state,
                                           const unsigned int number_of_blocks,
                                           ordered_block_id<unsigned int> ordered_bid)
@@ -72,7 +72,7 @@ template<
     unsigned int ItemsPerThread,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto lookback_block_scan(T (&values)[ItemsPerThread],
                          T /* initial_value */,
                          T& reduction,
@@ -97,7 +97,7 @@ template<
     unsigned int ItemsPerThread,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto lookback_block_scan(T (&values)[ItemsPerThread],
                          T initial_value,
                          T& reduction,
@@ -125,7 +125,7 @@ template<
     class PrefixCallback,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto lookback_block_scan(T (&values)[ItemsPerThread],
                          typename BlockScan::storage_type& storage,
                          PrefixCallback& prefix_callback_op,
@@ -150,7 +150,7 @@ template<
     class PrefixCallback,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto lookback_block_scan(T (&values)[ItemsPerThread],
                          typename BlockScan::storage_type& storage,
                          PrefixCallback& prefix_callback_op,
@@ -176,7 +176,7 @@ template<
     class ResultType,
     class LookbackScanState
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void lookback_scan_kernel_impl(InputIterator input,
                                OutputIterator output,
                                const size_t size,

--- a/rocprim/include/rocprim/device/detail/device_scan_reduce_then_scan.hpp
+++ b/rocprim/include/rocprim/device/detail/device_scan_reduce_then_scan.hpp
@@ -51,7 +51,7 @@ template<
     unsigned int ItemsPerThread,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto single_scan_block_scan(T (&input)[ItemsPerThread],
                             T (&output)[ItemsPerThread],
                             T initial_value,
@@ -76,7 +76,7 @@ template<
     unsigned int ItemsPerThread,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto single_scan_block_scan(T (&input)[ItemsPerThread],
                             T (&output)[ItemsPerThread],
                             T initial_value,
@@ -102,7 +102,7 @@ template<
     class BinaryFunction,
     class ResultType
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void single_scan_kernel_impl(InputIterator input,
                              const size_t input_size,
                              ResultType initial_value,
@@ -173,7 +173,7 @@ template<
     class BinaryFunction,
     class ResultType
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void block_reduce_kernel_impl(InputIterator input,
                               BinaryFunction scan_op,
                               ResultType * block_prefixes)
@@ -238,7 +238,7 @@ template<
     class ResultType,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto final_scan_block_scan(const unsigned int flat_block_id,
                            T (&input)[ItemsPerThread],
                            T (&output)[ItemsPerThread],
@@ -273,7 +273,7 @@ template<
     class ResultType,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto final_scan_block_scan(const unsigned int flat_block_id,
                            T (&input)[ItemsPerThread],
                            T (&output)[ItemsPerThread],
@@ -320,7 +320,7 @@ template<
     class BinaryFunction,
     class ResultType
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void final_scan_kernel_impl(InputIterator input,
                             const size_t input_size,
                             OutputIterator output,

--- a/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
@@ -39,14 +39,6 @@
 
 BEGIN_ROCPRIM_NAMESPACE
 
-// Currently HIP on Windows has a bug involving inline device functions generating
-// local memory/register allocation errors during compilation.  Current workaround is to
-// use __attribute__((always_inline)) for the affected functions
-#ifdef WIN32
-#define ROCPRIM_SEGMENTED_RADIX_SORT_INLINE inline __attribute__((always_inline))
-#else
-#define ROCPRIM_SEGMENTED_RADIX_SORT_INLINE inline
-#endif
 namespace detail
 {
 
@@ -86,7 +78,7 @@ public:
         class ValuesInputIterator,
         class ValuesOutputIterator
     >
-    ROCPRIM_DEVICE ROCPRIM_SEGMENTED_RADIX_SORT_INLINE
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(KeysInputIterator keys_input,
               key_type * keys_tmp,
               KeysOutputIterator keys_output,
@@ -152,7 +144,7 @@ public:
     }
 
     // When all iterators are raw pointers, this overload is used to minimize code duplication in the kernel
-    ROCPRIM_DEVICE ROCPRIM_SEGMENTED_RADIX_SORT_INLINE
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(key_type * keys_input,
               key_type * keys_tmp,
               key_type * keys_output,
@@ -227,7 +219,7 @@ private:
         class ValuesInputIterator,
         class ValuesOutputIterator
     >
-    ROCPRIM_DEVICE ROCPRIM_SEGMENTED_RADIX_SORT_INLINE
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(KeysInputIterator keys_input,
               KeysOutputIterator keys_output,
               ValuesInputIterator values_input,
@@ -312,7 +304,7 @@ public:
         class ValuesInputIterator,
         class ValuesOutputIterator
     >
-    ROCPRIM_DEVICE ROCPRIM_SEGMENTED_RADIX_SORT_INLINE
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(KeysInputIterator keys_input,
               key_type * keys_tmp,
               KeysOutputIterator keys_output,
@@ -347,7 +339,7 @@ public:
     }
 
     // When all iterators are raw pointers, this overload is used to minimize code duplication in the kernel
-    ROCPRIM_DEVICE ROCPRIM_SEGMENTED_RADIX_SORT_INLINE
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(key_type * keys_input,
               key_type * keys_tmp,
               key_type * keys_output,
@@ -375,7 +367,7 @@ public:
         class ValuesInputIterator,
         class ValuesOutputIterator
     >
-    ROCPRIM_DEVICE ROCPRIM_SEGMENTED_RADIX_SORT_INLINE
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool sort(KeysInputIterator keys_input,
               KeysOutputIterator keys_output,
               ValuesInputIterator values_input,
@@ -457,7 +449,7 @@ public:
         class ValuesInputIterator,
         class ValuesOutputIterator
     >
-    ROCPRIM_DEVICE ROCPRIM_SEGMENTED_RADIX_SORT_INLINE
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     bool sort(KeysInputIterator,
               KeysOutputIterator,
               ValuesInputIterator,
@@ -483,7 +475,7 @@ template<
     class ValuesOutputIterator,
     class OffsetIterator
 >
-ROCPRIM_DEVICE ROCPRIM_SEGMENTED_RADIX_SORT_INLINE
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void segmented_sort(KeysInputIterator keys_input,
                     typename std::iterator_traits<KeysInputIterator>::value_type * keys_tmp,
                     KeysOutputIterator keys_output,

--- a/rocprim/include/rocprim/device/detail/device_segmented_reduce.hpp
+++ b/rocprim/include/rocprim/device/detail/device_segmented_reduce.hpp
@@ -46,7 +46,7 @@ template<
     class ResultType,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void segmented_reduce(InputIterator input,
                       OutputIterator output,
                       OffsetIterator begin_offsets,

--- a/rocprim/include/rocprim/device/detail/device_segmented_scan.hpp
+++ b/rocprim/include/rocprim/device/detail/device_segmented_scan.hpp
@@ -48,7 +48,7 @@ template<
     unsigned int ItemsPerThread,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto segmented_scan_block_scan(T (&input)[ItemsPerThread],
                                T (&output)[ItemsPerThread],
                                T& prefix,
@@ -78,7 +78,7 @@ template<
     unsigned int ItemsPerThread,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto segmented_scan_block_scan(T (&input)[ItemsPerThread],
                                T (&output)[ItemsPerThread],
                                T& prefix,
@@ -119,7 +119,7 @@ template<
     class InitValueType,
     class BinaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void segmented_scan(InputIterator input,
                     OutputIterator output,
                     OffsetIterator begin_offsets,

--- a/rocprim/include/rocprim/device/detail/device_transform.hpp
+++ b/rocprim/include/rocprim/device/detail/device_transform.hpp
@@ -76,7 +76,7 @@ template<
     class OutputIterator,
     class UnaryFunction
 >
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void transform_kernel_impl(InputIterator input,
                            const size_t input_size,
                            OutputIterator output,

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -111,7 +111,7 @@ public:
         return sizeof(prefix_underlying_type) * (::rocprim::host_warp_size() + number_of_blocks);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void initialize_prefix(const unsigned int block_id,
                            const unsigned int number_of_blocks)
     {
@@ -143,20 +143,20 @@ public:
         }
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void set_partial(const unsigned int block_id, const T value)
     {
         this->set(block_id, PREFIX_PARTIAL, value);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void set_complete(const unsigned int block_id, const T value)
     {
         this->set(block_id, PREFIX_COMPLETE, value);
     }
 
     // block_id must be > 0
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void get(const unsigned int block_id, flag_type& flag, T& value)
     {
         constexpr unsigned int padding = ::rocprim::device_warp_size();
@@ -200,7 +200,7 @@ public:
     }
 
 private:
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void set(const unsigned int block_id, const flag_type flag, const T value)
     {
         constexpr unsigned int padding = ::rocprim::device_warp_size();
@@ -256,7 +256,7 @@ public:
         return size;
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void initialize_prefix(const unsigned int block_id,
                            const unsigned int number_of_blocks)
     {
@@ -271,7 +271,7 @@ public:
         }
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void set_partial(const unsigned int block_id, const T value)
     {
         constexpr unsigned int padding = ::rocprim::device_warp_size();
@@ -281,7 +281,7 @@ public:
         store_volatile<flag_type>(&prefixes_flags[padding + block_id], PREFIX_PARTIAL);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void set_complete(const unsigned int block_id, const T value)
     {
         constexpr unsigned int padding = ::rocprim::device_warp_size();
@@ -292,7 +292,7 @@ public:
     }
 
     // block_id must be > 0
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void get(const unsigned int block_id, flag_type& flag, T& value)
     {
         constexpr unsigned int padding = ::rocprim::device_warp_size();
@@ -345,7 +345,7 @@ class lookback_scan_prefix_op
     );
 
 public:
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     lookback_scan_prefix_op(unsigned int block_id,
                             BinaryFunction scan_op,
                             LookbackScanState &scan_state)
@@ -355,10 +355,10 @@ public:
     {
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     ~lookback_scan_prefix_op() = default;
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce_partial_prefixes(unsigned int block_id,
                                  flag_type& flag,
                                  T& partial_prefix)
@@ -386,7 +386,7 @@ public:
             );
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     T get_prefix()
     {
         flag_type flag;
@@ -415,7 +415,7 @@ public:
         return prefix;
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     T operator()(T reduction)
     {
         // Set partial prefix for next block

--- a/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
+++ b/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
@@ -60,13 +60,13 @@ struct ordered_block_id
         return sizeof(id_type);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reset()
     {
         *id = static_cast<id_type>(0);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     id_type get(unsigned int tid, storage_type& storage)
     {
         if(tid == 0)

--- a/rocprim/include/rocprim/intrinsics/atomic.hpp
+++ b/rocprim/include/rocprim/intrinsics/atomic.hpp
@@ -27,43 +27,43 @@ BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int atomic_add(unsigned int * address, unsigned int value)
     {
         return ::atomicAdd(address, value);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     int atomic_add(int * address, int value)
     {
         return ::atomicAdd(address, value);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     float atomic_add(float * address, float value)
     {
         return ::atomicAdd(address, value);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned long long atomic_add(unsigned long long * address, unsigned long long value)
     {
         return ::atomicAdd(address, value);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int atomic_wrapinc(unsigned int * address, unsigned int value)
     {
         return ::atomicInc(address, value);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int atomic_exch(unsigned int * address, unsigned int value)
     {
         return ::atomicExch(address, value);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned long long atomic_exch(unsigned long long * address, unsigned long long value)
     {
         return ::atomicExch(address, value);

--- a/rocprim/include/rocprim/intrinsics/bit.hpp
+++ b/rocprim/include/rocprim/intrinsics/bit.hpp
@@ -29,7 +29,7 @@ BEGIN_ROCPRIM_NAMESPACE
 /// @{
 
 /// \brief Returns a single bit at 'i' from 'x'
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 int get_bit(int x, int i)
 {
     return (x >> i) & 1;
@@ -38,7 +38,7 @@ int get_bit(int x, int i)
 /// \brief Bit count
 ///
 /// Returns the number of bit of \p x set.
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int bit_count(unsigned int x)
 {
     return __popc(x);
@@ -47,7 +47,7 @@ unsigned int bit_count(unsigned int x)
 /// \brief Bit count
 ///
 /// Returns the number of bit of \p x set.
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int bit_count(unsigned long long x)
 {
     return __popcll(x);

--- a/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -66,21 +66,21 @@ unsigned int host_warp_size()
 /// At device side this constant is available at compile time.
 ///
 /// It is constant for a device.
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 constexpr unsigned int device_warp_size()
 {
     return warpSize;
 }
 
 /// \brief Returns flat size of a multidimensional block (tile).
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int flat_block_size()
 {
     return blockDim.z * blockDim.y * blockDim.x;
 }
 
 /// \brief Returns flat size of a multidimensional tile (block).
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int flat_tile_size()
 {
     return flat_block_size();
@@ -89,7 +89,7 @@ unsigned int flat_tile_size()
 // IDs
 
 /// \brief Returns thread identifier in a warp.
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int lane_id()
 {
 #ifndef __HIP_CPU_RT__
@@ -101,7 +101,7 @@ unsigned int lane_id()
 }
 
 /// \brief Returns flat (linear, 1D) thread identifier in a multidimensional block (tile).
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int flat_block_thread_id()
 {
     return (threadIdx.z * blockDim.y * blockDim.x)
@@ -111,7 +111,7 @@ unsigned int flat_block_thread_id()
 
 /// \brief Returns flat (linear, 1D) thread identifier in a multidimensional block (tile). Use template parameters to optimize 1D or 2D kernels.
 template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSizeZ>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto flat_block_thread_id()
     -> typename std::enable_if<(BlockSizeY == 1 && BlockSizeZ == 1), unsigned int>::type
 {
@@ -119,7 +119,7 @@ auto flat_block_thread_id()
 }
 
 template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSizeZ>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto flat_block_thread_id()
     -> typename std::enable_if<(BlockSizeY > 1 && BlockSizeZ == 1), unsigned int>::type
 {
@@ -127,7 +127,7 @@ auto flat_block_thread_id()
 }
 
 template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSizeZ>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto flat_block_thread_id()
     -> typename std::enable_if<(BlockSizeY > 1 && BlockSizeZ > 1), unsigned int>::type
 {
@@ -136,20 +136,20 @@ auto flat_block_thread_id()
 }
 
 /// \brief Returns flat (linear, 1D) thread identifier in a multidimensional tile (block).
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int flat_tile_thread_id()
 {
     return flat_block_thread_id();
 }
 
 /// \brief Returns warp id in a block (tile).
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int warp_id()
 {
     return flat_block_thread_id()/device_warp_size();
 }
 
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int warp_id(unsigned int flat_id)
 {
     return flat_id/device_warp_size();
@@ -157,14 +157,14 @@ unsigned int warp_id(unsigned int flat_id)
 
 /// \brief Returns warp id in a block (tile). Use template parameters to optimize 1D or 2D kernels.
 template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSizeZ>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int warp_id()
 {
     return flat_block_thread_id<BlockSizeX, BlockSizeY, BlockSizeZ>()/device_warp_size();
 }
 
 /// \brief Returns flat (linear, 1D) block identifier in a multidimensional grid.
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int flat_block_id()
 {
     return (blockIdx.z * gridDim.y * gridDim.x)
@@ -173,7 +173,7 @@ unsigned int flat_block_id()
 }
 
 template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSizeZ>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto flat_block_id()
     -> typename std::enable_if<(BlockSizeY == 1 && BlockSizeZ == 1), unsigned int>::type
 {
@@ -181,7 +181,7 @@ auto flat_block_id()
 }
 
 template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSizeZ>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto flat_block_id()
     -> typename std::enable_if<(BlockSizeY > 1 && BlockSizeZ == 1), unsigned int>::type
 {
@@ -189,7 +189,7 @@ auto flat_block_id()
 }
 
 template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSizeZ>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto flat_block_id()
     -> typename std::enable_if<(BlockSizeY > 1 && BlockSizeZ > 1), unsigned int>::type
 {
@@ -200,7 +200,7 @@ auto flat_block_id()
 // Sync
 
 /// \brief Synchronize all threads in a block (tile)
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void syncthreads()
 {
     __syncthreads();
@@ -208,7 +208,7 @@ void syncthreads()
 
 /// \brief All lanes in a wave come to convergence point simultaneously
 /// with SIMT, thus no special instruction is needed in the ISA
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 void wave_barrier()
 {
     __builtin_amdgcn_wave_barrier();
@@ -218,7 +218,7 @@ namespace detail
 {
     /// \brief Returns thread identifier in a multidimensional block (tile) by dimension.
     template<unsigned int Dim>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int block_thread_id()
     {
         static_assert(Dim > 2, "Dim must be 0, 1 or 2");
@@ -228,7 +228,7 @@ namespace detail
 
     /// \brief Returns block identifier in a multidimensional grid by dimension.
     template<unsigned int Dim>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int block_id()
     {
         static_assert(Dim > 2, "Dim must be 0, 1 or 2");
@@ -238,7 +238,7 @@ namespace detail
 
     /// \brief Returns block size in a multidimensional grid by dimension.
     template<unsigned int Dim>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int block_size()
     {
         static_assert(Dim > 2, "Dim must be 0, 1 or 2");
@@ -248,7 +248,7 @@ namespace detail
 
     /// \brief Returns grid size by dimension.
     template<unsigned int Dim>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int grid_size()
     {
         static_assert(Dim > 2, "Dim must be 0, 1 or 2");
@@ -259,7 +259,7 @@ namespace detail
     #define ROCPRIM_DETAIL_CONCAT(A, B) A B
     #define ROCPRIM_DETAIL_DEFINE_HIP_API_ID_FUNC(name, prefix, dim, suffix) \
         template<> \
-        ROCPRIM_DEVICE inline \
+        ROCPRIM_DEVICE ROCPRIM_INLINE \
         unsigned int name<dim>() \
         { \
             return ROCPRIM_DETAIL_CONCAT(prefix, suffix); \
@@ -280,7 +280,7 @@ namespace detail
 
     // Return thread id in a "logical warp", which can be smaller than a hardware warp size.
     template<unsigned int LogicalWarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto logical_lane_id()
         -> typename std::enable_if<detail::is_power_of_two(LogicalWarpSize), unsigned int>::type
     {
@@ -288,7 +288,7 @@ namespace detail
     }
 
     template<unsigned int LogicalWarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto logical_lane_id()
         -> typename std::enable_if<!detail::is_power_of_two(LogicalWarpSize), unsigned int>::type
     {
@@ -296,7 +296,7 @@ namespace detail
     }
 
     template<>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int logical_lane_id<device_warp_size()>()
     {
         return lane_id();
@@ -304,32 +304,32 @@ namespace detail
 
     // Return id of "logical warp" in a block
     template<unsigned int LogicalWarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int logical_warp_id()
     {
         return flat_block_thread_id()/LogicalWarpSize;
     }
 
     template<>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int logical_warp_id<device_warp_size()>()
     {
         return warp_id();
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void memory_fence_system()
     {
         ::__threadfence_system();
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void memory_fence_block()
     {
         ::__threadfence_block();
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void memory_fence_device()
     {
         ::__threadfence();

--- a/rocprim/include/rocprim/intrinsics/warp.hpp
+++ b/rocprim/include/rocprim/intrinsics/warp.hpp
@@ -33,7 +33,7 @@ BEGIN_ROCPRIM_NAMESPACE
 /// for the <tt>i</tt>-th thread of the warp and the <tt>i</tt>-th thread is active.
 ///
 /// \param predicate - input to be evaluated for all active lanes
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 lane_mask_type ballot(int predicate)
 {
     return ::__ballot(predicate);
@@ -43,7 +43,7 @@ lane_mask_type ballot(int predicate)
 ///
 /// For each thread, this function returns the number of active threads which
 /// have <tt>i</tt>-th bit of \p x set and come before the current thread.
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int masked_bit_count(lane_mask_type x, unsigned int add = 0)
 {
     int c;
@@ -75,7 +75,7 @@ unsigned int masked_bit_count(lane_mask_type x, unsigned int add = 0)
 namespace detail
 {
 
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 int warp_any(int predicate)
 {
 #ifndef __HIP_CPU_RT__
@@ -93,7 +93,7 @@ int warp_any(int predicate)
 #endif
 }
 
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 int warp_all(int predicate)
 {
 #ifndef __HIP_CPU_RT__
@@ -121,7 +121,7 @@ int warp_all(int predicate)
  * LABEL_BITS of \p label as the calling thread.
  */
 template <int LABEL_BITS>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int MatchAny(unsigned int label)
 {
     unsigned int retval;

--- a/rocprim/include/rocprim/intrinsics/warp_shuffle.hpp
+++ b/rocprim/include/rocprim/intrinsics/warp_shuffle.hpp
@@ -55,7 +55,7 @@ bit_cast(const From& src) noexcept
 #endif
 
 template<class T, class ShuffleOp>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<std::is_trivially_copyable<T>::value && (sizeof(T) % sizeof(int) == 0), T>::type
 warp_shuffle_op(const T& input, ShuffleOp&& op)
 {
@@ -82,7 +82,7 @@ warp_shuffle_op(const T& input, ShuffleOp&& op)
 }
 
 template<class T, class ShuffleOp>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::enable_if<!(std::is_trivially_copyable<T>::value && (sizeof(T) % sizeof(int) == 0)), T>::type
 warp_shuffle_op(const T& input, ShuffleOp&& op)
 {
@@ -112,7 +112,7 @@ warp_shuffle_op(const T& input, ShuffleOp&& op)
 }
 
 template<class T, int dpp_ctrl, int row_mask = 0xf, int bank_mask = 0xf, bool bound_ctrl = false>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 T warp_move_dpp(const T& input)
 {
     return detail::warp_shuffle_op(
@@ -151,7 +151,7 @@ T warp_move_dpp(const T& input)
 /// \param src_lane - warp if of a thread whose \p input should be returned
 /// \param width - logical warp width
 template<class T>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 T warp_shuffle(const T& input, const int src_lane, const int width = device_warp_size())
 {
     return detail::warp_shuffle_op(
@@ -176,7 +176,7 @@ T warp_shuffle(const T& input, const int src_lane, const int width = device_warp
 /// \param delta - offset for calculating source lane id
 /// \param width - logical warp width
 template<class T>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 T warp_shuffle_up(const T& input, const unsigned int delta, const int width = device_warp_size())
 {
     return detail::warp_shuffle_op(
@@ -201,7 +201,7 @@ T warp_shuffle_up(const T& input, const unsigned int delta, const int width = de
 /// \param delta - offset for calculating source lane id
 /// \param width - logical warp width
 template<class T>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 T warp_shuffle_down(const T& input, const unsigned int delta, const int width = device_warp_size())
 {
     return detail::warp_shuffle_op(
@@ -225,7 +225,7 @@ T warp_shuffle_down(const T& input, const unsigned int delta, const int width = 
 /// \param lane_mask - mask used for calculating source lane id
 /// \param width - logical warp width
 template<class T>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 T warp_shuffle_xor(const T& input, const int lane_mask, const int width = device_warp_size())
 {
     return detail::warp_shuffle_op(

--- a/rocprim/include/rocprim/thread/thread_load.hpp
+++ b/rocprim/include/rocprim/thread/thread_load.hpp
@@ -112,7 +112,7 @@ ROCPRIM_ASM_THREAD_LOAD_GROUP(load_cs, "", "");
 template <
     cache_load_modifier MODIFIER = load_default,
     typename InputIteratorT>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 typename std::iterator_traits<InputIteratorT>::value_type
 thread_load(InputIteratorT itr)
 {
@@ -129,7 +129,7 @@ thread_load(InputIteratorT itr)
 template <
     cache_load_modifier MODIFIER = load_default,
     typename T>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 T thread_load(T* ptr)
 {
 #ifndef __HIP_CPU_RT__

--- a/rocprim/include/rocprim/thread/thread_reduce.hpp
+++ b/rocprim/include/rocprim/thread/thread_reduce.hpp
@@ -49,7 +49,7 @@ template <
     typename    T,
     typename    ReductionOp,
     bool        NoPrefix = false>
-ROCPRIM_DEVICE inline T thread_reduce(
+ROCPRIM_DEVICE ROCPRIM_INLINE T thread_reduce(
     T*           input,
     ReductionOp reduction_op,
     T           prefix = T(0))
@@ -79,7 +79,7 @@ template <
     int         LENGTH,
     typename    T,
     typename    ReductionOp>
-ROCPRIM_DEVICE inline T thread_reduce(
+ROCPRIM_DEVICE ROCPRIM_INLINE T thread_reduce(
     T           (&input)[LENGTH],
     ReductionOp reduction_op,
     T           prefix)
@@ -98,7 +98,7 @@ template <
     int         LENGTH,
     typename    T,
     typename    ReductionOp>
-ROCPRIM_DEVICE inline T thread_reduce(
+ROCPRIM_DEVICE ROCPRIM_INLINE T thread_reduce(
     T           (&input)[LENGTH],
     ReductionOp reduction_op)
 {

--- a/rocprim/include/rocprim/thread/thread_scan.hpp
+++ b/rocprim/include/rocprim/thread/thread_scan.hpp
@@ -60,7 +60,7 @@ BEGIN_ROCPRIM_NAMESPACE
      int         LENGTH,
      typename    T,
      typename    ScanOp>
- ROCPRIM_DEVICE inline
+ ROCPRIM_DEVICE ROCPRIM_INLINE
  T thread_scan_exclusive(
      T                   inclusive,
      T                   exclusive,
@@ -96,7 +96,7 @@ BEGIN_ROCPRIM_NAMESPACE
      int         LENGTH,
      typename    T,
      typename    ScanOp>
- ROCPRIM_DEVICE inline
+ ROCPRIM_DEVICE ROCPRIM_INLINE
  T thread_scan_exclusive(
      T           *input,                 ///< [in] Input array
      T           *output,                ///< [out] Output array (may be aliased to \p input)
@@ -129,7 +129,7 @@ BEGIN_ROCPRIM_NAMESPACE
      int         LENGTH,
      typename    T,
      typename    ScanOp>
- ROCPRIM_DEVICE inline
+ ROCPRIM_DEVICE ROCPRIM_INLINE
  T thread_scan_exclusive(
      T           (&input)[LENGTH],       ///< [in] Input array
      T           (&output)[LENGTH],      ///< [out] Output array (may be aliased to \p input)
@@ -153,7 +153,7 @@ BEGIN_ROCPRIM_NAMESPACE
      int         LENGTH,
      typename    T,
      typename    ScanOp>
- ROCPRIM_DEVICE inline
+ ROCPRIM_DEVICE ROCPRIM_INLINE
  T thread_scan_inclusive(
      T                   inclusive,
      T                   *input,                 ///< [in] Input array
@@ -184,7 +184,7 @@ BEGIN_ROCPRIM_NAMESPACE
      int         LENGTH,
      typename    T,
      typename    ScanOp>
- ROCPRIM_DEVICE inline
+ ROCPRIM_DEVICE ROCPRIM_INLINE
  T thread_scan_inclusive(
      T           *input,
      T           *output,
@@ -210,7 +210,7 @@ BEGIN_ROCPRIM_NAMESPACE
      int         LENGTH,
      typename    T,
      typename    ScanOp>
- ROCPRIM_DEVICE inline
+ ROCPRIM_DEVICE ROCPRIM_INLINE
  T thread_scan_inclusive(
      T           (&input)[LENGTH],       ///< [in] Input array
      T           (&output)[LENGTH],      ///< [out] Output array (may be aliased to \p input)
@@ -234,7 +234,7 @@ BEGIN_ROCPRIM_NAMESPACE
      int         LENGTH,
      typename    T,
      typename    ScanOp>
- ROCPRIM_DEVICE inline
+ ROCPRIM_DEVICE ROCPRIM_INLINE
  T thread_scan_inclusive(
      T           *input,                 ///< [in] Input array
      T           *output,                ///< [out] Output array (may be aliased to \p input)
@@ -268,7 +268,7 @@ BEGIN_ROCPRIM_NAMESPACE
      int         LENGTH,
      typename    T,
      typename    ScanOp>
- ROCPRIM_DEVICE inline
+ ROCPRIM_DEVICE ROCPRIM_INLINE
  T thread_scan_inclusive(
      T           (&input)[LENGTH],
      T           (&output)[LENGTH],

--- a/rocprim/include/rocprim/thread/thread_search.hpp
+++ b/rocprim/include/rocprim/thread/thread_search.hpp
@@ -91,7 +91,7 @@ template <
     typename InputIteratorT,
     typename OffsetT,
     typename T>
-ROCPRIM_DEVICE inline OffsetT lower_bound(
+ROCPRIM_DEVICE ROCPRIM_INLINE OffsetT lower_bound(
     InputIteratorT      input,
     OffsetT             num_items,
     T                   val)
@@ -127,7 +127,7 @@ template <
     typename InputIteratorT,
     typename OffsetT,
     typename T>
-ROCPRIM_DEVICE inline OffsetT upper_bound(
+ROCPRIM_DEVICE ROCPRIM_INLINE OffsetT upper_bound(
     InputIteratorT      input,              ///< [in] Input sequence
     OffsetT             num_items,          ///< [in] Input sequence length
     T                   val)                ///< [in] Search key

--- a/rocprim/include/rocprim/thread/thread_store.hpp
+++ b/rocprim/include/rocprim/thread/thread_store.hpp
@@ -114,7 +114,7 @@ template <
     typename OutputIteratorT,
     typename T
 >
-ROCPRIM_DEVICE inline void thread_store(
+ROCPRIM_DEVICE ROCPRIM_INLINE void thread_store(
     OutputIteratorT itr,
     T               val)
 {
@@ -130,7 +130,7 @@ template <
     cache_store_modifier MODIFIER = store_default,
     typename T
 >
-ROCPRIM_DEVICE inline void thread_store(
+ROCPRIM_DEVICE ROCPRIM_INLINE void thread_store(
     T *ptr,
     T val)
 {

--- a/rocprim/include/rocprim/type_traits.hpp
+++ b/rocprim/include/rocprim/type_traits.hpp
@@ -138,7 +138,7 @@ struct get_unsigned_bits_type<T,8>
 };
 
 template<typename T, typename UnsignedBits>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto TwiddleIn(UnsignedBits key)
     -> typename std::enable_if<is_floating_point<T>::value, UnsignedBits>::type
 {
@@ -148,7 +148,7 @@ auto TwiddleIn(UnsignedBits key)
 }
 
 template<typename T, typename UnsignedBits>
-static ROCPRIM_DEVICE inline
+static ROCPRIM_DEVICE ROCPRIM_INLINE
 auto TwiddleIn(UnsignedBits key)
     -> typename std::enable_if<is_unsigned<T>::value, UnsignedBits>::type
 {
@@ -156,7 +156,7 @@ auto TwiddleIn(UnsignedBits key)
 };
 
 template<typename T, typename UnsignedBits>
-static ROCPRIM_DEVICE inline
+static ROCPRIM_DEVICE ROCPRIM_INLINE
 auto TwiddleIn(UnsignedBits key)
     -> typename std::enable_if<is_integral<T>::value && is_signed<T>::value, UnsignedBits>::type
 {
@@ -165,7 +165,7 @@ auto TwiddleIn(UnsignedBits key)
 };
 
 template<typename T, typename UnsignedBits>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto TwiddleOut(UnsignedBits key)
     -> typename std::enable_if<is_floating_point<T>::value, UnsignedBits>::type
 {
@@ -175,7 +175,7 @@ auto TwiddleOut(UnsignedBits key)
 }
 
 template<typename T, typename UnsignedBits>
-static ROCPRIM_DEVICE inline
+static ROCPRIM_DEVICE ROCPRIM_INLINE
 auto TwiddleOut(UnsignedBits key)
     -> typename std::enable_if<is_unsigned<T>::value, UnsignedBits>::type
 {
@@ -183,7 +183,7 @@ auto TwiddleOut(UnsignedBits key)
 };
 
 template<typename T, typename UnsignedBits>
-static ROCPRIM_DEVICE inline
+static ROCPRIM_DEVICE ROCPRIM_INLINE
 auto TwiddleOut(UnsignedBits key)
     -> typename std::enable_if<is_integral<T>::value && is_signed<T>::value, UnsignedBits>::type
 {

--- a/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -48,7 +48,7 @@ public:
     using storage_type = detail::empty_storage_type;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input, T& output, BinaryFunction reduce_op)
     {
         output = input;
@@ -89,7 +89,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input, T& output, storage_type& storage, BinaryFunction reduce_op)
     {
         (void) storage; // disables unused parameter warning
@@ -97,7 +97,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input, T& output, unsigned int valid_items, BinaryFunction reduce_op)
     {
         // Fallback to shuffle-based implementation
@@ -106,7 +106,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input, T& output, unsigned int valid_items,
                 storage_type& storage, BinaryFunction reduce_op)
     {
@@ -115,7 +115,7 @@ public:
     }
 
     template<class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void head_segmented_reduce(T input, T& output, Flag flag, BinaryFunction reduce_op)
     {
         // Fallback to shuffle-based implementation
@@ -124,7 +124,7 @@ public:
     }
 
     template<class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void tail_segmented_reduce(T input, T& output, Flag flag, BinaryFunction reduce_op)
     {
         // Fallback to shuffle-based implementation
@@ -133,7 +133,7 @@ public:
     }
 
     template<class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void head_segmented_reduce(T input, T& output, Flag flag,
                                storage_type& storage, BinaryFunction reduce_op)
     {
@@ -143,7 +143,7 @@ public:
     }
 
     template<class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void tail_segmented_reduce(T input, T& output, Flag flag,
                                storage_type& storage, BinaryFunction reduce_op)
     {

--- a/rocprim/include/rocprim/warp/detail/warp_reduce_shared_mem.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_reduce_shared_mem.hpp
@@ -51,7 +51,7 @@ public:
     using storage_type = detail::raw_storage<storage_type_>;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input, T& output, storage_type& storage, BinaryFunction reduce_op)
     {
         constexpr unsigned int ceiling = next_power_of_two(WarpSize);
@@ -75,7 +75,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input, T& output, unsigned int valid_items,
                 storage_type& storage, BinaryFunction reduce_op)
     {
@@ -100,7 +100,7 @@ public:
     }
 
     template<class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void head_segmented_reduce(T input, T& output, Flag flag,
                                storage_type& storage, BinaryFunction reduce_op)
     {
@@ -108,7 +108,7 @@ public:
     }
 
     template<class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void tail_segmented_reduce(T input, T& output, Flag flag,
                                storage_type& storage, BinaryFunction reduce_op)
     {
@@ -117,7 +117,7 @@ public:
 
 private:
     template<bool HeadSegmented, class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void segmented_reduce(T input, T& output, Flag flag,
                           storage_type& storage, BinaryFunction reduce_op)
     {
@@ -141,7 +141,7 @@ private:
     }
 
     template<bool Switch>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<(Switch == false)>::type
     set_output(T& output, storage_type& storage)
     {
@@ -151,7 +151,7 @@ private:
     }
 
     template<bool Switch>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<(Switch == true)>::type
     set_output(T& output, storage_type& storage)
     {

--- a/rocprim/include/rocprim/warp/detail/warp_reduce_shuffle.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_reduce_shuffle.hpp
@@ -48,7 +48,7 @@ public:
     using storage_type = detail::empty_storage_type;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input, T& output, BinaryFunction reduce_op)
     {
         output = input;
@@ -64,7 +64,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input, T& output, storage_type& storage, BinaryFunction reduce_op)
     {
         (void) storage; // disables unused parameter warning
@@ -72,7 +72,7 @@ public:
     }
 
     template<bool UseAllReduceDummy = UseAllReduce, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input, T& output, unsigned int valid_items, BinaryFunction reduce_op)
     {
         output = input;
@@ -89,7 +89,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void reduce(T input, T& output, unsigned int valid_items,
                 storage_type& storage, BinaryFunction reduce_op)
     {
@@ -98,21 +98,21 @@ public:
     }
 
     template<class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void head_segmented_reduce(T input, T& output, Flag flag, BinaryFunction reduce_op)
     {
         this->segmented_reduce<true>(input, output, flag, reduce_op);
     }
 
     template<class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void tail_segmented_reduce(T input, T& output, Flag flag, BinaryFunction reduce_op)
     {
         this->segmented_reduce<false>(input, output, flag, reduce_op);
     }
 
     template<class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void head_segmented_reduce(T input, T& output, Flag flag,
                                storage_type& storage, BinaryFunction reduce_op)
     {
@@ -121,7 +121,7 @@ public:
     }
 
     template<class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void tail_segmented_reduce(T input, T& output, Flag flag,
                                storage_type& storage, BinaryFunction reduce_op)
     {
@@ -131,7 +131,7 @@ public:
 
 private:
     template<bool HeadSegmented, class Flag, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void segmented_reduce(T input, T& output, Flag flag, BinaryFunction reduce_op)
     {
         // Get logical lane id of the last valid value in the segment,
@@ -141,7 +141,7 @@ private:
     }
 
     template<bool Switch>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<(Switch == false)>::type
     set_output(T& output)
     {
@@ -150,7 +150,7 @@ private:
     }
 
     template<bool Switch>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<(Switch == true)>::type
     set_output(T& output)
     {

--- a/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
@@ -46,7 +46,7 @@ public:
     using storage_type = detail::empty_storage_type;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input, T& output, BinaryFunction scan_op)
     {
         const unsigned int lane_id = ::rocprim::lane_id();
@@ -87,7 +87,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input, T& output,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -96,7 +96,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input, T& output, T& reduction,
                         BinaryFunction scan_op)
     {
@@ -106,7 +106,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input, T& output, T& reduction,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -115,7 +115,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output, T init, BinaryFunction scan_op)
     {
         inclusive_scan(input, output, scan_op);
@@ -124,7 +124,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output, T init,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -133,7 +133,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -144,7 +144,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output, T init, T& reduction,
                         BinaryFunction scan_op)
     {
@@ -156,7 +156,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output, T init, T& reduction,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -165,7 +165,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output, T init,
               BinaryFunction scan_op)
     {
@@ -175,7 +175,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output, T init,
               storage_type& storage, BinaryFunction scan_op)
     {
@@ -184,7 +184,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output,
               storage_type& storage, BinaryFunction scan_op)
     {
@@ -195,7 +195,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output, T init, T& reduction,
               BinaryFunction scan_op)
     {
@@ -207,7 +207,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output, T init, T& reduction,
               storage_type& storage, BinaryFunction scan_op)
     {
@@ -215,7 +215,7 @@ public:
         scan(input, inclusive_output, exclusive_output, init, reduction, scan_op);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     T broadcast(T input, const unsigned int src_lane, storage_type& storage)
     {
         (void) storage;
@@ -223,7 +223,7 @@ public:
     }
 
 protected:
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_exclusive(T inclusive_input, T& exclusive_output, storage_type& storage)
     {
         (void) storage;
@@ -233,7 +233,7 @@ protected:
 private:
     // Changes inclusive scan results to exclusive scan results
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_exclusive(T inclusive_input, T& exclusive_output, T init,
                       BinaryFunction scan_op)
     {
@@ -247,7 +247,7 @@ private:
         }
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_exclusive(T inclusive_input, T& exclusive_output)
     {
         // shift to get exclusive results

--- a/rocprim/include/rocprim/warp/detail/warp_scan_shared_mem.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_scan_shared_mem.hpp
@@ -48,7 +48,7 @@ public:
     using storage_type = detail::raw_storage<storage_type_>;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input, T& output,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -70,7 +70,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input, T& output, T& reduction,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -80,7 +80,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output, T init,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -89,7 +89,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -98,7 +98,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output, T init, T& reduction,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -109,7 +109,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output, T init,
               storage_type& storage, BinaryFunction scan_op)
     {
@@ -118,7 +118,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output,
               storage_type& storage, BinaryFunction scan_op)
     {
@@ -127,7 +127,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output, T init, T& reduction,
               storage_type& storage, BinaryFunction scan_op)
     {
@@ -137,7 +137,7 @@ public:
         to_exclusive(exclusive_output, init, storage, scan_op);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     T broadcast(T input, const unsigned int src_lane, storage_type& storage)
     {
         storage_type_& storage_ = storage.get();
@@ -149,7 +149,7 @@ public:
     }
 
 protected:
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_exclusive(T inclusive_input, T& exclusive_output, storage_type& storage)
     {
         (void) inclusive_input;
@@ -159,7 +159,7 @@ protected:
 private:
     // Calculate exclusive results base on inclusive scan results in storage.threads[].
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_exclusive(T& exclusive_output, T init,
                       storage_type& storage, BinaryFunction scan_op)
     {
@@ -172,7 +172,7 @@ private:
         }
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_exclusive(T& exclusive_output, storage_type& storage)
     {
         const unsigned int lid = detail::logical_lane_id<WarpSize>();

--- a/rocprim/include/rocprim/warp/detail/warp_scan_shuffle.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_scan_shuffle.hpp
@@ -46,7 +46,7 @@ public:
     using storage_type = detail::empty_storage_type;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input, T& output, BinaryFunction scan_op)
     {
         output = input;
@@ -62,7 +62,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input, T& output,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -71,7 +71,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input, T& output, T& reduction,
                         BinaryFunction scan_op)
     {
@@ -81,7 +81,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void inclusive_scan(T input, T& output, T& reduction,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -90,7 +90,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output, T init, BinaryFunction scan_op)
     {
         inclusive_scan(input, output, scan_op);
@@ -99,7 +99,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output, T init,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -108,7 +108,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -119,7 +119,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output, T init, T& reduction,
                         BinaryFunction scan_op)
     {
@@ -131,7 +131,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void exclusive_scan(T input, T& output, T init, T& reduction,
                         storage_type& storage, BinaryFunction scan_op)
     {
@@ -140,7 +140,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output, T init,
               BinaryFunction scan_op)
     {
@@ -150,7 +150,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output, T init,
               storage_type& storage, BinaryFunction scan_op)
     {
@@ -159,7 +159,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output,
               storage_type& storage, BinaryFunction scan_op)
     {
@@ -170,7 +170,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output, T init, T& reduction,
               BinaryFunction scan_op)
     {
@@ -182,7 +182,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void scan(T input, T& inclusive_output, T& exclusive_output, T init, T& reduction,
               storage_type& storage, BinaryFunction scan_op)
     {
@@ -190,7 +190,7 @@ public:
         scan(input, inclusive_output, exclusive_output, init, reduction, scan_op);
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     T broadcast(T input, const unsigned int src_lane, storage_type& storage)
     {
         (void) storage;
@@ -198,7 +198,7 @@ public:
     }
 
 protected:
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_exclusive(T inclusive_input, T& exclusive_output, storage_type& storage)
     {
         (void) storage;
@@ -208,7 +208,7 @@ protected:
 private:
     // Changes inclusive scan results to exclusive scan results
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_exclusive(T inclusive_input, T& exclusive_output, T init,
                       BinaryFunction scan_op)
     {
@@ -222,7 +222,7 @@ private:
         }
     }
 
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void to_exclusive(T inclusive_input, T& exclusive_output)
     {
         // shift to get exclusive results

--- a/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
@@ -33,7 +33,7 @@ namespace detail
 
 // Returns logical warp id of the last thread in thread's segment
 template<bool HeadSegmented, unsigned int WarpSize, class Flag>
-ROCPRIM_DEVICE inline
+ROCPRIM_DEVICE ROCPRIM_INLINE
 auto last_in_warp_segment(Flag flag)
     -> typename std::enable_if<(WarpSize <= __AMDGCN_WAVEFRONT_SIZE), unsigned int>::type
 {

--- a/rocprim/include/rocprim/warp/detail/warp_sort_shuffle.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_sort_shuffle.hpp
@@ -43,7 +43,7 @@ class warp_sort_shuffle
 {
 private:
     template<int warp, class V, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<!(WarpSize > warp)>::type
     swap(Key& k, V& v, int mask, bool dir, BinaryFunction compare_function)
     {
@@ -55,7 +55,7 @@ private:
     }
 
     template<int warp, class V, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<(WarpSize > warp)>::type
     swap(Key& k, V& v, int mask, bool dir, BinaryFunction compare_function)
     {
@@ -70,7 +70,7 @@ private:
     }
 
     template<int warp, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<!(WarpSize > warp)>::type
     swap(Key& k, int mask, bool dir, BinaryFunction compare_function)
     {
@@ -81,7 +81,7 @@ private:
     }
 
     template<int warp, class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<(WarpSize > warp)>::type
     swap(Key& k, int mask, bool dir, BinaryFunction compare_function)
     {
@@ -94,7 +94,7 @@ private:
     }
 
     template<class BinaryFunction, class... KeyValue>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void bitonic_sort(BinaryFunction compare_function, KeyValue&... kv)
     {
         static_assert(
@@ -137,7 +137,7 @@ public:
     using storage_type = ::rocprim::detail::empty_storage_type;
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_value, BinaryFunction compare_function)
     {
         // sort by value only
@@ -145,7 +145,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_value, storage_type& storage,
               BinaryFunction compare_function)
     {
@@ -154,7 +154,7 @@ public:
     }
 
     template<class BinaryFunction, class V = Value>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<(sizeof(V) <= sizeof(int))>::type
     sort(Key& thread_key, Value& thread_value,
          BinaryFunction compare_function)
@@ -163,7 +163,7 @@ public:
     }
 
     template<class BinaryFunction, class V = Value>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     typename std::enable_if<!(sizeof(V) <= sizeof(int))>::type
     sort(Key& thread_key, Value& thread_value,
          BinaryFunction compare_function)
@@ -175,7 +175,7 @@ public:
     }
 
     template<class BinaryFunction>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key& thread_key, Value& thread_value,
               storage_type& storage, BinaryFunction compare_function)
     {

--- a/rocprim/include/rocprim/warp/warp_reduce.hpp
+++ b/rocprim/include/rocprim/warp/warp_reduce.hpp
@@ -177,7 +177,7 @@ public:
     /// \endcode
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto reduce(T input,
                 T& output,
                 storage_type& storage,
@@ -190,7 +190,7 @@ public:
     /// \brief Performs reduction across threads in a logical warp.
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto reduce(T ,
                 T& ,
                 storage_type& ,
@@ -249,7 +249,7 @@ public:
     /// \endcode
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto reduce(T input,
                 T& output,
                 int valid_items,
@@ -263,7 +263,7 @@ public:
     /// \brief Performs reduction across threads in a logical warp.
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto reduce(T ,
                 T& ,
                 int ,
@@ -295,7 +295,7 @@ public:
     /// Synchronization barrier should be placed before \p storage is reused
     /// or repurposed: \p __syncthreads() or \p rocprim::syncthreads().
     template<class Flag, class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto head_segmented_reduce(T input,
                                T& output,
                                Flag flag,
@@ -309,7 +309,7 @@ public:
     /// \brief Performs head-segmented reduction across threads in a logical warp.
     /// Invalid Warp Size
     template<class Flag, class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto head_segmented_reduce(T ,
                                T& ,
                                Flag ,
@@ -341,7 +341,7 @@ public:
     /// Synchronization barrier should be placed before \p storage is reused
     /// or repurposed: \p __syncthreads() or \p rocprim::syncthreads().
     template<class Flag, class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto tail_segmented_reduce(T input,
                                T& output,
                                Flag flag,
@@ -355,7 +355,7 @@ public:
     /// \brief Performs tail-segmented reduction across threads in a logical warp.
     /// Invalid Warp Size
     template<class Flag, class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto tail_segmented_reduce(T ,
                                T& ,
                                Flag ,

--- a/rocprim/include/rocprim/warp/warp_scan.hpp
+++ b/rocprim/include/rocprim/warp/warp_scan.hpp
@@ -178,7 +178,7 @@ public:
     /// <tt>{33, -34, -34, -36, ..., -64}</tt> etc.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto inclusive_scan(T input,
                         T& output,
                         storage_type& storage,
@@ -191,7 +191,7 @@ public:
     /// \brief Performs inclusive scan across threads in a logical warp.
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto inclusive_scan(T ,
                         T& ,
                         storage_type& ,
@@ -253,7 +253,7 @@ public:
     /// The \p reduction will be equal \p 64.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto inclusive_scan(T input,
                         T& output,
                         T& reduction,
@@ -267,7 +267,7 @@ public:
     /// \brief Performs inclusive scan and reduction across threads in a logical warp.
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto inclusive_scan(T ,
                         T& ,
                         T& ,
@@ -333,7 +333,7 @@ public:
     /// <tt>{100, 33, -34, -34, -36, ..., -62}</tt> etc.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto exclusive_scan(T input,
                         T& output,
                         T init,
@@ -347,7 +347,7 @@ public:
     /// \brief Performs exclusive scan across threads in a logical warp.
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto exclusive_scan(T ,
                         T& ,
                         T ,
@@ -414,7 +414,7 @@ public:
     /// <tt>{10, 11, 12, 13, ..., 73}</tt>. The \p reduction will be 64.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto exclusive_scan(T input,
                         T& output,
                         T init,
@@ -429,7 +429,7 @@ public:
     /// \brief Performs exclusive scan and reduction across threads in a logical warp.
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto exclusive_scan(T ,
                         T& ,
                         T ,
@@ -502,7 +502,7 @@ public:
     /// <tt>{100, 33, -34, -34, -36, ..., -62}</tt> etc.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto scan(T input,
               T& inclusive_output,
               T& exclusive_output,
@@ -517,7 +517,7 @@ public:
     /// \brief Performs inclusive and exclusive scan operations across threads
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto scan(T ,
               T& ,
               T& ,
@@ -590,7 +590,7 @@ public:
     /// be <tt>{10, 11, 12, 13, ..., 73}</tt>. The \p reduction will be 64.
     /// \endparblock
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto scan(T input,
               T& inclusive_output,
               T& exclusive_output,
@@ -609,7 +609,7 @@ public:
     /// \brief Performs inclusive and exclusive scan operations across threads
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto scan(T ,
               T& ,
               T& ,
@@ -634,7 +634,7 @@ public:
     /// Synchronization barrier should be placed before \p storage is reused
     /// or repurposed: \p __syncthreads() or \p rocprim::syncthreads().
     template<unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto broadcast(T input,
                    const unsigned int src_lane,
                    storage_type& storage)
@@ -646,7 +646,7 @@ public:
     /// \brief Broadcasts value from one thread to all threads in logical warp.
     /// Invalid Warp Size
     template<unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto broadcast(T ,
                    const unsigned int ,
                    storage_type& )
@@ -660,7 +660,7 @@ public:
 protected:
 
     template<unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto to_exclusive(T inclusive_input, T& exclusive_output, storage_type& storage)
         -> typename std::enable_if<(FunctionWarpSize <= __AMDGCN_WAVEFRONT_SIZE), void>::type
     {
@@ -668,7 +668,7 @@ protected:
     }
 
     template<unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto to_exclusive(T , T& , storage_type&)
         -> typename std::enable_if<(FunctionWarpSize > __AMDGCN_WAVEFRONT_SIZE), void>::type
     {

--- a/rocprim/include/rocprim/warp/warp_sort.hpp
+++ b/rocprim/include/rocprim/warp/warp_sort.hpp
@@ -125,7 +125,7 @@ public:
     /// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto sort(Key& thread_key,
               BinaryFunction compare_function = BinaryFunction())
         -> typename std::enable_if<(FunctionWarpSize <= __AMDGCN_WAVEFRONT_SIZE), void>::type
@@ -136,7 +136,7 @@ public:
     /// \brief Warp sort for any data type.
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto sort(Key& ,
               BinaryFunction compare_function = BinaryFunction())
         -> typename std::enable_if<(FunctionWarpSize > __AMDGCN_WAVEFRONT_SIZE), void>::type
@@ -175,7 +175,7 @@ public:
     /// }
     /// \endcode
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto sort(Key& thread_key,
               storage_type& storage,
               BinaryFunction compare_function = BinaryFunction())
@@ -189,7 +189,7 @@ public:
     /// \brief Warp sort for any data type using temporary storage.
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto sort(Key& ,
               storage_type& ,
               BinaryFunction compare_function = BinaryFunction())
@@ -212,7 +212,7 @@ public:
     /// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
     /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto sort(Key& thread_key,
               Value& thread_value,
               BinaryFunction compare_function = BinaryFunction())
@@ -226,7 +226,7 @@ public:
     /// \brief Warp sort by key for any data type.
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto sort(Key& ,
               Value& ,
               BinaryFunction compare_function = BinaryFunction())
@@ -267,7 +267,7 @@ public:
     /// }
     /// \endcode
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto sort(Key& thread_key,
               Value& thread_value,
               storage_type& storage,
@@ -282,7 +282,7 @@ public:
     /// \brief Warp sort by key for any data type using temporary storage.
     /// Invalid Warp Size
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
-    ROCPRIM_DEVICE inline
+    ROCPRIM_DEVICE ROCPRIM_INLINE
     auto sort(Key& ,
               Value& ,
               storage_type& ,


### PR DESCRIPTION
This is required for device functions due to a bug in HIP on Windows where we get local memory limit exceeded errors during compilation.  I had previously done it for just device_segmented_radix_sort, but in newer hip on windows builds the local memory error has spread to even more algorithms, so I decided to just change them all.

This also affects rocThrust.