### PR TITLE
Hotfixes from release/rocm-rel-4.5 at release 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,23 @@
 
 Full documentation for rocPRIM is available at [https://codedocs.xyz/ROCmSoftwarePlatform/rocPRIM/](https://codedocs.xyz/ROCmSoftwarePlatform/rocPRIM/)
 
-## [Unreleased rocPRIM-2.10.12 for ROCm 5.0.0]
-### Known issues
-- Unit tests may soft hang on MI200 when running in hipMallocManaged mode.
-- block_histogram, device_scan unit tests failing for HIP on Windows
-
-## [Unreleased rocPRIM-2.10.11 for ROCm 4.5.0]
+## rocPRIM-2.10.11 for ROCm 4.5.0
 ### Addded
-- Initial HIP on Windows support. See README for instructions on how to build and install.
-- bfloat16 support added.
-### Changed
-- Packaging split into a runtime package called rocprim and a development package called rocprim-devel. The development package depends on runtime. The runtime package suggests the development package for all supported OSes except CentOS 7 to aid in the transition. The suggests feature in packaging is introduced as a deprecated feature and will be removed in a future rocm release.
-    - As rocPRIM is a header-only library, the runtime package is an empty placeholder used to aid in the transition. This package is also a deprecated feature and will be removed in a future rocm release.
-### Known issues
-- Unit tests may soft hang on MI200 when running in hipMallocManaged mode.
-### Deprecated
-- The warp_size() function is now deprecated; please switch to host_warp_size() and device_warp_size() for host and device references respectively.
-
-## [Unreleased rocPRIM-2.10.11 for ROCm 4.4.0]
-### Added
 - Code coverage tools build option
 - Address sanitizer build option
 - gfx1030 support added.
 - Experimental [HIP-CPU](https://github.com/ROCm-Developer-Tools/HIP-CPU) support; build using GCC/Clang/MSVC on Win/Linux. It is work in progress, many algorithms still known to fail.
+- Initial HIP on Windows support. See README for instructions on how to build and install.
+- bfloat16 support added.
 ### Optimizations
 - Added single tile radix sort for smaller sizes.
 - Improved performance for radix sort for larger element sizes.
+### Changed
+- Package renamed to rocprim-dev for `.deb`, and to rocprim-devel for `.rpm`. As rocPRIM is a header-only library, there is no associated runtime package, so for compatibility this development package provides the package rocprim. The provides feature in packaging is introduced as a deprecated feature and will be removed in a future rocm release.
 ### Deprecated
 - The warp_size() function is now deprecated; please switch to host_warp_size() and device_warp_size() for host and device references respectively.
 
-## [Unreleased rocPRIM-2.10.10 for ROCm 4.3.0]
+## rocPRIM-2.10.10 for ROCm 4.3.0
 ### Fixed
 - Bugfix & minor performance improvement for merge_sort when input and output storage are the same.
 ### Added
@@ -39,7 +26,7 @@ Full documentation for rocPRIM is available at [https://codedocs.xyz/ROCmSoftwar
 ### Deprecated
 - The warp_size() function is now deprecated; please switch to host_warp_size() and device_warp_size() for host and device references respectively.
 
-## [rocPRIM-2.10.9 for ROCm 4.2.0]
+## rocPRIM-2.10.9 for ROCm 4.2.0
 ### Fixed
 - Size zero inputs are now properly handled with newer ROCm builds that no longer allow zero-size kernel grid/block dimensions
 ### Changed
@@ -47,7 +34,7 @@ Full documentation for rocPRIM is available at [https://codedocs.xyz/ROCmSoftwar
 ### Known issues
 - Device scan unit test currently failing due to LLVM bug.
 
-## [rocPRIM-2.10.8 for ROCm 4.1.0]
+## rocPRIM-2.10.8 for ROCm 4.1.0
 ### Fixed
 - Texture cache iteration support has been re-enabled.
 - Benchmark builds have been re-enabled.
@@ -55,17 +42,17 @@ Full documentation for rocPRIM is available at [https://codedocs.xyz/ROCmSoftwar
 ### Known issues
 - Device scan unit test currently failing due to LLVM bug.
 
-## [rocPRIM-2.10.7 for ROCm 4.0.0]
+## rocPRIM-2.10.7 for ROCm 4.0.0
 ### Added
 - No new features
 
-## [rocPRIM-2.10.6 for ROCm 3.10]
+## rocPRIM-2.10.6 for ROCm 3.10
 ### Optimizations
 - Updates to DPP instructions for warp shuffle
 ### Known issues
 - Benchmark builds are disabled due to compiler bug.
 
-## [rocPRIM-2.10.5 for ROCm 3.9.0]
+## rocPRIM-2.10.5 for ROCm 3.9.0
 ### Added
 - Added HIP cmake dependency
 ### Optimizations
@@ -74,27 +61,27 @@ Full documentation for rocPRIM is available at [https://codedocs.xyz/ROCmSoftwar
 ### Known issues
 - Benchmark builds are disabled due to compiler bug.
 
-## [rocPRIM-2.10.4 for ROCm 3.8.0]
+## rocPRIM-2.10.4 for ROCm 3.8.0
 ### Fixed
 - Fix for rocPRIM texture cache iterator
 ### Known issues
 - None
 
-## [rocPRIM-2.10.3 for ROCm 3.7.0]
+## rocPRIM-2.10.3 for ROCm 3.7.0
 ### Fixed
 - Package dependency correct to hip-rocclr
 ### Known issues
 - rocPRIM texture cache iterator functionality is broken in the runtime. It will be fixed in the next release. Please use the prior release if calling this function.
 
-## [rocPRIM-2.10.2 for ROCm 3.6.0]
+## rocPRIM-2.10.2 for ROCm 3.6.0
 ### Added
 - No new features
 
-## [rocPRIM-2.10.1 for ROCm 3.5.1]
+## rocPRIM-2.10.1 for ROCm 3.5.1
 ### Fixed
 - Point release with compilation fix.
 
-## [rocPRIM-2.10.1 for ROCm 3.5.0]
+## rocPRIM-2.10.1 for ROCm 3.5.0
 ### Added
 - Improved tests with fixed and random seeds for test data
 - Network interface improvements with API v3

--- a/test/rocprim/test_device_radix_sort.cpp
+++ b/test/rocprim/test_device_radix_sort.cpp
@@ -62,13 +62,11 @@ typedef ::testing::Types<
     params<double, int, true>,
     params<float, int>,
     params<rocprim::half, long long>,
-    //TODO: Disable bfloat16 test until we get a better bfloat16 implemetation for host side
-    //params<rocprim::bfloat16, long long>,
+    params<rocprim::bfloat16, long long>,
     params<int8_t, int8_t>,
     params<uint8_t, uint8_t>,
     params<rocprim::half, rocprim::half>,
-    //TODO: Disable bfloat16 test until we get a better bfloat16 implemetation for host side
-    //params<rocprim::bfloat16, rocprim::bfloat16>,
+    params<rocprim::bfloat16, rocprim::bfloat16>,
     params<int, test_utils::custom_test_type<float>>,
 
     // start_bit and end_bit
@@ -80,9 +78,8 @@ typedef ::testing::Types<
     params<unsigned int, double, true, 4, 21>,
     params<unsigned int, rocprim::half, true, 0, 15>,
     params<unsigned short, rocprim::half, false, 3, 22>,
-    //TODO: Disable bfloat16 test until we get a better bfloat16 implemetation for host side
-    //params<unsigned int, rocprim::bfloat16, true, 0, 15>,
-    //params<unsigned short, rocprim::bfloat16, false, 3, 22>,
+    params<unsigned int, rocprim::bfloat16, true, 0, 12>,
+    params<unsigned short, rocprim::bfloat16, false, 3, 11>,
     params<unsigned long long, char, false, 8, 20>,
     params<unsigned short, test_utils::custom_test_type<double>, false, 8, 11>,
 
@@ -292,7 +289,7 @@ TYPED_TEST(RocprimDeviceRadixSort, SortPairs)
             }
 
             std::vector<value_type> values_input(size);
-            std::iota(values_input.begin(), values_input.end(), 0);
+            test_utils::iota(values_input.begin(), values_input.end(), 0);
 
             key_type * d_keys_input;
             key_type * d_keys_output;
@@ -599,7 +596,7 @@ TYPED_TEST(RocprimDeviceRadixSort, SortPairsDoubleBuffer)
             }
 
             std::vector<value_type> values_input(size);
-            std::iota(values_input.begin(), values_input.end(), 0);
+            test_utils::iota(values_input.begin(), values_input.end(), 0);
 
             key_type * d_keys_input;
             key_type * d_keys_output;

--- a/test/rocprim/test_utils.hpp
+++ b/test/rocprim/test_utils.hpp
@@ -1462,6 +1462,16 @@ void assert_eq(const rocprim::bfloat16& result, const rocprim::bfloat16& expecte
     ASSERT_EQ(bfloat16_to_native(result), bfloat16_to_native(expected));
 }
 
+//TODO: Use custom iota until the follwing PR merge: https://github.com/ROCm-Developer-Tools/HIP/pull/2303
+template<class ForwardIt, class T>
+void iota(ForwardIt first, ForwardIt last, T value)
+{
+    using value_type = typename std::iterator_traits<ForwardIt>::value_type;
+    while(first != last) {
+        *first++ = static_cast<value_type>(value);
+        ++value;
+    }
+}
 
 } // end test_utils namespace
 


### PR DESCRIPTION
This is an autogenerated PR.
This is intended to pull any hotfixes for ROCm release 4.5 (including changelogs and documentation) back into develop.