### PR TITLE
309 pytorch unit test failure test tensor creation ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Full documentation for rocPRIM is available at [https://codedocs.xyz/ROCmSoftwarePlatform/rocPRIM/](https://codedocs.xyz/ROCmSoftwarePlatform/rocPRIM/)
 
+## [Unreleased rocPRIM-2.10.13 for ROCm 5.1.0]
+### Fixed
+- Fixed radix sort int64_t bug introduced in [2.10.11]
+### Added
+- Future value
+### Changed
+- The reduce/scan algorithm precision issues in the tests has been resolved for half types.
+
 ## [Unreleased rocPRIM-2.10.12 for ROCm 5.0.0]
 ### Fixed
 - Enable bfloat16 tests and reduce threshold for bfloat16
@@ -17,7 +25,7 @@ Full documentation for rocPRIM is available at [https://codedocs.xyz/ROCmSoftwar
     - the block sort step supports multiple items per thread
 ### Changed
 - size_limit for scan, reduce and transform can now be set in the config struct instead of a parameter
-- Device_scan and device_segmented_scan: `inclusive_scan` now uses the input-type as accumulator-type, `exclusive_scan` uses initial-value-type. 
+- Device_scan and device_segmented_scan: `inclusive_scan` now uses the input-type as accumulator-type, `exclusive_scan` uses initial-value-type.
   - This particularly changes behaviour of small-size input types with large-size output types (e.g. `short` input, `int` output).
   - And low-res input with high-res output (e.g. `float` input, `double` output)
 - Revert old Fiji workaround, because they solved the issue at compiler side

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -240,9 +240,10 @@ public:
     /// \param [in] storage - reference to a temporary storage object of type storage_type.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ///
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
@@ -294,9 +295,10 @@ public:
     /// \param [in, out] keys - reference to an array of keys provided by a thread.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void sort(Key (&keys)[ItemsPerThread],
               unsigned int begin_bit = 0,
@@ -312,9 +314,10 @@ public:
     /// \param [in] storage - reference to a temporary storage object of type storage_type.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ///
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
@@ -366,9 +369,10 @@ public:
     /// \param [in, out] keys - reference to an array of keys provided by a thread.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void sort_desc(Key (&keys)[ItemsPerThread],
                    unsigned int begin_bit = 0,
@@ -388,9 +392,10 @@ public:
     /// \param [in] storage - reference to a temporary storage object of type storage_type.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ///
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
@@ -451,9 +456,10 @@ public:
     /// \param [in, out] values - reference to an array of values provided by a thread.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     template<bool WithValues = with_values>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void sort(Key (&keys)[ItemsPerThread],
@@ -475,9 +481,10 @@ public:
     /// \param [in] storage - reference to a temporary storage object of type storage_type.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ///
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
@@ -538,9 +545,10 @@ public:
     /// \param [in, out] values - reference to an array of values provided by a thread.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     template<bool WithValues = with_values>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void sort_desc(Key (&keys)[ItemsPerThread],
@@ -559,9 +567,10 @@ public:
     /// \param [in] storage - reference to a temporary storage object of type storage_type.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ///
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
@@ -614,9 +623,10 @@ public:
     /// \param [in, out] keys - reference to an array of keys provided by a thread.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void sort_to_striped(Key (&keys)[ItemsPerThread],
                          unsigned int begin_bit = 0,
@@ -633,9 +643,10 @@ public:
     /// \param [in] storage - reference to a temporary storage object of type storage_type.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ///
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
@@ -688,9 +699,10 @@ public:
     /// \param [in, out] keys - reference to an array of keys provided by a thread.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void sort_desc_to_striped(Key (&keys)[ItemsPerThread],
                               unsigned int begin_bit = 0,
@@ -710,9 +722,10 @@ public:
     /// \param [in] storage - reference to a temporary storage object of type storage_type.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ///
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
@@ -771,9 +784,10 @@ public:
     /// \param [in, out] values - reference to an array of values provided by a thread.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     template<bool WithValues = with_values>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void sort_to_striped(Key (&keys)[ItemsPerThread],
@@ -795,9 +809,10 @@ public:
     /// \param [in] storage - reference to a temporary storage object of type storage_type.
     /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
     /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+    /// Non-default value not supported for floating-point key-types.
     /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
     /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-    /// value: \p <tt>8 * sizeof(Key)</tt>.
+    /// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
     ///
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused

--- a/rocprim/include/rocprim/detail/radix_sort.hpp
+++ b/rocprim/include/rocprim/detail/radix_sort.hpp
@@ -62,7 +62,7 @@ struct radix_key_codec_integral<Key, BitKey, typename std::enable_if<::rocprim::
     static unsigned int extract_digit(bit_key_type bit_key, unsigned int start, unsigned int length)
     {
         unsigned int mask = (1u << length) - 1;
-        return (unsigned int)(bit_key >> start) & mask;
+        return static_cast<unsigned int>(bit_key >> start) & mask;
     }
 };
 
@@ -90,7 +90,7 @@ struct radix_key_codec_integral<Key, BitKey, typename std::enable_if<::rocprim::
     static unsigned int extract_digit(bit_key_type bit_key, unsigned int start, unsigned int length)
     {
         unsigned int mask = (1u << length) - 1;
-        return (unsigned int)(bit_key >> start) & mask;
+        return static_cast<unsigned int>(bit_key >> start) & mask;
     }
 };
 
@@ -123,7 +123,7 @@ struct radix_key_codec_floating
         // -0.0 should be treated as +0.0 for stable sort
         // -0.0 is encoded as inverted sign_bit, +0.0 as sign_bit
         // or vice versa for descending sort
-        return (unsigned int)((bit_key == sign_bit ? ~sign_bit : bit_key) >> start) & mask;
+        return static_cast<unsigned int>((bit_key == sign_bit ? ~sign_bit : bit_key) >> start) & mask;
     }
 };
 
@@ -161,7 +161,7 @@ struct radix_key_codec_base<bool>
     static unsigned int extract_digit(bit_key_type bit_key, unsigned int start, unsigned int length)
     {
         unsigned int mask = (1u << length) - 1;
-        return (unsigned int)(bit_key >> start) & mask;
+        return static_cast<unsigned int>(bit_key >> start) & mask;
     }
 };
 

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -830,7 +830,8 @@ auto compare_nans(const T&, const T&)
 template<
     bool Descending,
     bool UseRadixMask,
-    class T
+    class T,
+    class Enable = void
 >
 struct radix_merge_compare;
 
@@ -853,115 +854,59 @@ struct radix_merge_compare<true, false, T>
         return compare_nans<T>(a, b) || a > b;
     }
 };
-/*
-template<class T>
-struct radix_merge_compare<false, true, T>
-{
-    using key_codec = radix_key_codec<T, true>;
-    using bit_key_type = typename key_codec::bit_key_type;
-
-    unsigned int bit, length;
-
-    radix_merge_compare(const unsigned int bit, const unsigned int current_radix_bits)
-    {
-        this->bit = bit;
-        this->length = current_radix_bits;
-    }
-
-    ROCPRIM_DEVICE ROCPRIM_INLINE
-    bool operator()(const T& a, const T& b) const
-    {
-        const bit_key_type encoded_key_a = key_codec::encode(a);
-        const bit_key_type masked_key_a  = key_codec::extract_digit(encoded_key_a, bit, length);
-
-        const bit_key_type encoded_key_b = key_codec::encode(b);
-        const bit_key_type masked_key_b  = key_codec::extract_digit(encoded_key_b, bit, length);
-
-        return key_codec::decode(masked_key_b) > key_codec::decode(masked_key_a);
-    }
-};
 
 template<class T>
-struct radix_merge_compare<true, true, T>
+struct radix_merge_compare<false, true, T, typename std::enable_if<rocprim::is_integral<T>::value>::type>
 {
-    using key_codec = radix_key_codec<T, true>;
-    using bit_key_type = typename key_codec::bit_key_type;
+    T radix_mask;
 
-    unsigned int bit, length;
-
-    radix_merge_compare(const unsigned int bit, const unsigned int current_radix_bits)
+    radix_merge_compare(const unsigned int start_bit, const unsigned int current_radix_bits)
     {
-        this->bit = bit;
-        this->length = current_radix_bits;
-    }
-
-    ROCPRIM_DEVICE ROCPRIM_INLINE
-    bool operator()(const T& a, const T& b) const
-    {
-        const bit_key_type encoded_key_a = key_codec::encode(a);
-        const bit_key_type masked_key_a  = key_codec::extract_digit(encoded_key_a, bit, length);
-
-        const bit_key_type encoded_key_b = key_codec::encode(b);
-        const bit_key_type masked_key_b  = key_codec::extract_digit(encoded_key_b, bit, length);
-
-        return key_codec::decode(masked_key_a) > key_codec::decode(masked_key_b);
-    }
-};*/
-
-template<class T>
-struct radix_merge_compare<false, true, T>
-{
-    using key_codec = radix_key_codec<T, true>;
-    using bit_key_type = typename key_codec::bit_key_type;
-
-    bit_key_type radix_mask;
-
-    radix_merge_compare(const unsigned int bit, const unsigned int current_radix_bits)
-    {
-        bit_key_type radix_mask_upper  = (bit_key_type(1) << (current_radix_bits + bit)) - 1;
-        bit_key_type radix_mask_bottom = bit == 0 ? 0 : ((bit_key_type(1) << bit) - 1);
+        T radix_mask_upper  = (T(1) << (current_radix_bits + start_bit)) - 1;
+        T radix_mask_bottom = (T(1) << start_bit) - 1;
         radix_mask = radix_mask_upper ^ radix_mask_bottom;
     }
 
     ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const T& a, const T& b) const
     {
-        const bit_key_type encoded_key_a = key_codec::encode(a);
-        const bit_key_type masked_key_a  = encoded_key_a & radix_mask;
-
-        const bit_key_type encoded_key_b = key_codec::encode(b);
-        const bit_key_type masked_key_b  = encoded_key_b & radix_mask;
-
-        return key_codec::decode(masked_key_b) > key_codec::decode(masked_key_a);
+        const T masked_key_a  = a & radix_mask;
+        const T masked_key_b  = b & radix_mask;
+        return masked_key_b > masked_key_a;
     }
 };
 
 template<class T>
-struct radix_merge_compare<true, true, T>
+struct radix_merge_compare<true, true, T, typename std::enable_if<rocprim::is_integral<T>::value>::type>
 {
-    using key_codec = radix_key_codec<T, true>;
-    using bit_key_type = typename key_codec::bit_key_type;
+    T radix_mask;
 
-    bit_key_type radix_mask;
-
-    radix_merge_compare(const unsigned int bit, const unsigned int current_radix_bits)
+    radix_merge_compare(const unsigned int start_bit, const unsigned int current_radix_bits)
     {
-        bit_key_type radix_mask_upper  = (bit_key_type(1) << (current_radix_bits + bit)) - 1;
-        bit_key_type radix_mask_bottom = bit == 0 ? 0 : ((bit_key_type(1) << bit) - 1);
-        radix_mask = radix_mask_upper ^ radix_mask_bottom;
+        T radix_mask_upper  = (T(1) << (current_radix_bits + start_bit)) - 1;
+        T radix_mask_bottom = (T(1) << start_bit) - 1;
+        radix_mask = (radix_mask_upper ^ radix_mask_bottom);
     }
 
     ROCPRIM_DEVICE ROCPRIM_INLINE
     bool operator()(const T& a, const T& b) const
     {
-        const bit_key_type encoded_key_a = key_codec::encode(a);
-        const bit_key_type masked_key_a  = encoded_key_a & radix_mask;
-
-        const bit_key_type encoded_key_b = key_codec::encode(b);
-        const bit_key_type masked_key_b  = encoded_key_b & radix_mask;
-
-        return key_codec::decode(masked_key_a) > key_codec::decode(masked_key_b);
+        const T masked_key_a  = a & radix_mask;
+        const T masked_key_b  = b & radix_mask;
+        return masked_key_a > masked_key_b;
     }
+};
+
+template<bool Descending, class T>
+struct radix_merge_compare<Descending, true, T, typename std::enable_if<rocprim::is_floating_point<T>::value>::type>
+{
+    // radix_merge_compare supports masks only for integrals.
+    // even though masks are never used for floating point-types,
+    // it needs to be able to compile.
+    radix_merge_compare(const unsigned int, const unsigned int){}
+
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    bool operator()(const T&, const T&) const { return false; }
 };
 
 template<>

--- a/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -754,9 +754,10 @@ hipError_t radix_sort_impl(void * temporary_storage,
 /// \param [in] size - number of element in the input range.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -857,9 +858,10 @@ hipError_t radix_sort_keys(void * temporary_storage,
 /// \param [in] size - number of element in the input range.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -967,9 +969,10 @@ hipError_t radix_sort_keys_desc(void * temporary_storage,
 /// \param [in] size - number of element in the input range.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -1089,9 +1092,10 @@ hipError_t radix_sort_pairs(void * temporary_storage,
 /// \param [in] size - number of element in the input range.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -1202,9 +1206,10 @@ hipError_t radix_sort_pairs_desc(void * temporary_storage,
 /// \param [in] size - number of element in the input range.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -1311,9 +1316,10 @@ hipError_t radix_sort_keys(void * temporary_storage,
 /// \param [in] size - number of element in the input range.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -1423,9 +1429,10 @@ hipError_t radix_sort_keys_desc(void * temporary_storage,
 /// \param [in] size - number of element in the input range.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -1547,9 +1554,10 @@ hipError_t radix_sort_pairs(void * temporary_storage,
 /// \param [in] size - number of element in the input range.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.

--- a/rocprim/include/rocprim/device/device_scan.hpp
+++ b/rocprim/include/rocprim/device/device_scan.hpp
@@ -27,8 +27,8 @@
 #include "../config.hpp"
 #include "../functional.hpp"
 #include "../type_traits.hpp"
+#include "../types/future_value.hpp"
 #include "../detail/various.hpp"
-#include "../detail/match_result_type.hpp"
 
 #include "device_scan_config.hpp"
 #include "device_transform.hpp"
@@ -50,18 +50,19 @@ template<
     class InputIterator,
     class OutputIterator,
     class BinaryFunction,
-    class ResultType
+    class InitValueType,
+    class InitValueIterator
 >
 ROCPRIM_KERNEL
 __launch_bounds__(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE)
 void single_scan_kernel(InputIterator input,
                         const size_t size,
-                        ResultType initial_value,
+                        const input_value<InitValueType, InitValueIterator> initial_value,
                         OutputIterator output,
                         BinaryFunction scan_op)
 {
     single_scan_kernel_impl<Exclusive, Config>(
-        input, size, initial_value, output, scan_op
+        input, size, initial_value.get(), output, scan_op
     );
 }
 
@@ -92,23 +93,24 @@ template<
     class InputIterator,
     class OutputIterator,
     class BinaryFunction,
-    class ResultType
+    class InitValueType,
+    class InitValueIterator
 >
 ROCPRIM_KERNEL
 __launch_bounds__(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE)
 void final_scan_kernel(InputIterator input,
                        const size_t size,
                        OutputIterator output,
-                       const ResultType initial_value,
+                       const input_value<InitValueType, InitValueIterator> initial_value,
                        BinaryFunction scan_op,
-                       ResultType * block_prefixes,
-                       ResultType * previous_last_element = nullptr,
-                       ResultType * new_last_element = nullptr,
+                       InitValueType* block_prefixes,
+                       InitValueType* previous_last_element = nullptr,
+                       InitValueType* new_last_element = nullptr,
                        bool override_first_value = false,
                        bool save_last_value = false)
 {
     final_scan_kernel_impl<Exclusive, Config>(
-        input, size, output, initial_value,
+        input, size, output, initial_value.get(),
         scan_op, block_prefixes,
         previous_last_element, new_last_element,
         override_first_value, save_last_value
@@ -123,7 +125,8 @@ template<
     class InputIterator,
     class OutputIterator,
     class BinaryFunction,
-    class ResultType,
+    class InitValueType,
+    class InitValueIterator,
     class LookBackScanState
 >
 ROCPRIM_KERNEL
@@ -131,18 +134,18 @@ __launch_bounds__(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE)
 void lookback_scan_kernel(InputIterator input,
                           OutputIterator output,
                           const size_t size,
-                          ResultType initial_value,
+                          const input_value<InitValueType, InitValueIterator> initial_value,
                           BinaryFunction scan_op,
                           LookBackScanState lookback_scan_state,
                           const unsigned int number_of_blocks,
                           ordered_block_id<unsigned int> ordered_bid,
-                          ResultType * previous_last_element = nullptr,
-                          ResultType * new_last_element = nullptr,
+                          InitValueType* previous_last_element = nullptr,
+                          InitValueType* new_last_element = nullptr,
                           bool override_first_value = false,
                           bool save_last_value = false)
 {
     lookback_scan_kernel_impl<Exclusive, Config>(
-        input, output, size, initial_value, scan_op,
+        input, output, size, initial_value.get(), scan_op,
         lookback_scan_state, number_of_blocks, ordered_bid,
         previous_last_element, new_last_element,
         override_first_value, save_last_value
@@ -193,6 +196,7 @@ template<
     class InputIterator,
     class OutputIterator,
     class InitValueType,
+    class InitValueIterator,
     class BinaryFunction
 >
 inline
@@ -200,16 +204,13 @@ auto scan_impl(void * temporary_storage,
                size_t& storage_size,
                InputIterator input,
                OutputIterator output,
-               const InitValueType initial_value,
+               const input_value<InitValueType, InitValueIterator> initial_value,
                const size_t size,
                BinaryFunction scan_op,
                const hipStream_t stream,
                bool debug_synchronous)
     -> typename std::enable_if<!Config::use_lookback, hipError_t>::type
 {
-    using input_type = typename std::iterator_traits<InputIterator>::value_type;
-    using result_type = typename std::conditional<Exclusive, InitValueType, input_type>::type;
-
     using config = Config;
 
     constexpr unsigned int block_size = config::block_size;
@@ -220,7 +221,7 @@ auto scan_impl(void * temporary_storage,
     static constexpr size_t aligned_size_limit = ::rocprim::max<size_t>(size_limit - size_limit % items_per_block, items_per_block);
     size_t limited_size = std::min<size_t>(size, aligned_size_limit);
     const bool use_limited_size = limited_size == aligned_size_limit;
-    size_t nested_prefixes_size_bytes = scan_get_temporary_storage_bytes<result_type>(limited_size, items_per_block);
+    size_t nested_prefixes_size_bytes = scan_get_temporary_storage_bytes<InitValueType>(limited_size, items_per_block);
 
     // Calculate required temporary storage
     if(temporary_storage == nullptr)
@@ -228,7 +229,7 @@ auto scan_impl(void * temporary_storage,
         storage_size = nested_prefixes_size_bytes;
 
         if(use_limited_size)
-            storage_size += 4 * sizeof(result_type);
+            storage_size += 4 * sizeof(InitValueType);
 
         // Make sure user won't try to allocate 0 bytes memory, because
         // hipMalloc will return nullptr when size is zero.
@@ -266,16 +267,16 @@ auto scan_impl(void * temporary_storage,
 
             // Pointer to array with block_prefixes
             char * ptr = reinterpret_cast<char *>(temporary_storage);
-            result_type * block_prefixes = reinterpret_cast<result_type*>(ptr);
-            result_type * previous_last_element = nullptr;
-            result_type * new_last_element = nullptr;
+            InitValueType* block_prefixes = reinterpret_cast<InitValueType*>(ptr);
+            InitValueType* previous_last_element = nullptr;
+            InitValueType* new_last_element = nullptr;
             if(use_limited_size)
             {
                 ptr += nested_prefixes_size_bytes;
-                previous_last_element = reinterpret_cast<result_type*>(ptr);
+                previous_last_element = reinterpret_cast<InitValueType*>(ptr);
 
-                ptr += sizeof(result_type);
-                new_last_element = reinterpret_cast<result_type*>(ptr);
+                ptr += sizeof(InitValueType);
+                new_last_element = reinterpret_cast<InitValueType*>(ptr);
             }
 
             // Grid size for block_reduce_kernel, we don't need to calculate reduction
@@ -286,7 +287,7 @@ auto scan_impl(void * temporary_storage,
                 if(debug_synchronous) start = std::chrono::high_resolution_clock::now();
                 hipLaunchKernelGGL(
                     HIP_KERNEL_NAME(detail::block_reduce_kernel<
-                        config, InputIterator, BinaryFunction, result_type
+                        config, InputIterator, BinaryFunction, InitValueType
                     >),
                     dim3(grid_size), dim3(block_size), 0, stream,
                     input + offset, scan_op, block_prefixes
@@ -307,7 +308,7 @@ auto scan_impl(void * temporary_storage,
 
                 // Calculate size of temporary storage for nested device scan operation
                 void * nested_temp_storage = static_cast<void*>(block_prefixes + number_of_blocks);
-                auto nested_temp_storage_size = storage_size - (number_of_blocks * sizeof(result_type));
+                auto nested_temp_storage_size = storage_size - (number_of_blocks * sizeof(InitValueType));
 
                 if(debug_synchronous) start = std::chrono::high_resolution_clock::now();
                 auto error = scan_impl<false, config>(
@@ -315,12 +316,11 @@ auto scan_impl(void * temporary_storage,
                     nested_temp_storage_size,
                     block_prefixes, // input
                     block_prefixes, // output
-                    result_type(), // dummy initial value
+                    input_value<InitValueType, InitValueIterator>{InitValueType()}, // dummy initial value
                     number_of_blocks, // input size
                     scan_op,
                     stream,
-                    debug_synchronous,
-                    size_limit
+                    debug_synchronous
                 );
                 if(error != hipSuccess) return error;
                 ROCPRIM_DETAIL_HIP_SYNC("nested_device_scan", number_of_blocks, start);
@@ -335,7 +335,7 @@ auto scan_impl(void * temporary_storage,
                     Exclusive, // flag for exclusive scan operation
                     config, // kernel configuration (block size, ipt)
                     InputIterator, OutputIterator,
-                    BinaryFunction, result_type
+                    BinaryFunction, InitValueType
                 >),
                 dim3(grid_size), dim3(block_size), 0, stream,
                 input + offset,
@@ -356,7 +356,7 @@ auto scan_impl(void * temporary_storage,
             {
                 hipError_t error = ::rocprim::transform(
                     new_last_element, previous_last_element, 1,
-                    ::rocprim::identity<result_type>(),
+                    ::rocprim::identity<InitValueType>(),
                     stream, debug_synchronous
                 );
                 if(error != hipSuccess) return error;
@@ -393,6 +393,7 @@ template<
     class InputIterator,
     class OutputIterator,
     class InitValueType,
+    class InitValueIterator,
     class BinaryFunction
 >
 inline
@@ -400,20 +401,17 @@ auto scan_impl(void * temporary_storage,
                size_t& storage_size,
                InputIterator input,
                OutputIterator output,
-               const InitValueType initial_value,
+               const input_value<InitValueType, InitValueIterator> initial_value,
                const size_t size,
                BinaryFunction scan_op,
                const hipStream_t stream,
                bool debug_synchronous)
     -> typename std::enable_if<Config::use_lookback, hipError_t>::type
 {
-    using input_type = typename std::iterator_traits<InputIterator>::value_type;
-    using result_type = typename std::conditional<Exclusive, InitValueType, input_type>::type;
-
     using config = Config;
 
-    using scan_state_type = detail::lookback_scan_state<result_type>;
-    using scan_state_with_sleep_type = detail::lookback_scan_state<result_type, true>;
+    using scan_state_type = detail::lookback_scan_state<InitValueType>;
+    using scan_state_with_sleep_type = detail::lookback_scan_state<InitValueType, true>;
     using ordered_block_id_type = detail::ordered_block_id<unsigned int>;
 
     constexpr unsigned int block_size = config::block_size;
@@ -439,7 +437,7 @@ auto scan_impl(void * temporary_storage,
         storage_size = scan_state_bytes + ordered_block_id_bytes;
 
         if(use_limited_size)
-            storage_size += 2 * sizeof(result_type);
+            storage_size += 2 * sizeof(InitValueType);
 
         return hipSuccess;
     }
@@ -462,14 +460,14 @@ auto scan_impl(void * temporary_storage,
         );
 
         // The last element
-        result_type * previous_last_element = nullptr;
-        result_type * new_last_element = nullptr;
+        InitValueType* previous_last_element = nullptr;
+        InitValueType* new_last_element = nullptr;
         if(use_limited_size)
         {
-            ptr += storage_size - sizeof(result_type);
-            new_last_element = reinterpret_cast<result_type*>(ptr);
-            ptr -= sizeof(result_type);
-            previous_last_element = reinterpret_cast<result_type*>(ptr);
+            ptr += storage_size - sizeof(InitValueType);
+            new_last_element = reinterpret_cast<InitValueType*>(ptr);
+            ptr -= sizeof(InitValueType);
+            previous_last_element = reinterpret_cast<InitValueType*>(ptr);
         }
 
         hipDeviceProp_t prop;
@@ -530,7 +528,7 @@ auto scan_impl(void * temporary_storage,
                         Exclusive, // flag for exclusive scan operation
                         config, // kernel configuration (block size, ipt)
                         InputIterator, OutputIterator,
-                        BinaryFunction, result_type, scan_state_with_sleep_type
+                        BinaryFunction, InitValueType, InitValueIterator, scan_state_with_sleep_type
                     >),
                     dim3(grid_size), dim3(block_size), 0, stream,
                     input + offset, output + offset, current_size, initial_value,
@@ -556,7 +554,7 @@ auto scan_impl(void * temporary_storage,
                         Exclusive, // flag for exclusive scan operation
                         config, // kernel configuration (block size, ipt)
                         InputIterator, OutputIterator,
-                        BinaryFunction, result_type, scan_state_type
+                        BinaryFunction, InitValueType, InitValueIterator, scan_state_type
                     >),
                     dim3(grid_size), dim3(block_size), 0, stream,
                     input + offset, output + offset, current_size, initial_value,
@@ -572,7 +570,7 @@ auto scan_impl(void * temporary_storage,
             {
                 hipError_t error = ::rocprim::transform(
                     new_last_element, previous_last_element, 1,
-                    ::rocprim::identity<result_type>(),
+                    ::rocprim::identity<InitValueType>(),
                     stream, debug_synchronous
                 );
                 if(error != hipSuccess) return error;
@@ -710,7 +708,7 @@ hipError_t inclusive_scan(void * temporary_storage,
     return detail::scan_impl<false, config>(
         temporary_storage, storage_size,
         // input_type() is a dummy initial value (not used)
-        input, output, input_type(), size,
+        input, output, detail::make_input_value(input_type()), size,
         scan_op, stream, debug_synchronous
     );
 }
@@ -746,6 +744,7 @@ hipError_t inclusive_scan(void * temporary_storage,
 /// \param [out] output - iterator to the first element in the output range. It can be
 /// same as \p input.
 /// \param [in] initial_value - initial value to start the scan.
+/// A rocpim::future_value may be passed to use a value that will be later computed.
 /// \param [in] size - number of element in the input range.
 /// \param [in] scan_op - binary operation function object that will be used for scan.
 /// The signature of the function should be equivalent to the following:
@@ -817,17 +816,17 @@ hipError_t exclusive_scan(void * temporary_storage,
                           const hipStream_t stream = 0,
                           bool debug_synchronous = false)
 {
-    using result_type = InitValueType;
+    using value_type = detail::future_type_t<InitValueType>;
 
     // Get default config if Config is default_config
     using config = detail::default_or_custom_config<
         Config,
-        detail::default_scan_config<ROCPRIM_TARGET_ARCH, result_type>
+        detail::default_scan_config<ROCPRIM_TARGET_ARCH, value_type>
     >;
 
     return detail::scan_impl<true, config>(
         temporary_storage, storage_size,
-        input, output, initial_value, size,
+        input, output, detail::make_input_value(initial_value), size,
         scan_op, stream, debug_synchronous
     );
 }

--- a/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
@@ -250,9 +250,10 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
 /// \param [in] end_offsets - iterator to the first element in the range of ending offsets.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -371,9 +372,10 @@ hipError_t segmented_radix_sort_keys(void * temporary_storage,
 /// \param [in] end_offsets - iterator to the first element in the range of ending offsets.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -499,9 +501,10 @@ hipError_t segmented_radix_sort_keys_desc(void * temporary_storage,
 /// \param [in] end_offsets - iterator to the first element in the range of ending offsets.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -639,9 +642,10 @@ hipError_t segmented_radix_sort_pairs(void * temporary_storage,
 /// \param [in] end_offsets - iterator to the first element in the range of ending offsets.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -770,9 +774,10 @@ hipError_t segmented_radix_sort_pairs_desc(void * temporary_storage,
 /// \param [in] end_offsets - iterator to the first element in the range of ending offsets.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -897,9 +902,10 @@ hipError_t segmented_radix_sort_keys(void * temporary_storage,
 /// \param [in] end_offsets - iterator to the first element in the range of ending offsets.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -1027,9 +1033,10 @@ hipError_t segmented_radix_sort_keys_desc(void * temporary_storage,
 /// \param [in] end_offsets - iterator to the first element in the range of ending offsets.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.
@@ -1169,9 +1176,10 @@ hipError_t segmented_radix_sort_pairs(void * temporary_storage,
 /// \param [in] end_offsets - iterator to the first element in the range of ending offsets.
 /// \param [in] begin_bit - [optional] index of the first (least significant) bit used in
 /// key comparison. Must be in range <tt>[0; 8 * sizeof(Key))</tt>. Default value: \p 0.
+/// Non-default value not supported for floating-point key-types.
 /// \param [in] end_bit - [optional] past-the-end index (most significant) bit used in
 /// key comparison. Must be in range <tt>(begin_bit; 8 * sizeof(Key)]</tt>. Default
-/// value: \p <tt>8 * sizeof(Key)</tt>.
+/// value: \p <tt>8 * sizeof(Key)</tt>. Non-default value not supported for floating-point key-types.
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. Default value is \p false.

--- a/rocprim/include/rocprim/types.hpp
+++ b/rocprim/include/rocprim/types.hpp
@@ -26,6 +26,7 @@
 // Meta configuration for rocPRIM
 #include "config.hpp"
 
+#include "types/future_value.hpp"
 #include "types/double_buffer.hpp"
 #include "types/integer_sequence.hpp"
 #include "types/key_value_pair.hpp"

--- a/rocprim/include/rocprim/types/future_value.hpp
+++ b/rocprim/include/rocprim/types/future_value.hpp
@@ -1,0 +1,203 @@
+// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ROCPRIM_TYPES_FUTURE_VALUE_HPP_
+#define ROCPRIM_TYPES_FUTURE_VALUE_HPP_
+
+#include "../config.hpp"
+
+/// \addtogroup utilsmodule
+/// @{
+
+BEGIN_ROCPRIM_NAMESPACE
+
+/**
+ * \brief Allows passing values that are not yet known at launch time as paramters to device algorithms.
+ *
+ * \note It is the users responsibility to ensure that value is available when the algorithm executes.
+ * This can be guaranteed with stream dependencies or explicit external synchronization.
+ *
+ * \code
+ * int* intermediate_result = nullptr;
+ * hipMalloc(reinterpret_cast<void**>(&intermediate_result), sizeof(intermediate_result));
+ * hipLaunchKernelGGL(compute_intermediate, blocks, threads, 0, stream, arg1, arg2, itermediate_result);
+ * const auto initial_value = rocprim::future_value<int>{intermediate_result};
+ * rocprim::exclusive_scan(temporary_storage,
+ *                         storage_size,
+ *                         input,
+ *                         output,
+ *                         initial_value,
+ *                         size);
+ * hipFree(intermediate_result)
+ * \endcode
+ *
+ * \tparam T
+ * \tparam Iter
+ */
+template <typename T, typename Iter = T*>
+class future_value
+{
+public:
+    using value_type    = T;
+    using iterator_type = Iter;
+
+    explicit ROCPRIM_HOST_DEVICE future_value(const Iter iter)
+        : iter_ {iter}
+    {
+    }
+
+    ROCPRIM_HOST_DEVICE operator T()
+    {
+        return *iter_;
+    }
+
+    ROCPRIM_HOST_DEVICE operator T() const
+    {
+        return *iter_;
+    }
+private:
+    Iter iter_;
+};
+
+namespace detail
+{
+    /**
+     * \brief Allows a single kernel to support both future and immediate values.
+     */
+    template <typename T, typename Iter = T*>
+    class input_value
+    {
+    public:
+        using value_type    = T;
+        using iterator_type = Iter;
+
+        ROCPRIM_HOST_DEVICE operator T()
+        {
+            return is_future_ ? future_value_ : immediate_value_;
+        }
+
+        ROCPRIM_HOST_DEVICE operator T() const
+        {
+            return is_future_ ? future_value_ : immediate_value_;
+        }
+
+        ROCPRIM_HOST_DEVICE T get()
+        {
+            return operator T();
+        }
+
+        ROCPRIM_HOST_DEVICE T get() const
+        {
+            return operator T();
+        }
+
+        explicit ROCPRIM_HOST_DEVICE input_value(const T immediate)
+            : immediate_value_ {immediate}
+            , is_future_ {false}
+        {
+        }
+
+        explicit ROCPRIM_HOST_DEVICE input_value(const future_value<T, Iter> future)
+            : future_value_ {future}
+            , is_future_ {true}
+        {
+        }
+
+        ROCPRIM_HOST_DEVICE input_value(const input_value& rhs)
+            : is_future_ {rhs.is_future_}
+        {
+            if(is_future_)
+            {
+                future_value_ = rhs.future_value_;
+            }
+            else
+            {
+                immediate_value_ = rhs.immediate_value_;
+            }
+        }
+
+        ROCPRIM_HOST_DEVICE input_value& operator=(const input_value& rhs)
+        {
+            is_future_ = rhs.is_future_;
+            if(is_future_)
+            {
+                future_value_ = rhs.future_value_;
+            }
+            else
+            {
+                immediate_value_ = rhs.immediate_value_;
+            }
+        }
+
+        ROCPRIM_HOST_DEVICE ~input_value()
+        {
+            if(is_future_) {
+                future_value_.~future_value<T, Iter>();
+            } else {
+                immediate_value_.~T();
+            }
+        }
+
+    private:
+        union
+        {
+            future_value<T, Iter> future_value_;
+            T                     immediate_value_;
+        };
+        bool is_future_;
+    };
+
+    template <typename T>
+    struct future_value_traits
+    {
+        using value_type    = T;
+        using iterator_type = T*;
+    };
+
+    template <typename T, typename Iter>
+    struct future_value_traits<::rocprim::future_value<T, Iter>>
+    {
+        using value_type    = T;
+        using iterator_type = Iter;
+    };
+
+    template <typename T>
+    using future_type_t = typename future_value_traits<T>::value_type;
+
+    template <typename T>
+    using future_iterator_t = typename future_value_traits<T>::iterator_type;
+
+    template <typename T, typename Iter>
+    input_value<T, Iter> make_input_value(const ::rocprim::future_value<T, Iter> future) {
+        return input_value<T, Iter>{future};
+    }
+
+    template <typename T>
+    input_value<T, T*> make_input_value(const T immediate_value) {
+        return input_value<T, T*>(immediate_value);
+    }
+}
+
+END_ROCPRIM_NAMESPACE
+
+/// @}
+// end of group utilsmodule
+
+#endif

--- a/test/rocprim/test_arg_index_iterator.cpp
+++ b/test/rocprim/test_arg_index_iterator.cpp
@@ -192,7 +192,7 @@ TYPED_TEST(RocprimArgIndexIteratorTests, ReduceArgMinimum)
         HIP_CHECK(hipDeviceSynchronize());
 
         // Check if output values are as expected
-        auto diff = std::max<T>(std::abs(test_utils::precision_threshold<T>::percentage * expected.value), T(test_utils::precision_threshold<T>::percentage));
+        auto diff = std::abs(test_utils::precision_threshold<T>::percentage * expected.value);
         if(std::is_integral<T>::value) diff = 0;
         ASSERT_EQ(output[0].key, expected.key);
         ASSERT_NEAR(output[0].value, expected.value, diff);

--- a/test/rocprim/test_block_reduce.kernels.hpp
+++ b/test/rocprim/test_block_reduce.kernels.hpp
@@ -90,8 +90,7 @@ struct static_run_algo
         }
         else
         {
-            float threshold_multiplier = std::is_same<T, ::rocprim::bfloat16>::value ? 10.0f : 5.0f;
-            test_utils::assert_near(output_reductions, expected_reductions, threshold_multiplier * test_utils::precision_threshold<T>::percentage);
+            test_utils::assert_near(output_reductions, expected_reductions, test_utils::precision_threshold<T>::percentage);
         }
     }
 };
@@ -157,8 +156,7 @@ struct static_run_valid
         );
 
         // Verifying results
-        float threshold_multiplier = std::is_same<T, ::rocprim::bfloat16>::value ? 10.0f : 5.0f;
-        test_utils::assert_near(output_reductions, expected_reductions, threshold_multiplier * test_utils::precision_threshold<T>::percentage);
+        test_utils::assert_near(output_reductions, expected_reductions, test_utils::precision_threshold<T>::percentage);
     }
 };
 
@@ -200,7 +198,7 @@ template<
 >
 void test_block_reduce_input_arrays()
 {
-    using binary_op_type = typename test_utils::select_maximum_operator<T>::type;;
+    using binary_op_type = typename test_utils::select_maximum_operator<T>::type;
     static constexpr auto algorithm = Algorithm;
     static constexpr size_t block_size = BlockSize;
     static constexpr size_t items_per_thread = ItemsPerThread;
@@ -235,7 +233,7 @@ void test_block_reduce_input_arrays()
             for(size_t j = 0; j < items_per_block; j++)
             {
                 auto idx = i * items_per_block + j;
-                value = apply(binary_op, value, output[idx]);
+                value = binary_op(value, output[idx]);
             }
             expected_reductions[i] = value;
         }
@@ -279,8 +277,7 @@ void test_block_reduce_input_arrays()
         );
 
         // Verifying results
-        float threshold_multiplier = std::is_same<T, ::rocprim::bfloat16>::value ? 10.0f : 5.0f;
-        test_utils::assert_near(output_reductions, expected_reductions, threshold_multiplier * test_utils::precision_threshold<T>::percentage);
+        test_utils::assert_near(output_reductions, expected_reductions, test_utils::precision_threshold<T>::percentage);
 
         HIP_CHECK(hipFree(device_output));
         HIP_CHECK(hipFree(device_output_reductions));

--- a/test/rocprim/test_block_scan.kernels.hpp
+++ b/test/rocprim/test_block_scan.kernels.hpp
@@ -498,7 +498,7 @@ auto test_block_scan_input_arrays()
             for(size_t j = 0; j < items_per_block; j++)
             {
                 auto idx = i * items_per_block + j;
-                expected[idx] = apply(binary_op, output[idx], expected[j > 0 ? idx-1 : idx]);
+                expected[idx] = binary_op(output[idx], expected[j > 0 ? idx-1 : idx]);
             }
         }
 
@@ -585,7 +585,7 @@ auto test_block_scan_input_arrays()
             for(size_t j = 0; j < items_per_block; j++)
             {
                 auto idx = i * items_per_block + j;
-                expected[idx] = apply(binary_op, output[idx], expected[j > 0 ? idx-1 : idx]);
+                expected[idx] = binary_op(output[idx], expected[j > 0 ? idx-1 : idx]);
             }
             expected_reductions[i] = expected[(i+1) * items_per_block - 1];
         }
@@ -699,7 +699,7 @@ auto test_block_scan_input_arrays()
             for(size_t j = 0; j < items_per_block; j++)
             {
                 auto idx = i * items_per_block + j;
-                expected[idx] = apply(binary_op, output[idx], expected[j > 0 ? idx-1 : idx]);
+                expected[idx] = binary_op(output[idx], expected[j > 0 ? idx-1 : idx]);
             }
             expected_block_prefixes[i] = expected[(i+1) * items_per_block - 1];
         }
@@ -813,7 +813,7 @@ auto test_block_scan_input_arrays()
             for(size_t j = 1; j < items_per_block; j++)
             {
                 auto idx = i * items_per_block + j;
-                expected[idx] = apply(binary_op, output[idx-1], expected[idx-1]);
+                expected[idx] = binary_op(output[idx-1], expected[idx-1]);
             }
         }
 
@@ -903,12 +903,12 @@ auto test_block_scan_input_arrays()
             for(size_t j = 1; j < items_per_block; j++)
             {
                 auto idx = i * items_per_block + j;
-                expected[idx] = apply(binary_op, output[idx-1], expected[idx-1]);
+                expected[idx] = binary_op(output[idx-1], expected[idx-1]);
             }
             for(size_t j = 0; j < items_per_block; j++)
             {
                 auto idx = i * items_per_block + j;
-                expected_reductions[i] = apply(binary_op, expected_reductions[i], output[idx]);
+                expected_reductions[i] = binary_op(expected_reductions[i], output[idx]);
             }
         }
 
@@ -1012,13 +1012,13 @@ auto test_block_scan_input_arrays()
             for(size_t j = 1; j < items_per_block; j++)
             {
                 auto idx = i * items_per_block + j;
-                expected[idx] = apply(binary_op, output[idx-1], expected[idx-1]);
+                expected[idx] = binary_op(output[idx-1], expected[idx-1]);
             }
             expected_block_prefixes[i] = block_prefix;
             for(size_t j = 0; j < items_per_block; j++)
             {
                 auto idx = i * items_per_block + j;
-                expected_block_prefixes[i] = apply(binary_op, expected_block_prefixes[i], output[idx]);
+                expected_block_prefixes[i] = binary_op(expected_block_prefixes[i], output[idx]);
             }
         }
 

--- a/test/rocprim/test_device_radix_sort.cpp
+++ b/test/rocprim/test_device_radix_sort.cpp
@@ -82,6 +82,11 @@ typedef ::testing::Types<
     params<unsigned short, rocprim::bfloat16, false, 3, 11>,
     params<unsigned long long, char, false, 8, 20>,
     params<unsigned short, test_utils::custom_test_type<double>, false, 8, 11>,
+    // some params used by PyTorch's Randperm()
+    params<int64_t, int64_t, false, 0, 34>,
+    params<int64_t, float, true, 0, 34>,
+    params<int64_t, rocprim::half, true, 0, 34>,
+    params<int64_t, int64_t, false, 0, 34, true>,
 
     // huge sizes to check correctness of more than 1 block per batch
     params<int, char, false, 0, 32, true>,

--- a/test/rocprim/test_device_reduce.cpp
+++ b/test/rocprim/test_device_reduce.cpp
@@ -43,7 +43,7 @@ struct DeviceReduceParams
     using input_type = InputType;
     using output_type = OutputType;
     // Tests output iterator with void value_type (OutputIterator concept)
-    static constexpr bool use_identity_iterator =  UseIdentityIterator;
+    static constexpr bool use_identity_iterator = UseIdentityIterator;
     static constexpr size_t size_limit = SizeLimit;
 };
 

--- a/test/rocprim/test_device_scan.cpp
+++ b/test/rocprim/test_device_scan.cpp
@@ -23,11 +23,9 @@
 #include "common_test_header.hpp"
 
 // required rocprim headers
-#include <rocprim/device/device_reduce.hpp>
 #include <rocprim/device/device_scan.hpp>
 #include <rocprim/device/device_scan_by_key.hpp>
 #include <rocprim/iterator/constant_iterator.hpp>
-#include <rocprim/types/future_value.hpp>
 
 // required test headers
 #include "test_utils_types.hpp"
@@ -258,7 +256,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
 
             // Calculate expected results on host
             std::vector<U> expected(input.size());
-            std::partial_sum(
+            test_utils::host_inclusive_scan(
                 input.begin(), input.end(),
                 expected.begin(), scan_op
             );
@@ -506,29 +504,10 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
 
             // Calculate expected results on host
             std::vector<U> expected(input.size());
-            std::partial_sum(
-                rocprim::make_zip_iterator(
-                    rocprim::make_tuple(input.begin(), keys.begin())
-                ),
-                rocprim::make_zip_iterator(
-                    rocprim::make_tuple(input.end(), keys.end())
-                ),
-                rocprim::make_zip_iterator(
-                    rocprim::make_tuple(expected.begin(), rocprim::make_discard_iterator())
-                ),
-                [scan_op, keys_compare_op](const rocprim::tuple<U, K>& t1,
-                                        const rocprim::tuple<U, K>& t2)
-                    -> rocprim::tuple<U, K>
-                {
-                    if(keys_compare_op(rocprim::get<1>(t1), rocprim::get<1>(t2)))
-                    {
-                        return rocprim::make_tuple(
-                            scan_op(rocprim::get<0>(t1), rocprim::get<0>(t2)),
-                            rocprim::get<1>(t2)
-                        );
-                    }
-                    return t2;
-                }
+            test_utils::host_inclusive_scan_by_key(
+                input.begin(), input.end(), keys.begin(),
+                expected.begin(),
+                scan_op, keys_compare_op
             );
 
             // temp storage
@@ -749,7 +728,7 @@ public:
     using pointer           = conditional_discard_value*;
     using iterator_category = std::random_access_iterator_tag;
     using difference_type   = std::ptrdiff_t;
-    
+
     __host__ __device__ single_index_iterator(T* value, size_t expected_index, size_t index = 0)
         : value_{value}
         , expected_index_{expected_index}
@@ -873,7 +852,7 @@ TEST(RocprimDeviceScanTests, LargeIndicesInclusiveScan)
             HIP_CHECK(hipMemcpy(&output, d_output, sizeof(T), hipMemcpyDeviceToHost));
             HIP_CHECK(hipDeviceSynchronize());
 
-            // Sum of 'size' increasing numbers starting at 'n' is size * (2n + size - 1) 
+            // Sum of 'size' increasing numbers starting at 'n' is size * (2n + size - 1)
             // The division is not integer division but either (size) or (2n + size - 1) has to be even.
             const T multiplicand_1 = size;
             const T multiplicand_2 = 2 * (*input_begin) + size - 1;
@@ -966,7 +945,7 @@ TEST(RocprimDeviceScanTests, LargeIndicesExclusiveScan)
             HIP_CHECK(hipMemcpy(&output, d_output, sizeof(T), hipMemcpyDeviceToHost));
             HIP_CHECK(hipDeviceSynchronize());
 
-            // Sum of 'size' - 1 increasing numbers starting at 'n' is (size - 1) * (2n + size - 2) 
+            // Sum of 'size' - 1 increasing numbers starting at 'n' is (size - 1) * (2n + size - 2)
             // The division is not integer division but either (size - 1) or (2n + size - 2) has to be even.
             const T multiplicand_1 = size - 1;
             const T multiplicand_2 = 2 * (*input_begin) + size - 2;
@@ -980,158 +959,6 @@ TEST(RocprimDeviceScanTests, LargeIndicesExclusiveScan)
 
             hipFree(d_temp_storage);
             hipFree(d_output);
-        }
-    }
-}
-
-using RocprimDeviceScanFutureTestsParams
-    = ::testing::Types<DeviceScanParams<char>,
-                       DeviceScanParams<int>,
-                       DeviceScanParams<float, double, rocprim::minimum<double>>,
-                       DeviceScanParams<double, double, rocprim::plus<double>, true>,
-                       DeviceScanParams<test_utils::custom_test_type<int>>,
-                       DeviceScanParams<test_utils::custom_test_array_type<long long, 5>>>;
-
-template <typename Params>
-class RocprimDeviceScanFutureTests : public RocprimDeviceScanTests<Params>
-{
-};
-
-TYPED_TEST_SUITE(RocprimDeviceScanFutureTests, RocprimDeviceScanFutureTestsParams);
-
-TYPED_TEST(RocprimDeviceScanFutureTests, ExclusiveScan)
-{
-    using T                                     = typename TestFixture::input_type;
-    using U                                     = typename TestFixture::output_type;
-    using scan_op_type                          = typename TestFixture::scan_op_type;
-    const bool            debug_synchronous     = TestFixture::debug_synchronous;
-    static constexpr bool use_identity_iterator = TestFixture::use_identity_iterator;
-    using Config                                = size_limit_config_t<TestFixture::size_limit>;
-
-    const int device_id = test_common_utils::obtain_device_from_ctest();
-    SCOPED_TRACE(testing::Message() << "with device_id= " << device_id);
-    HIP_CHECK(hipSetDevice(device_id));
-
-    for(size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
-    {
-        const unsigned int seed_value
-            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
-
-        SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
-
-        const std::vector<size_t> sizes = get_sizes(seed_value);
-        for(auto size : sizes)
-        {
-            if(size == 0 && test_common_utils::use_hmm())
-            {
-                // hipMallocManaged() currently doesnt support zero byte allocation
-                continue;
-            }
-            const hipStream_t stream = 0; // default
-
-            SCOPED_TRACE(testing::Message() << "with size = " << size);
-
-            // Generate data
-            const std::vector<T> future_input
-                = test_utils::get_random_data<T>(2048, 1, 10, ~seed_value);
-            const std::vector<T> input = test_utils::get_random_data<T>(size, 1, 10, seed_value);
-            std::vector<U>       output(input.size());
-
-            T* d_input;
-            U* d_output;
-            T* d_future_input;
-            T* d_initial_value;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(U)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_future_input,
-                                                         future_input.size() * sizeof(T)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_initial_value, sizeof(T)));
-            HIP_CHECK(
-                hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
-            HIP_CHECK(hipMemcpy(d_future_input,
-                                future_input.data(),
-                                future_input.size() * sizeof(T),
-                                hipMemcpyHostToDevice));
-            HIP_CHECK(hipDeviceSynchronize());
-
-            // scan function
-            scan_op_type scan_op;
-
-            const T initial_value = std::accumulate(future_input.begin(), future_input.end(), T(0));
-
-            // Calculate expected results on host
-            std::vector<U> expected(input.size());
-            test_utils::host_exclusive_scan(
-                input.begin(), input.end(), initial_value, expected.begin(), scan_op);
-
-            const auto future_iter
-                = test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_initial_value);
-            const auto future_initial_value
-                = rocprim::future_value<T, std::remove_const_t<decltype(future_iter)>> {
-                    future_iter};
-
-            // temp storage
-            size_t temp_storage_size_bytes;
-            char*  d_temp_storage = nullptr;
-            // Get size of d_temp_storage
-            HIP_CHECK(rocprim::exclusive_scan<Config>(
-                nullptr,
-                temp_storage_size_bytes,
-                d_input,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                future_initial_value,
-                input.size(),
-                scan_op,
-                stream,
-                debug_synchronous));
-
-            // temp_storage_size_bytes must be >0
-            ASSERT_GT(temp_storage_size_bytes, 0);
-
-            size_t temp_storage_reduce = 0;
-            HIP_CHECK(rocprim::reduce(
-                nullptr, temp_storage_reduce, d_future_input, d_initial_value, 2048));
-
-            // allocate temporary storage
-            HIP_CHECK(test_common_utils::hipMallocHelper(
-                &d_temp_storage, temp_storage_size_bytes + temp_storage_reduce));
-            HIP_CHECK(hipDeviceSynchronize());
-
-            // Fill initial value on the device
-            HIP_CHECK(rocprim::reduce(d_temp_storage + temp_storage_size_bytes,
-                                      temp_storage_reduce,
-                                      d_future_input,
-                                      d_initial_value,
-                                      2048));
-
-            // Run
-            HIP_CHECK(rocprim::exclusive_scan<Config>(
-                d_temp_storage,
-                temp_storage_size_bytes,
-                d_input,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                future_initial_value,
-                input.size(),
-                scan_op,
-                stream,
-                debug_synchronous));
-            HIP_CHECK(hipGetLastError());
-            HIP_CHECK(hipDeviceSynchronize());
-
-            // Copy output to host
-            HIP_CHECK(hipMemcpy(
-                output.data(), d_output, output.size() * sizeof(U), hipMemcpyDeviceToHost));
-            HIP_CHECK(hipDeviceSynchronize());
-
-            // Check if output values are as expected
-            ASSERT_NO_FATAL_FAILURE(test_utils::assert_near(
-                output, expected, test_utils::precision_threshold<T>::percentage));
-
-            hipFree(d_input);
-            hipFree(d_output);
-            hipFree(d_future_input);
-            hipFree(d_initial_value);
-            hipFree(d_temp_storage);
         }
     }
 }

--- a/test/rocprim/test_device_segmented_scan.cpp
+++ b/test/rocprim/test_device_segmented_scan.cpp
@@ -521,7 +521,10 @@ TYPED_TEST(RocprimDeviceSegmentedScan, InclusiveScanUsingHeadFlags)
             );
             HIP_CHECK(hipDeviceSynchronize());
 
-            ASSERT_NO_FATAL_FAILURE(test_utils::assert_near(output, expected, test_utils::precision_threshold<output_type>::percentage));
+            float multiplier = 1;
+            if(std::is_same<scan_op_type,rocprim::plus<float>>::value)
+                multiplier = 100;
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_near(output, expected, multiplier*test_utils::precision_threshold<output_type>::percentage));
 
             HIP_CHECK(hipFree(d_temp_storage));
             HIP_CHECK(hipFree(d_input));
@@ -700,8 +703,10 @@ TYPED_TEST(RocprimDeviceSegmentedScan, ExclusiveScanUsingHeadFlags)
                 )
             );
             HIP_CHECK(hipDeviceSynchronize());
-
-            ASSERT_NO_FATAL_FAILURE(test_utils::assert_near(output, expected, test_utils::precision_threshold<output_type>::percentage));
+            float multiplier = 1;
+            if(std::is_same<scan_op_type,rocprim::plus<float>>::value)
+                multiplier = 100;
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_near(output, expected, multiplier*test_utils::precision_threshold<output_type>::percentage));
 
             HIP_CHECK(hipFree(d_temp_storage));
             HIP_CHECK(hipFree(d_input));

--- a/test/rocprim/test_device_select.cpp
+++ b/test/rocprim/test_device_select.cpp
@@ -475,7 +475,7 @@ TYPED_TEST(RocprimDeviceSelectTests, Unique)
     using T = typename TestFixture::input_type;
     using U = typename TestFixture::output_type;
     using op_type = typename test_utils::select_equal_to_operator<T>::type;
-    using scan_op_type = typename test_utils::select_plus_operator<T>::type;
+    using scan_op_type = rocprim::plus<T>;
     static constexpr bool use_identity_iterator = TestFixture::use_identity_iterator;
     const bool debug_synchronous = TestFixture::debug_synchronous;
 
@@ -638,7 +638,7 @@ TEST(RocprimDeviceSelectTests, UniqueGuardedOperator)
     using T = int64_t;
     using F = int64_t;
     using U = int64_t;
-    using scan_op_type = typename test_utils::select_plus_operator<T>::type;
+    using scan_op_type = rocprim::plus<T>;
     static constexpr bool use_identity_iterator = false;
     const bool debug_synchronous = false;
 

--- a/test/rocprim/test_transform_iterator.cpp
+++ b/test/rocprim/test_transform_iterator.cpp
@@ -186,7 +186,7 @@ TYPED_TEST(RocprimTransformIteratorTests, TransformReduce)
         }
         else if(std::is_floating_point<value_type>::value)
         {
-            auto tolerance = std::max<value_type>(std::abs(0.1f * expected), value_type(test_utils::precision_threshold<value_type>::percentage));
+            auto tolerance = std::abs(test_utils::precision_threshold<value_type>::percentage * expected);
             ASSERT_NEAR(output[0], expected, tolerance);
         }
 

--- a/test/rocprim/test_utils_types.hpp
+++ b/test/rocprim/test_utils_types.hpp
@@ -210,12 +210,6 @@ static constexpr unsigned int items[n_items] = {
     1, 2, 4, 5, 7, 15, 32
 };
 
-template<class T, class BinaryOp>
-T apply(BinaryOp binary_op, const T& a, const T& b)
-{
-    return binary_op(a, b);
-}
-
 // Global utility defines
 #define test_suite_type_def_helper(name, suffix) \
     template<class Params> \

--- a/test/rocprim/test_warp_scan.hpp
+++ b/test/rocprim/test_warp_scan.hpp
@@ -31,7 +31,11 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::params::type;
-    using binary_op_type = typename test_utils::select_plus_operator<T>::type;
+    // for bfloat16 and half we use double for host-side accumulation
+    using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
+    binary_op_type_host binary_op_host;
+    using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -77,13 +81,14 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
         std::vector<T> expected(output.size(), (T)0);
 
         // Calculate expected results on host
-        binary_op_type binary_op;
         for(size_t i = 0; i < input.size() / logical_warp_size; i++)
         {
+            acc_type accumulator(0);
             for(size_t j = 0; j < logical_warp_size; j++)
             {
                 auto idx = i * logical_warp_size + j;
-                expected[idx] = apply(binary_op, input[idx], expected[j > 0 ? idx-1 : idx]);
+                accumulator = binary_op_host(input[idx], accumulator);
+                expected[idx] = static_cast<T>(accumulator);
             }
         }
 
@@ -147,7 +152,11 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::params::type;
-    using binary_op_type = typename test_utils::select_plus_operator<T>::type;
+    // for bfloat16 and half we use double for host-side accumulation
+    using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
+    binary_op_type_host binary_op_host;
+    using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -195,13 +204,14 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
         std::vector<T> expected_reductions(output_reductions.size(), (T)0);
 
         // Calculate expected results on host
-        binary_op_type binary_op;
         for(size_t i = 0; i < output.size() / logical_warp_size; i++)
         {
+            acc_type accumulator(0);
             for(size_t j = 0; j < logical_warp_size; j++)
             {
                 auto idx = i * logical_warp_size + j;
-                expected[idx] = apply(binary_op, input[idx], expected[j > 0 ? idx-1 : idx]);
+                accumulator = binary_op_host(input[idx],accumulator);
+                expected[idx] = static_cast<T>(accumulator);
             }
             expected_reductions[i] = expected[(i+1) * logical_warp_size - 1];
         }
@@ -283,7 +293,11 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::params::type;
-    using binary_op_type = typename test_utils::select_plus_operator<T>::type;
+     // for bfloat16 and half we use double for host-side accumulation
+    using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
+    binary_op_type_host binary_op_host;
+    using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -330,14 +344,15 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
         const T init = test_utils::get_random_value<T>(0, 100, seed_value);
 
         // Calculate expected results on host
-        binary_op_type binary_op;
         for(size_t i = 0; i < input.size() / logical_warp_size; i++)
         {
+            acc_type accumulator(init);
             expected[i * logical_warp_size] = init;
             for(size_t j = 1; j < logical_warp_size; j++)
             {
                 auto idx = i * logical_warp_size + j;
-                expected[idx] = apply(binary_op, input[idx-1], expected[idx-1]);
+                accumulator = binary_op_host(input[idx-1], accumulator);
+                expected[idx] = static_cast<T>(accumulator);
             }
         }
 
@@ -402,7 +417,11 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::params::type;
-    using binary_op_type = typename test_utils::select_plus_operator<T>::type;
+     // for bfloat16 and half we use double for host-side accumulation
+    using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
+    binary_op_type_host binary_op_host;
+    using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -451,21 +470,23 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
         const T init = test_utils::get_random_value<T>(0, 100, seed_value);
 
         // Calculate expected results on host
-        binary_op_type binary_op;
         for(size_t i = 0; i < input.size() / logical_warp_size; i++)
         {
+            acc_type accumulator(init);
             expected[i * logical_warp_size] = init;
             for(size_t j = 1; j < logical_warp_size; j++)
             {
                 auto idx = i * logical_warp_size + j;
-                expected[idx] = apply(binary_op, input[idx-1], expected[idx-1]);
+                accumulator = binary_op_host(input[idx-1], accumulator);
+                expected[idx] = static_cast<T>(accumulator);
             }
 
-            expected_reductions[i] = (T)0;
+            acc_type accumulator_reductions(0);
             for(size_t j = 0; j < logical_warp_size; j++)
             {
                 auto idx = i * logical_warp_size + j;
-                expected_reductions[i] = apply(binary_op, expected_reductions[i], input[idx]);
+                accumulator_reductions = binary_op_host(input[idx], accumulator_reductions);
+                expected_reductions[i] = static_cast<T>(accumulator_reductions);
             }
         }
 
@@ -545,7 +566,11 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::params::type;
-    using binary_op_type = typename test_utils::select_plus_operator<T>::type;
+     // for bfloat16 and half we use double for host-side accumulation
+    using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
+    binary_op_type_host binary_op_host;
+    using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -594,17 +619,20 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
         const T init = test_utils::get_random_value<T>(0, 100, seed_value);
 
         // Calculate expected results on host
-        binary_op_type binary_op;
         for(size_t i = 0; i < input.size() / logical_warp_size; i++)
         {
+            acc_type accumulator_inclusive(0);
+            acc_type accumulator_exclusive = init;
             expected_exclusive[i * logical_warp_size] = init;
             for(size_t j = 0; j < logical_warp_size; j++)
             {
                 auto idx = i * logical_warp_size + j;
-                expected_inclusive[idx] = apply(binary_op, input[idx], expected_inclusive[j > 0 ? idx-1 : idx]);
+                accumulator_inclusive = binary_op_host(input[idx], accumulator_inclusive);
+                expected_inclusive[idx] = static_cast<T>(accumulator_inclusive);
                 if(j > 0)
                 {
-                    expected_exclusive[idx] = apply(binary_op, input[idx-1], expected_exclusive[idx-1]);
+                    accumulator_exclusive = binary_op_host(input[idx-1], accumulator_exclusive);
+                    expected_exclusive[idx] = static_cast<T>(accumulator_exclusive);
                 }
             }
         }
@@ -691,7 +719,11 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::params::type;
-    using binary_op_type = typename test_utils::select_plus_operator<T>::type;
+     // for bfloat16 and half we use double for host-side accumulation
+    using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
+    binary_op_type_host binary_op_host;
+    using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -742,17 +774,20 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
         const T init = test_utils::get_random_value<T>(0, 100, seed_value);
 
         // Calculate expected results on host
-        binary_op_type binary_op;
         for(size_t i = 0; i < input.size() / logical_warp_size; i++)
         {
+            acc_type accumulator_inclusive(0);
+            acc_type accumulator_exclusive(init);
             expected_exclusive[i * logical_warp_size] = init;
             for(size_t j = 0; j < logical_warp_size; j++)
             {
                 auto idx = i * logical_warp_size + j;
-                expected_inclusive[idx] = apply(binary_op, input[idx], expected_inclusive[j > 0 ? idx-1 : idx]);
+                accumulator_inclusive = binary_op_host(input[idx], accumulator_inclusive);
+                expected_inclusive[idx] = static_cast<T>(accumulator_inclusive);
                 if(j > 0)
                 {
-                    expected_exclusive[idx] = apply(binary_op, input[idx-1], expected_exclusive[idx-1]);
+                    accumulator_exclusive = binary_op_host(input[idx-1], accumulator_exclusive);
+                    expected_exclusive[idx] = static_cast<T>(accumulator_exclusive);
                 }
             }
             expected_reductions[i] = expected_inclusive[(i+1) * logical_warp_size - 1];
@@ -859,6 +894,14 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
 
     using base_type = typename TestFixture::params::type;
     using T = test_utils::custom_test_type<base_type>;
+    using acc_type = base_type;
+    if(std::is_same<acc_type, rocprim::bfloat16>::value)
+        GTEST_SKIP();
+    /* Enable the following when assignment operator has been added to hip_bfloat16
+     * https://github.com/ROCm-Developer-Tools/HIP/pull/2303/files
+     * using acc_type = typename std::conditional<std::is_same<base_type,rocprim::bfloat16>::value ||
+                                                   std::is_same<base_type,rocprim::half>::value, double, base_type>::type; */
+
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -916,10 +959,12 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
         // Calculate expected results on host
         for(size_t i = 0; i < input.size() / logical_warp_size; i++)
         {
+            test_utils::custom_test_type<acc_type> accumulator(acc_type(0));
             for(size_t j = 0; j < logical_warp_size; j++)
             {
                 auto idx = i * logical_warp_size + j;
-                expected[idx] = input[idx] + expected[j > 0 ? idx-1 : idx];
+                accumulator = static_cast<test_utils::custom_test_type<acc_type>>(input[idx]) + accumulator;
+                expected[idx] = static_cast<T>(accumulator);
             }
         }
 

--- a/test/rocprim/test_zip_iterator.cpp
+++ b/test/rocprim/test_zip_iterator.cpp
@@ -248,7 +248,7 @@ TEST(RocprimZipIteratorTests, Transform)
         // Check if output values are as expected
         for(size_t i = 0; i < output.size(); i++)
         {
-            auto diff = std::max<U>(std::abs(test_utils::precision_threshold<U>::percentage * expected[i]), U(test_utils::precision_threshold<U>::percentage));
+            auto diff = std::abs(test_utils::precision_threshold<U>::percentage * expected[i]);
             if(std::is_integral<U>::value) diff = 0;
             ASSERT_NEAR(output[i], expected[i], diff) << "where index = " << i;
         }
@@ -429,11 +429,11 @@ TEST(RocprimZipIteratorTests, TransformReduce)
         HIP_CHECK(hipDeviceSynchronize());
 
         // Check if output values are as expected
-        auto diff1 = std::max<U1>(std::abs(test_utils::precision_threshold<U1>::percentage * expected1), U1(test_utils::precision_threshold<U1>::percentage));
+        auto diff1 = std::abs(test_utils::precision_threshold<U1>::percentage * expected1);
         if(std::is_integral<U1>::value) diff1 = 0;
         ASSERT_NEAR(output1[0], expected1, diff1);
 
-        auto diff2 = std::max<U2>(std::abs(test_utils::precision_threshold<U2>::percentage * expected2), U2(test_utils::precision_threshold<U2>::percentage));
+        auto diff2 = std::abs(test_utils::precision_threshold<U2>::percentage * expected2);
         if(std::is_integral<U2>::value) diff2 = 0;
         ASSERT_NEAR(output2[0], expected2, diff2);
 


### PR DESCRIPTION
* Fix the comperator operator with bigger bit length than 32.
* Also containes future value implementation
* The reduce/scan algorithm precision issues in the tests has been resolved for half types.