### PR TITLE
EXSWSTRHPC-129 - Add extra synchronization temporarily to block histogram sort

### DIFF
--- a/test/rocprim/test_block_histogram.hpp
+++ b/test/rocprim/test_block_histogram.hpp
@@ -20,6 +20,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// For intellisense: make the file stand-alone
+#ifndef suite_name_atomic
+
+// required rocprim headers
+#include <rocprim/block/block_load.hpp>
+#include <rocprim/block/block_store.hpp>
+#include <rocprim/block/block_histogram.hpp>
+
+// required test headers
+#include "test_utils_types.hpp"
+#include "common_test_header.hpp"
+
+// kernel definitions
+#include "test_block_histogram.kernels.hpp"
+
+// Start stamping out tests
+struct RocprimBlockHistogramAtomicInputArrayTests;
+struct RocprimBlockHistogramSortInputArrayTests;
+
+struct Integral;
+#define suite_name_atomic RocprimBlockHistogramAtomicInputArrayTests
+#define suite_name_sort RocprimBlockHistogramSortInputArrayTests
+#define block_params_atomic BlockHistAtomicParamsIntegral
+#define block_params_sort BlockHistSortParamsIntegral
+#define name_suffix Integral
+
+#endif
+
 block_histo_test_suite_type_def(suite_name_atomic, name_suffix)
 block_histo_test_suite_type_def(suite_name_sort, name_suffix)
 

--- a/test/rocprim/test_utils_types.hpp
+++ b/test/rocprim/test_utils_types.hpp
@@ -192,17 +192,17 @@ typedef ::testing::Types<
 > BlockHistAtomicParamsFloating;
 
 typedef ::testing::Types<
-    block_param_type(uint8_t, int),
+    block_param_type(int, uint8_t),
     block_param_type(uint8_t, uint8_t),
-    block_param_type(uint8_t, short),
-    block_param_type(uint8_t, int8_t)
+    block_param_type(short, uint8_t),
+    block_param_type(int, int8_t)
 > BlockHistSortParamsIntegral;
 
 typedef ::testing::Types<
-    block_param_type(unsigned short, rocprim::half),
-    block_param_type(unsigned int, rocprim::half),
-    block_param_type(unsigned short, rocprim::bfloat16),
-    block_param_type(unsigned int, rocprim::bfloat16)
+    block_param_type(rocprim::half, unsigned short),
+    block_param_type(rocprim::half, unsigned int),
+    block_param_type(rocprim::bfloat16, unsigned short),
+    block_param_type(rocprim::bfloat16, unsigned int)
 > BlockHistSortParamsFloating;
 
 static constexpr size_t n_items = 7;


### PR DESCRIPTION
There is an issue if a single block has all the items, but for now this works.