### PR TITLE
Fix for test failures with rocm 5.3.0 `char`

### DIFF
--- a/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -433,6 +433,11 @@ private:
         for(unsigned base = 0; base < ItemsPerThread; base += 2 * offset)
         {
             ROCPRIM_UNROLL
+// Workaround to prevent the compiler thinking this is a 'Parallel Loop' on clang 15
+// because it leads to invalid code generation with `T` = `char` and `ItemsPerthread` = 4
+#if defined(__clang_major__) && __clang_major__ >= 15
+    #pragma clang loop vectorize(disable)
+#endif
             for(unsigned i = 0; i < offset; ++i)
             {
                 thread_swap(kv..., dir, base + i, base + i + offset, compare_function);

--- a/rocprim/include/rocprim/warp/detail/warp_sort_shuffle.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_sort_shuffle.hpp
@@ -231,6 +231,11 @@ private:
             const bool local_dir = ((base & group_size) > 0) != dir;
 
             ROCPRIM_UNROLL
+// Workaround to prevent the compiler thinking this is a 'Parallel Loop' on clang 15
+// because it leads to invalid code generation with `T` = `char` and `ItemsPerthread` = 4
+#if defined(__clang_major__) && __clang_major__ >= 15
+    #pragma clang loop vectorize(disable)
+#endif
             for(unsigned i = 0; i < offset; ++i) {
                 thread_swap(kv..., base + i, base + i + offset, local_dir, compare_function);
             }


### PR DESCRIPTION
Hotfix due to compiler issue.
Side-effects:
Degrades performance with 5-10% in `warp_sort` & `block_sort` for `float` & `double` datatypes.
Improves performance with 90% in  `warp_sort` for `__half` datatype when `ItemsPerThread==4`.