### PR TITLE
ENABLE ORIGINAL FILE DUMP IN VERSION HDR FILE WRAPPER FOR BKWDCOMP

### DIFF
--- a/rocprim/CMakeLists.txt
+++ b/rocprim/CMakeLists.txt
@@ -34,6 +34,7 @@ if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
     "rocprim_version.hpp"
     WRAPPER_LOCATIONS rocprim/include/rocprim
     OUTPUT_LOCATIONS rocprim/wrapper/include/rocprim
+    ORIGINAL_FILES ${CMAKE_CURRENT_BINARY_DIR}/include/rocprim/rocprim_version.hpp
   )
 endif( )
 


### PR DESCRIPTION
Summary of proposed changes:

- Original Header File Dump enabled for version header file wrapper to support backward Compatibility for PT/TF
- Depends on wrapper functions of rocm-cmake version https://github.com/RadeonOpenCompute/rocm-cmake/commit/d108dbf05e029996d5d7bcbe258abb1166547a30