### PR TITLE
HOTFIX: Remove backwards compatibility headers on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 
 # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
 option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_dir(
     "${PROJECT_SOURCE_DIR}/rocprim/include/rocprim"
     WRAPPER_LOCATIONS rocprim/include/rocprim

--- a/rocprim/CMakeLists.txt
+++ b/rocprim/CMakeLists.txt
@@ -29,7 +29,7 @@ configure_file(
   @ONLY
 )
 
-if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_file(
     "rocprim_version.hpp"
     WRAPPER_LOCATIONS rocprim/include/rocprim
@@ -73,7 +73,7 @@ rocm_install(
 )
 
 
-if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
 rocm_install(
     DIRECTORY
        "${PROJECT_BINARY_DIR}/rocprim/wrapper/"


### PR DESCRIPTION
The backwards compatibility headers should not be generated or installed on Windows.