### PR TITLE
Disable all HMM tests

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -35,11 +35,12 @@ def runTestCommand (platform, project)
     def hmmTestCommand = ''
     if (platform.jenkinsLabel.contains('gfx90a'))
     {
-        hmmTestCommand = """
+        echo("HMM TESTS DISABLED")
+        /*hmmTestCommand = """
                             export HSA_XNACK=1
                             export ROCPRIM_USE_HMM=1
                             ${testCommand} ${hmmTestCommandExclude}
-                         """
+                         """*/
     }
     echo(env.JOB_NAME)
     if (env.JOB_NAME.contains('bleeding-edge'))


### PR DESCRIPTION
HMM tests are too unstable on CI.  Temporarily disabling until we can figure out whats going on.