### PR TITLE
Replacing hipPeekAtLastError with hipGetLastError

### DIFF
--- a/benchmark/benchmark_block_discontinuity.cpp
+++ b/benchmark/benchmark_block_discontinuity.cpp
@@ -237,7 +237,7 @@ void run_benchmark(benchmark::State& state, hipStream_t stream, size_t N)
             dim3(size/items_per_block), dim3(BlockSize), 0, stream,
             d_input, d_output
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         auto end = std::chrono::high_resolution_clock::now();

--- a/benchmark/benchmark_block_exchange.cpp
+++ b/benchmark/benchmark_block_exchange.cpp
@@ -305,7 +305,7 @@ void run_benchmark(benchmark::State& state, hipStream_t stream, size_t N)
             dim3(size/items_per_block), dim3(BlockSize), 0, stream,
             d_input, d_ranks, d_output
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         auto end = std::chrono::high_resolution_clock::now();

--- a/benchmark/benchmark_block_histogram.cpp
+++ b/benchmark/benchmark_block_histogram.cpp
@@ -152,7 +152,7 @@ void run_benchmark(benchmark::State& state, hipStream_t stream, size_t N)
             dim3(size/items_per_block), dim3(BlockSize), 0, stream,
             d_input, d_output
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         auto end = std::chrono::high_resolution_clock::now();

--- a/benchmark/benchmark_block_radix_sort.cpp
+++ b/benchmark/benchmark_block_radix_sort.cpp
@@ -179,7 +179,7 @@ void run_benchmark(benchmark::State& state, benchmark_kinds benchmark_kind, hipS
                 d_input, d_output
             );
         }
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         auto end = std::chrono::high_resolution_clock::now();

--- a/benchmark/benchmark_block_reduce.cpp
+++ b/benchmark/benchmark_block_reduce.cpp
@@ -142,7 +142,7 @@ void run_benchmark(benchmark::State& state, hipStream_t stream, size_t N)
             dim3(size/items_per_block), dim3(BlockSize), 0, stream,
             d_input, d_output
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         auto end = std::chrono::high_resolution_clock::now();

--- a/benchmark/benchmark_block_scan.cpp
+++ b/benchmark/benchmark_block_scan.cpp
@@ -181,7 +181,7 @@ void run_benchmark(benchmark::State& state, hipStream_t stream, size_t N)
             dim3(size/items_per_block), dim3(BlockSize), 0, stream,
             d_input, d_output
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         auto end = std::chrono::high_resolution_clock::now();

--- a/benchmark/benchmark_block_sort.cpp
+++ b/benchmark/benchmark_block_sort.cpp
@@ -164,7 +164,7 @@ void run_benchmark(benchmark::State& state, benchmark_kinds benchmark_kind, hipS
                 d_input, d_output
             );
         }
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         auto end = std::chrono::high_resolution_clock::now();

--- a/benchmark/benchmark_warp_reduce.cpp
+++ b/benchmark/benchmark_warp_reduce.cpp
@@ -123,7 +123,7 @@ auto execute_warp_reduce_kernel(T* input, T* output, Flag* /* flags */,
         dim3(size/BlockSize), dim3(BlockSize), 0, stream,
         input, output
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
 }
 
 template<
@@ -145,7 +145,7 @@ auto execute_warp_reduce_kernel(T* input, T* output, Flag* flags,
         dim3(size/BlockSize), dim3(BlockSize), 0, stream,
         input, flags, output
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
 }
 
 template<

--- a/benchmark/benchmark_warp_scan.cpp
+++ b/benchmark/benchmark_warp_scan.cpp
@@ -137,7 +137,7 @@ void run_benchmark(benchmark::State& state, hipStream_t stream, size_t size)
                 d_input, d_output, input[0]
             );
         }
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         auto end = std::chrono::high_resolution_clock::now();

--- a/benchmark/benchmark_warp_sort.cpp
+++ b/benchmark/benchmark_warp_sort.cpp
@@ -163,7 +163,7 @@ void run_benchmark(benchmark::State& state, hipStream_t stream, size_t size)
                 d_input_key
             );
         }
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         auto end = std::chrono::high_resolution_clock::now();

--- a/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/rocprim/include/rocprim/device/device_histogram.hpp
@@ -110,7 +110,7 @@ void histogram_global_kernel(SampleIterator samples,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_merge.hpp
+++ b/rocprim/include/rocprim/device/device_merge.hpp
@@ -94,7 +94,7 @@ void merge_kernel(IndexIterator index,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_merge_sort.hpp
+++ b/rocprim/include/rocprim/device/device_merge_sort.hpp
@@ -99,7 +99,7 @@ void block_merge_kernel(KeysInputIterator keys_input,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_partition.hpp
+++ b/rocprim/include/rocprim/device/device_partition.hpp
@@ -96,7 +96,7 @@ void init_offset_scan_state_kernel(OffsetLookBackScanState offset_scan_state,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -131,7 +131,7 @@ void sort_and_scatter_kernel(KeysInputIterator keys_input,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/device_reduce.hpp
@@ -74,7 +74,7 @@ void block_reduce_kernel(InputIterator input,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_reduce_by_key.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_by_key.hpp
@@ -137,7 +137,7 @@ void scan_and_scatter_carry_outs_kernel(const carry_out<Result> * carry_outs,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_scan.hpp
+++ b/rocprim/include/rocprim/device/device_scan.hpp
@@ -174,7 +174,7 @@ void init_lookback_scan_state_kernel(LookBackScanState lookback_scan_state,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
@@ -83,7 +83,7 @@ void segmented_sort_kernel(KeysInputIterator keys_input,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_segmented_reduce.hpp
+++ b/rocprim/include/rocprim/device/device_segmented_reduce.hpp
@@ -67,7 +67,7 @@ void segmented_reduce_kernel(InputIterator input,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_segmented_scan.hpp
+++ b/rocprim/include/rocprim/device/device_segmented_scan.hpp
@@ -73,7 +73,7 @@ void segmented_scan_kernel(InputIterator input,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/device_transform.hpp
+++ b/rocprim/include/rocprim/device/device_transform.hpp
@@ -63,7 +63,7 @@ void transform_kernel(InputIterator input,
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/rocprim/include/rocprim/device/specialization/device_radix_single_sort.hpp
+++ b/rocprim/include/rocprim/device/specialization/device_radix_single_sort.hpp
@@ -30,7 +30,7 @@ namespace detail
 
 #define ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(name, size, start) \
     { \
-        auto _error = hipPeekAtLastError(); \
+        auto _error = hipGetLastError(); \
         if(_error != hipSuccess) return _error; \
         if(debug_synchronous) \
         { \

--- a/test/rocprim/detail/get_rocprim_version.cpp
+++ b/test/rocprim/detail/get_rocprim_version.cpp
@@ -42,7 +42,7 @@ unsigned int get_rocprim_version_on_device()
         dim3(1), dim3(1), 0, 0,
         d_version
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     HIP_CHECK(

--- a/test/rocprim/test_arg_index_iterator.cpp
+++ b/test/rocprim/test_arg_index_iterator.cpp
@@ -178,7 +178,7 @@ TYPED_TEST(RocprimArgIndexIteratorTests, ReduceArgMinimum)
                 reduce_op, stream, debug_synchronous
             )
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Copy output to host

--- a/test/rocprim/test_block_adjacent_difference.kernels.hpp
+++ b/test/rocprim/test_block_adjacent_difference.kernels.hpp
@@ -261,7 +261,7 @@ auto test_block_adjacent_difference()
             dim3(grid_size), dim3(block_size), 0, 0,
             device_input, device_heads
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Reading results
@@ -373,7 +373,7 @@ auto test_block_adjacent_difference()
             dim3(grid_size), dim3(block_size), 0, 0,
             device_input, device_tails
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Reading results
@@ -499,7 +499,7 @@ auto test_block_adjacent_difference()
             dim3(grid_size), dim3(block_size), 0, 0,
             device_input, device_heads, device_tails
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Reading results

--- a/test/rocprim/test_block_discontinuity.kernels.hpp
+++ b/test/rocprim/test_block_discontinuity.kernels.hpp
@@ -261,7 +261,7 @@ auto test_block_discontinuity()
             dim3(grid_size), dim3(block_size), 0, 0,
             device_input, device_heads
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Reading results
@@ -373,7 +373,7 @@ auto test_block_discontinuity()
             dim3(grid_size), dim3(block_size), 0, 0,
             device_input, device_tails
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Reading results
@@ -499,7 +499,7 @@ auto test_block_discontinuity()
             dim3(grid_size), dim3(block_size), 0, 0,
             device_input, device_heads, device_tails
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Reading results

--- a/test/rocprim/test_block_exchange.kernels.hpp
+++ b/test/rocprim/test_block_exchange.kernels.hpp
@@ -238,7 +238,7 @@ auto test_block_exchange()
         dim3(grid_size), dim3(block_size), 0, 0,
         device_input, device_output
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     // Reading results
@@ -322,7 +322,7 @@ auto test_block_exchange()
         dim3(grid_size), dim3(block_size), 0, 0,
         device_input, device_output
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     // Reading results
@@ -418,7 +418,7 @@ auto test_block_exchange()
         dim3(grid_size), dim3(block_size), 0, 0,
         device_input, device_output
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     // Reading results
@@ -512,7 +512,7 @@ auto test_block_exchange()
         dim3(grid_size), dim3(block_size), 0, 0,
         device_input, device_output
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     // Reading results
@@ -613,7 +613,7 @@ auto test_block_exchange()
         dim3(grid_size), dim3(block_size), 0, 0,
         device_input, device_output, device_ranks
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     // Reading results
@@ -717,7 +717,7 @@ auto test_block_exchange()
         dim3(grid_size), dim3(block_size), 0, 0,
         device_input, device_output, device_ranks
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     // Reading results

--- a/test/rocprim/test_block_scan.kernels.hpp
+++ b/test/rocprim/test_block_scan.kernels.hpp
@@ -521,7 +521,7 @@ auto test_block_scan_input_arrays()
             device_output
         );
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -624,7 +624,7 @@ auto test_block_scan_input_arrays()
             device_output, device_output_reductions
         );
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -740,7 +740,7 @@ auto test_block_scan_input_arrays()
             device_output, device_output_bp, block_prefix
         );
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -836,7 +836,7 @@ auto test_block_scan_input_arrays()
             device_output, init
         );
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -940,7 +940,7 @@ auto test_block_scan_input_arrays()
             device_output, device_output_reductions, init
         );
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -1050,7 +1050,7 @@ auto test_block_scan_input_arrays()
             device_output, device_output_bp, block_prefix
         );
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory

--- a/test/rocprim/test_constant_iterator.cpp
+++ b/test/rocprim/test_constant_iterator.cpp
@@ -101,7 +101,7 @@ TYPED_TEST(RocprimConstantIteratorTests, Transform)
                 transform<T>(), stream, debug_synchronous
             )
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Copy output to host

--- a/test/rocprim/test_counting_iterator.cpp
+++ b/test/rocprim/test_counting_iterator.cpp
@@ -106,7 +106,7 @@ TYPED_TEST(RocprimCountingIteratorTests, Transform)
                 transform<T>(), stream, debug_synchronous
             )
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Copy output to host

--- a/test/rocprim/test_device_merge.cpp
+++ b/test/rocprim/test_device_merge.cpp
@@ -204,7 +204,7 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
                     compare_op, stream, debug_synchronous
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             ASSERT_FALSE(out_of_bounds.get());
@@ -392,7 +392,7 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
                     compare_op, stream, debug_synchronous
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             ASSERT_FALSE(out_of_bounds.get());

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -182,7 +182,7 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
                     compare_op, stream, debug_synchronous
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host
@@ -334,7 +334,7 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
                     compare_op, stream, debug_synchronous
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host

--- a/test/rocprim/test_device_reduce.cpp
+++ b/test/rocprim/test_device_reduce.cpp
@@ -235,7 +235,7 @@ TYPED_TEST(RocprimDeviceReduceTests, Reduce)
                     input.size(), rocprim::plus<U>(), stream, debug_synchronous
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host
@@ -339,7 +339,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceMinimum)
                     test_utils::numeric_limits<U>::max(), input.size(), rocprim::minimum<U>(), stream, debug_synchronous
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host
@@ -479,7 +479,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceArgMinimum)
                     max, input.size(), reduce_op, stream, debug_synchronous
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host

--- a/test/rocprim/test_device_scan.cpp
+++ b/test/rocprim/test_device_scan.cpp
@@ -169,7 +169,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanEmptyInput)
             0, scan_op_type(), stream, debug_synchronous
         )
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     ASSERT_FALSE(out_of_bounds.get());
@@ -264,7 +264,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
                     input.size(), scan_op, stream, debug_synchronous, size_limit
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host
@@ -378,7 +378,7 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
                     stream, debug_synchronous, size_limit
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host
@@ -532,7 +532,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
                     size_limit
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host
@@ -669,7 +669,7 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
                     size_limit
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host

--- a/test/rocprim/test_device_transform.cpp
+++ b/test/rocprim/test_device_transform.cpp
@@ -183,7 +183,7 @@ TYPED_TEST(RocprimDeviceTransformTests, Transform)
                     input.size(), transform<U>(), stream, debug_synchronous
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host
@@ -316,7 +316,7 @@ TYPED_TEST(RocprimDeviceTransformTests, BinaryTransform)
                     input1.size(), binary_transform<T1, T2, U>(), stream, debug_synchronous
                 )
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host

--- a/test/rocprim/test_intrinsics.cpp
+++ b/test/rocprim/test_intrinsics.cpp
@@ -173,7 +173,7 @@ TYPED_TEST(RocprimIntrinsicsTests, ShuffleUp)
                     dim3(1), dim3(hardware_warp_size), 0, 0,
                     device_data, delta, logical_warp_size
                 );
-                HIP_CHECK(hipPeekAtLastError());
+                HIP_CHECK(hipGetLastError());
                 HIP_CHECK(hipDeviceSynchronize());
 
                 // Read from device memory
@@ -276,7 +276,7 @@ TYPED_TEST(RocprimIntrinsicsTests, ShuffleDown)
                     dim3(1), dim3(hardware_warp_size), 0, 0,
                     device_data, delta, logical_warp_size
                 );
-                HIP_CHECK(hipPeekAtLastError());
+                HIP_CHECK(hipGetLastError());
                 HIP_CHECK(hipDeviceSynchronize());
 
                 // Read from device memory
@@ -392,7 +392,7 @@ TYPED_TEST(RocprimIntrinsicsTests, ShuffleIndex)
                 dim3(1), dim3(hardware_warp_size), 0, 0,
                 device_data, device_src_lanes, logical_warp_size
             );
-            HIP_CHECK(hipPeekAtLastError());
+            HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
             // Read from device memory
@@ -492,7 +492,7 @@ TEST(RocprimIntrinsicsTests, ShuffleUpCustomStruct)
                     dim3(1), dim3(hardware_warp_size), 0, 0,
                     device_data, delta, logical_warp_size
                 );
-                HIP_CHECK(hipPeekAtLastError());
+                HIP_CHECK(hipGetLastError());
                 HIP_CHECK(hipDeviceSynchronize());
 
                 // Read from device memory
@@ -591,7 +591,7 @@ TEST(RocprimIntrinsicsTests, ShuffleUpCustomAlignedStruct)
                     dim3(1), dim3(hardware_warp_size), 0, 0,
                     device_data, delta, logical_warp_size
                 );
-                HIP_CHECK(hipPeekAtLastError());
+                HIP_CHECK(hipGetLastError());
                 HIP_CHECK(hipDeviceSynchronize());
 
                 // Read from device memory

--- a/test/rocprim/test_texture_cache_iterator.cpp
+++ b/test/rocprim/test_texture_cache_iterator.cpp
@@ -125,7 +125,7 @@ TYPED_TEST(RocprimTextureCacheIteratorTests, Transform)
                 transform<T>(), stream, debug_synchronous
             )
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Copy output to host

--- a/test/rocprim/test_transform_iterator.cpp
+++ b/test/rocprim/test_transform_iterator.cpp
@@ -167,7 +167,7 @@ TYPED_TEST(RocprimTransformIteratorTests, TransformReduce)
                 TestFixture::debug_synchronous
             )
         );
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         HIP_CHECK(

--- a/test/rocprim/test_warp_reduce.hpp
+++ b/test/rocprim/test_warp_reduce.hpp
@@ -120,7 +120,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSum)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -239,7 +239,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSum)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -355,7 +355,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSumValid)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -476,7 +476,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSumValid)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -601,7 +601,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceCustomStruct)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -738,7 +738,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -898,7 +898,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, TailSegmentedReduceSum)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory

--- a/test/rocprim/test_warp_scan.hpp
+++ b/test/rocprim/test_warp_scan.hpp
@@ -119,7 +119,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -245,7 +245,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -373,7 +373,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -507,7 +507,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
                 device_input, device_output, device_output_reductions, init
             );
         }
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -653,7 +653,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -811,7 +811,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -955,7 +955,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
             );
         }
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory

--- a/test/rocprim/test_warp_sort.hpp
+++ b/test/rocprim/test_warp_sort.hpp
@@ -92,7 +92,7 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, Sort)
             d_output
         );
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
@@ -203,7 +203,7 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, SortKeyInt)
             d_output_key, d_output_value
         );
 
-        HIP_CHECK(hipPeekAtLastError());
+        HIP_CHECK(hipGetLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory

--- a/test/test_hip_api.cpp
+++ b/test/test_hip_api.cpp
@@ -76,7 +76,7 @@ TEST(HIPTests, Saxpy)
         dim3((N + 255)/256), dim3(256), 0, 0,
         d_x, d_y, a, N
     );
-    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipGetLastError());
 
     HIP_CHECK(
         hipMemcpy(


### PR DESCRIPTION
In newer versions of HIP, hipGetLastError/hipPeekAtLastError now returns any error produced by any of the runtime calls that did not successfuly complete, not just the error code of the last runtime call.  This now matches CUDA's behaviour.

For example, in this snippet of code:

   1: hipLaunchKernelGGL(MyKernel, dim3(2), dim3(128), 0, 0, 10000,x);
   2: hipDeviceSynchronize();
   3: hipError_t error = hipGetLastError();

If the call to hipLaunchKernelGGL fails, hipDeviceSynchronize (which succeeds) should not reset the last error to hipSuccess. hipGetLastError should still return the non-success error code returned by hipLaunchKernelGGL.

In the fixed version of HIP, the last error is reset to hipSuccess only after calling hipGetLastError.

It looks like rocPRIM assumes the old (incorrect) behaviour of HIP, which was causing some test failures in PyTorch/Tensorflow.  Looking at how rocPRIM uses hipPeekAtLastError, I think we can safely move to hipGetLastError, especially in the library since in all cases we are capturing the error and returning it along the call stack.