### PR TITLE
Fix radix_merge_sort partial specialization to cover all cases

### DIFF
--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -929,7 +929,10 @@ struct radix_merge_compare<true, true, T, typename std::enable_if<rocprim::is_in
 };
 
 template<bool Descending, class T>
-struct radix_merge_compare<Descending, true, T, typename std::enable_if<rocprim::is_floating_point<T>::value>::type>
+struct radix_merge_compare<Descending,
+                           true,
+                           T,
+                           typename std::enable_if<!rocprim::is_integral<T>::value>::type>
 {
     // radix_merge_compare supports masks only for integrals.
     // even though masks are never used for floating point-types,


### PR DESCRIPTION
Libraries dependent on rocPRIM may use radix sort and segmented radix
sort with types different from what's known to rocPRIM (e.g. custom
or library wrappers around float16).
This use-case was accidentally broken by using `rocprim::is_floating_point`.
In this case, since the specialization is never actually called at runtime,
the negation of the other condition is more appropriate (i.e. non integers).
In the future clearly defined customization points should be added.