### PR TITLE
Disable block histogram test for HIP on Windows OSDB jobs

### DIFF
--- a/rtest.xml
+++ b/rtest.xml
@@ -6,6 +6,6 @@
   <run name="all_tests">{CTEST_FILTER} {CTEST_REGEX}</run>
 </test>
 <test sets="osdb">
-  <run name="all_tests">{CTEST_FILTER} rocprim.device_scan</run>
+  <run name="all_tests">{CTEST_FILTER} {CTEST_REGEX}</run>
 </test>
 </testset>


### PR DESCRIPTION
It was previously disabled for PSDB jobs, we also need to disable it for OSDB until we get it fixed.  Already marked as a known issue with rocPRIM.  We need to get a successful build artifact for rocPRIM so that hipCUB develop CI will pass.