### PR TITLE
workaround for double to __half bug causing test failures

### DIFF
--- a/test/rocprim/test_block_reduce.hpp
+++ b/test/rocprim/test_block_reduce.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,7 @@ typed_test_def(suite_name_single, name_suffix, Reduce)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     constexpr size_t block_size = TestFixture::block_size;
 
@@ -69,7 +70,7 @@ typed_test_def(suite_name_single, name_suffix, Reduce)
                 auto idx = i * block_size + j;
                 value = binary_op_host(value, output[idx]);
             }
-            expected_reductions[i] = static_cast<T>(value);
+            expected_reductions[i] = static_cast<cast_type>(value);
         }
 
         // Preparing device
@@ -182,6 +183,7 @@ typed_test_def(suite_name_single, name_suffix, ReduceValid)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     constexpr size_t block_size = TestFixture::block_size;
 
@@ -214,7 +216,7 @@ typed_test_def(suite_name_single, name_suffix, ReduceValid)
                 auto idx = i * block_size + j;
                 value = binary_op_host(value, output[idx]);
             }
-            expected_reductions[i] = static_cast<T>(value);
+            expected_reductions[i] = static_cast<cast_type>(value);
         }
 
         // Preparing device

--- a/test/rocprim/test_block_scan.hpp
+++ b/test/rocprim/test_block_scan.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@ typed_test_def(suite_name_single, name_suffix, InclusiveScan)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type             = typename test_utils::select_plus_operator_host<T>::cast_type;
     constexpr size_t block_size = TestFixture::block_size;
 
     int device_id = test_common_utils::obtain_device_from_ctest();
@@ -66,7 +67,7 @@ typed_test_def(suite_name_single, name_suffix, InclusiveScan)
             {
                 auto idx = i * block_size + j;
                 accumulator = binary_op_host(output[idx], accumulator);
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<cast_type>(accumulator);
             }
         }
 
@@ -96,6 +97,7 @@ typed_test_def(suite_name_single, name_suffix, InclusiveScanReduce)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type             = typename test_utils::select_plus_operator_host<T>::cast_type;
     constexpr size_t block_size = TestFixture::block_size;
 
     int device_id = test_common_utils::obtain_device_from_ctest();
@@ -131,7 +133,7 @@ typed_test_def(suite_name_single, name_suffix, InclusiveScanReduce)
             {
                 auto idx = i * block_size + j;
                 accumulator = binary_op_host(output[idx], accumulator);
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<cast_type>(accumulator);
             }
             expected_reductions[i] = expected[(i+1) * block_size - 1];
         }
@@ -170,6 +172,7 @@ typed_test_def(suite_name_single, name_suffix, InclusiveScanPrefixCallback)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     constexpr size_t block_size = TestFixture::block_size;
 
@@ -207,7 +210,7 @@ typed_test_def(suite_name_single, name_suffix, InclusiveScanPrefixCallback)
             {
                 auto idx = i * block_size + j;
                 accumulator = binary_op_host(output[idx], accumulator);
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<cast_type>(accumulator);
             }
             expected_block_prefixes[i] = expected[(i+1) * block_size - 1];
         }
@@ -246,6 +249,7 @@ typed_test_def(suite_name_single, name_suffix, ExclusiveScan)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     constexpr size_t block_size = TestFixture::block_size;
 
@@ -282,7 +286,7 @@ typed_test_def(suite_name_single, name_suffix, ExclusiveScan)
             {
                 auto idx = i * block_size + j;
                 accumulator = binary_op_host(output[idx-1], accumulator);
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<cast_type>(accumulator);
             }
         }
 
@@ -312,6 +316,7 @@ typed_test_def(suite_name_single, name_suffix, ExclusiveScanReduce)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     constexpr size_t block_size = TestFixture::block_size;
 
@@ -351,7 +356,7 @@ typed_test_def(suite_name_single, name_suffix, ExclusiveScanReduce)
             {
                 auto idx = i * block_size + j;
                 accumulator = binary_op_host(output[idx-1], accumulator);
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<cast_type>(accumulator);
             }
             acc_type accumulator_reductions(0);
             expected_reductions[i] = 0;
@@ -359,7 +364,7 @@ typed_test_def(suite_name_single, name_suffix, ExclusiveScanReduce)
             {
                 auto idx = i * block_size + j;
                 accumulator_reductions = binary_op_host(accumulator_reductions, output[idx]);
-                expected_reductions[i] = static_cast<T>(accumulator_reductions);
+                expected_reductions[i] = static_cast<cast_type>(accumulator_reductions);
             }
         }
 
@@ -397,6 +402,7 @@ typed_test_def(suite_name_single, name_suffix, ExclusiveScanPrefixCallback)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     constexpr size_t block_size = TestFixture::block_size;
 
@@ -435,7 +441,7 @@ typed_test_def(suite_name_single, name_suffix, ExclusiveScanPrefixCallback)
             {
                 auto idx = i * block_size + j;
                 accumulator = binary_op_host(output[idx-1], accumulator);
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<cast_type>(accumulator);
             }
 
             acc_type accumulator_block_prefixes = block_prefix;
@@ -444,7 +450,7 @@ typed_test_def(suite_name_single, name_suffix, ExclusiveScanPrefixCallback)
             {
                 auto idx = i * block_size + j;
                 accumulator_block_prefixes = binary_op_host(output[idx], accumulator_block_prefixes);
-                expected_block_prefixes[i] = static_cast<T>(accumulator_block_prefixes);
+                expected_block_prefixes[i] = static_cast<cast_type>(accumulator_block_prefixes);
             }
         }
 

--- a/test/rocprim/test_device_reduce.cpp
+++ b/test/rocprim/test_device_reduce.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -90,17 +90,19 @@ typedef ::testing::Types<
     DeviceReduceParams<int, int, false, 1073741824>,
     DeviceReduceParams<int8_t, int8_t>,
     DeviceReduceParams<uint8_t, uint8_t>,
-    DeviceReduceParams<rocprim::half, rocprim::half>,
+    // #156 temporarily disable half test due to known issue with converting from double to half
+    // DeviceReduceParams<rocprim::half, rocprim::half>,
     DeviceReduceParams<rocprim::bfloat16, rocprim::bfloat16>,
     DeviceReduceParams<test_utils::custom_test_type<float>, test_utils::custom_test_type<float>>,
-    DeviceReduceParams<test_utils::custom_test_type<int>, test_utils::custom_test_type<float>>
-> RocprimDeviceReduceTestsParams;
+    DeviceReduceParams<test_utils::custom_test_type<int>, test_utils::custom_test_type<float>>>
+    RocprimDeviceReduceTestsParams;
 
 typedef ::testing::Types<
     DeviceReduceParams<float, float, false, 2048>,
-    DeviceReduceParams<rocprim::half, rocprim::half>,
-    DeviceReduceParams<rocprim::bfloat16, rocprim::bfloat16>
-> RocprimDeviceReducePrecisionTestsParams;
+    // #156 temporarily disable half test due to known issue with converting from double to half
+    // DeviceReduceParams<rocprim::half, rocprim::half>,
+    DeviceReduceParams<rocprim::bfloat16, rocprim::bfloat16>>
+    RocprimDeviceReducePrecisionTestsParams;
 
 std::vector<size_t> get_sizes(int seed_value)
 {

--- a/test/rocprim/test_device_segmented_reduce.cpp
+++ b/test/rocprim/test_device_segmented_reduce.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -67,7 +67,8 @@ typedef ::testing::Types<
     params<uint8_t, uint8_t, rocprim::plus<uint8_t>, 10, 1000, 10000>,
     params<uint8_t, uint8_t, rocprim::maximum<uint8_t>, 50, 2, 10>,
     params<rocprim::half, rocprim::half, test_utils::half_maximum, 0, 1000, 2000>,
-    params<rocprim::half, rocprim::half, test_utils::half_plus, 50, 2, 10>,
+    // #156 temporarily disable half test due to known issue with converting from double to half
+    // params<rocprim::half, rocprim::half, test_utils::half_plus, 50, 2, 10>,
     params<rocprim::bfloat16, rocprim::bfloat16, test_utils::bfloat16_maximum, 0, 1000, 2000>,
     params<rocprim::bfloat16, rocprim::bfloat16, test_utils::bfloat16_plus, 50, 2, 10>,
     params<custom_short2, custom_int2, rocprim::plus<custom_int2>, 10, 1000, 10000>,
@@ -80,8 +81,8 @@ typedef ::testing::Types<
 #endif
     params<rocprim::bfloat16, float, rocprim::plus<float>, 0, 10, 300>,
     params<rocprim::half, rocprim::half, test_utils::half_minimum, 0, 1000, 30000>,
-    params<rocprim::bfloat16, rocprim::bfloat16, test_utils::bfloat16_minimum, 0, 1000, 30000>
-> Params;
+    params<rocprim::bfloat16, rocprim::bfloat16, test_utils::bfloat16_minimum, 0, 1000, 30000>>
+    Params;
 
 TYPED_TEST_SUITE(RocprimDeviceSegmentedReduce, Params);
 

--- a/test/rocprim/test_utils.hpp
+++ b/test/rocprim/test_utils.hpp
@@ -179,6 +179,10 @@ struct select_plus_operator_host
 {
     typedef ::rocprim::plus<T> type;
     typedef T acc_type;
+    // #156 temporarily disable half test due to known issue with converting from double to half
+    //      cast_type is the type that should be used to cast acc_type to T.
+    //      overload needed temporarily due to compiler bug in half conversions
+    typedef T cast_type;
 };
 
 template<>
@@ -186,6 +190,7 @@ struct select_plus_operator_host<::rocprim::half>
 {
     typedef ::rocprim::plus<double> type;
     typedef double acc_type;
+    typedef float                   cast_type;
 };
 
 template<>
@@ -193,6 +198,7 @@ struct select_plus_operator_host<::rocprim::bfloat16>
 {
     typedef ::rocprim::plus<double> type;
     typedef double acc_type;
+    typedef ::rocprim::bfloat16     cast_type;
 };
 
 // Minimum to operator selector

--- a/test/rocprim/test_warp_reduce.hpp
+++ b/test/rocprim/test_warp_reduce.hpp
@@ -32,6 +32,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSum)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -89,7 +90,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSum)
                 auto idx = i * logical_warp_size + j;
                 value = binary_op_host(input[idx], value);
             }
-            expected[i] = static_cast<T>(value);
+            expected[i] = static_cast<cast_type>(value);
         }
 
         T* device_input;
@@ -154,6 +155,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSum)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -210,7 +212,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSum)
             for (size_t j = 0; j < logical_warp_size; j++)
             {
                 auto idx = i * logical_warp_size + j;
-                expected[idx] = static_cast<T>(value);
+                expected[idx] = static_cast<cast_type>(value);
             }
         }
 
@@ -276,6 +278,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSumValid)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -330,7 +333,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSumValid)
                 auto idx = i * logical_warp_size + j;
                 value = binary_op_host(input[idx], value);
             }
-            expected[i] = static_cast<T>(value);
+            expected[i] = static_cast<cast_type>(value);
         }
 
         T* device_input;
@@ -396,6 +399,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSumValid)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
 
@@ -453,7 +457,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSumValid)
             for (size_t j = 0; j < logical_warp_size; j++)
             {
                 auto idx = i * logical_warp_size + j;
-                expected[idx] = static_cast<T>(value);
+                expected[idx] = static_cast<cast_type>(value);
             }
         }
 
@@ -517,6 +521,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceCustomStruct)
     using base_type = typename TestFixture::params::type;
     using T = test_utils::custom_test_type<base_type>;
     using acc_type = typename test_utils::select_plus_operator_host<base_type>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<base_type>::cast_type;
 
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
@@ -580,7 +585,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceCustomStruct)
                 auto idx = i * logical_warp_size + j;
                 value = value + static_cast<test_utils::custom_test_type<acc_type>>(input[idx]);
             }
-            expected[i] = static_cast<T>(value);
+            expected[i] = static_cast<test_utils::custom_test_type<cast_type>>(value);
         }
 
         T* device_input;
@@ -646,6 +651,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     using flag_type = unsigned char;
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
@@ -725,7 +731,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
         {
             if(i%logical_warp_size == 0 || flags[i])
             {
-                expected[segment_head_index] = static_cast<T>(reduction);
+                expected[segment_head_index] = static_cast<cast_type>(reduction);
                 segment_head_index = i;
                 reduction = input[i];
             }
@@ -734,7 +740,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
                 reduction = binary_op_host(input[i], reduction);
             }
         }
-        expected[segment_head_index] = static_cast<T>(reduction);
+        expected[segment_head_index] = static_cast<cast_type>(reduction);
 
         // Launching kernel
         if (current_device_warp_size == ws32)
@@ -798,6 +804,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, TailSegmentedReduceSum)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     using flag_type = unsigned char;
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
@@ -894,7 +901,8 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, TailSegmentedReduceSum)
                     next++;
                 }
                 i++;
-                expected[segment_index] = static_cast<T>(binary_op_host(reduction, input[i]));
+                expected[segment_index]
+                    = static_cast<cast_type>(binary_op_host(reduction, input[i]));
                 segment_indexes.push_back(segment_index);
             }
         }

--- a/test/rocprim/test_warp_scan.hpp
+++ b/test/rocprim/test_warp_scan.hpp
@@ -35,6 +35,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
@@ -88,7 +89,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
             {
                 auto idx = i * logical_warp_size + j;
                 accumulator = binary_op_host(input[idx], accumulator);
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<cast_type>(accumulator);
             }
         }
 
@@ -156,6 +157,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
@@ -211,7 +213,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
             {
                 auto idx = i * logical_warp_size + j;
                 accumulator = binary_op_host(input[idx],accumulator);
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<cast_type>(accumulator);
             }
             expected_reductions[i] = expected[(i+1) * logical_warp_size - 1];
         }
@@ -297,6 +299,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
@@ -352,7 +355,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
             {
                 auto idx = i * logical_warp_size + j;
                 accumulator = binary_op_host(input[idx-1], accumulator);
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<cast_type>(accumulator);
             }
         }
 
@@ -421,6 +424,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
@@ -478,7 +482,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
             {
                 auto idx = i * logical_warp_size + j;
                 accumulator = binary_op_host(input[idx-1], accumulator);
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<cast_type>(accumulator);
             }
 
             acc_type accumulator_reductions(0);
@@ -486,7 +490,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
             {
                 auto idx = i * logical_warp_size + j;
                 accumulator_reductions = binary_op_host(input[idx], accumulator_reductions);
-                expected_reductions[i] = static_cast<T>(accumulator_reductions);
+                expected_reductions[i] = static_cast<cast_type>(accumulator_reductions);
             }
         }
 
@@ -570,6 +574,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
@@ -628,11 +633,11 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
             {
                 auto idx = i * logical_warp_size + j;
                 accumulator_inclusive = binary_op_host(input[idx], accumulator_inclusive);
-                expected_inclusive[idx] = static_cast<T>(accumulator_inclusive);
+                expected_inclusive[idx] = static_cast<cast_type>(accumulator_inclusive);
                 if(j > 0)
                 {
                     accumulator_exclusive = binary_op_host(input[idx-1], accumulator_exclusive);
-                    expected_exclusive[idx] = static_cast<T>(accumulator_exclusive);
+                    expected_exclusive[idx] = static_cast<cast_type>(accumulator_exclusive);
                 }
             }
         }
@@ -723,6 +728,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
     using binary_op_type_host = typename test_utils::select_plus_operator_host<T>::type;
     binary_op_type_host binary_op_host;
     using acc_type = typename test_utils::select_plus_operator_host<T>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
 
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
@@ -783,11 +789,11 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
             {
                 auto idx = i * logical_warp_size + j;
                 accumulator_inclusive = binary_op_host(input[idx], accumulator_inclusive);
-                expected_inclusive[idx] = static_cast<T>(accumulator_inclusive);
+                expected_inclusive[idx] = static_cast<cast_type>(accumulator_inclusive);
                 if(j > 0)
                 {
                     accumulator_exclusive = binary_op_host(input[idx-1], accumulator_exclusive);
-                    expected_exclusive[idx] = static_cast<T>(accumulator_exclusive);
+                    expected_exclusive[idx] = static_cast<cast_type>(accumulator_exclusive);
                 }
             }
             expected_reductions[i] = expected_inclusive[(i+1) * logical_warp_size - 1];
@@ -895,6 +901,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
     using base_type = typename TestFixture::params::type;
     using T = test_utils::custom_test_type<base_type>;
     using acc_type = typename test_utils::select_plus_operator_host<base_type>::acc_type;
+    using cast_type = typename test_utils::select_plus_operator_host<base_type>::cast_type;
 
     // logical warp side for warp primitive, execution warp size is always rocprim::warp_size()
     static constexpr size_t logical_warp_size = TestFixture::params::warp_size;
@@ -958,7 +965,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
             {
                 auto idx = i * logical_warp_size + j;
                 accumulator = static_cast<test_utils::custom_test_type<acc_type>>(input[idx]) + accumulator;
-                expected[idx] = static_cast<T>(accumulator);
+                expected[idx] = static_cast<test_utils::custom_test_type<cast_type>>(accumulator);
             }
         }
 


### PR DESCRIPTION
Workaround for rocPRIM test failures observed with recent ROCm build. Underlying issue is `double` to `__half` conversion.