### PR TITLE
Updated HIP Path, enhanced GNU install dir usage

### DIFF
--- a/rocprim/CMakeLists.txt
+++ b/rocprim/CMakeLists.txt
@@ -45,7 +45,7 @@ target_include_directories(rocprim
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/rocprim>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
 )
 
 # This target links against HIP library
@@ -54,9 +54,6 @@ target_link_libraries(rocprim_hip INTERFACE rocprim hip::device)
 
 
 # Installation
-
-include(GNUInstallDirs)
-set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
 
 # We need to install headers manually as rocm_install_targets
 # does not support header-only libraries (INTERFACE targets)

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -4,9 +4,9 @@
 #set(CMAKE_GENERATOR_PLATFORM x64)
 
 if (DEFINED ENV{ROCM_PATH})
-  set(rocm_bin "$ENV{ROCM_PATH}/hip/bin")
+  set(rocm_bin "$ENV{ROCM_PATH}/bin")
 else()
-  set(rocm_bin "/opt/rocm/hip/bin")
+  set(rocm_bin "/opt/rocm/bin")
 endif()
 
 


### PR DESCRIPTION
Proposed Change:
- Update HIP bin prefix path to ROCM_PATH   (reorg structure)
- enhanced GNUinstall dir (removed additional include, and include install dir mapped to gnuinstalldir.
- 