### PR TITLE
Make device functions always inline

### DIFF
--- a/rocprim/include/rocprim/config.hpp
+++ b/rocprim/include/rocprim/config.hpp
@@ -51,13 +51,11 @@
         #define ROCPRIM_DEFAULT_MIN_WARPS_PER_EU 1
     #endif
     // Currently HIP on Windows has a bug involving inline device functions generating
-    // local memory/register allocation errors during compilation.  Current workaround is to
+    // local memory/register allocation errors during compilation.  Also on Linux
+    // when compiling in debug mode all optimizations including inlining are disabled,
+    // resulting in the same compilation error.  Current workaround is to
     // use __attribute__((always_inline)) for the affected functions
-    #ifdef WIN32
-      #define ROCPRIM_INLINE inline __attribute__((always_inline))
-    #else
-      #define ROCPRIM_INLINE inline __attribute__((always_inline))
-    #endif
+    #define ROCPRIM_INLINE inline __attribute__((always_inline))
 #endif
 
 #if ( defined(__gfx801__) || \


### PR DESCRIPTION
Due to new changes to the HIP compiler, in debug mode no optimizations are made, which means __inline__ functions are not inlined.  This leads to local memory errors when compiling.  We must now set inline __attribute__((always_inline)) to ensure that rocPRIM builds in debug mode.

There does not seem to be any effect on binary size, at least looking at the unit tests.