### PR TITLE
Fix ambiguous/undefined order of arguments to function

### DIFF
--- a/test/rocprim/test_utils.hpp
+++ b/test/rocprim/test_utils.hpp
@@ -706,7 +706,7 @@ OutputIt host_exclusive_scan_by_key(InputIt first, InputIt last, KeyIt k_first,
 
     while ((first+1) != last)
     {
-        if(key_compare_op(*k_first, *++k_first))
+        if(key_compare_op(*k_first, *(k_first+1)))
         {
             sum = op(sum, *first);
         }
@@ -714,6 +714,7 @@ OutputIt host_exclusive_scan_by_key(InputIt first, InputIt last, KeyIt k_first,
         {
             sum = initial_value;
         }
+	k_first++;
         *++d_first = sum;
         first++;
     }


### PR DESCRIPTION
The order of evaluation of function parameters in C++ is not guaranteed:
https://stackoverflow.com/questions/2934904/order-of-evaluation-in-c-function-parameters#:~:text=The%20order%20of%20evaluation%20of%20arguments%20is%20unspecified.,will%20be%20called%20before%20foo%20.

With the previous code, the order of evaluation is different on HIP on Windows vs. Linux.  This could lead to *++k_first being evaluated before *k_first, leading to incorrect results.  

I am modifying the code to be unambiguous.  The test now passes on HIP on Windows.