### PR TITLE
Fix spelling and grammar

### DIFF
--- a/rocprim/include/rocprim/config.hpp
+++ b/rocprim/include/rocprim/config.hpp
@@ -43,7 +43,7 @@
     #else
     #define ROCPRIM_KERNEL __global__
     #endif
-    // TODO: These paremeters should be tuned for NAVI in the close future.
+    // TODO: These parameters should be tuned for NAVI in the close future.
     #ifndef ROCPRIM_DEFAULT_MAX_BLOCK_SIZE
         #define ROCPRIM_DEFAULT_MAX_BLOCK_SIZE 256
     #endif

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -44,7 +44,7 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-// Wrapping functions that allow to call proper methods (with or without values)
+// Wrapping functions that allow one to call proper methods (with or without values)
 // (a variant with values is enabled only when Value is not empty_type)
 template<bool Descending = false, class SortType, class SortKey, class SortValue, unsigned int ItemsPerThread>
 ROCPRIM_DEVICE ROCPRIM_INLINE

--- a/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
+++ b/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
@@ -66,7 +66,7 @@ namespace detail
         };
 
         // Load flagged values
-        // - if the scan is exlusive the last item of each segment (range where the keys compare equal)
+        // - if the scan is exclusive, the last item of each segment (range where the keys compare equal)
         //   is flagged and reset to the initial value. Adding the last item of the range to the 
         //   second to last using `headflag_scan_op_wrapper` will return the initial_value,
         //   which is exactly what should be saved at the start of the next range.

--- a/rocprim/include/rocprim/device/device_histogram_config.hpp
+++ b/rocprim/include/rocprim/device/device_histogram_config.hpp
@@ -36,7 +36,7 @@ BEGIN_ROCPRIM_NAMESPACE
 /// \brief Configuration of device-level histogram operation.
 ///
 /// \tparam HistogramConfig - configuration of histogram kernel. Must be \p kernel_config.
-/// \tparam MaxGridSize - maximim number of blocks to launch.
+/// \tparam MaxGridSize - maximum number of blocks to launch.
 /// \tparam SharedImplMaxBins - maximum total number of bins for all active channels
 /// for the shared memory histogram implementation (samples -> shared memory bins -> global memory bins),
 /// when exceeded the global memory implementation is used (samples -> global memory bins).

--- a/rocprim/include/rocprim/device/device_scan.hpp
+++ b/rocprim/include/rocprim/device/device_scan.hpp
@@ -679,7 +679,7 @@ auto scan_impl(void * temporary_storage,
 /// short * input;
 /// int * output;
 ///
-/// // Use a transform iterator to specifiy a custom accumulator type
+/// // Use a transform iterator to specify a custom accumulator type
 /// auto input_iterator = rocprim::make_transform_iterator(
 ///     input, [] __device__ (T in) { return static_cast<int>(in); });
 ///

--- a/scripts/code-format/check-format.sh
+++ b/scripts/code-format/check-format.sh
@@ -48,7 +48,7 @@ grep '^no modified files to format$\|^clang-format did not modify any files$' \
 # Dump formatting diff and signal failure
 printf \
 "\033[31m==== FORMATTING VIOLATIONS DETECTED ====\033[0m
-run '\033[33m%s --style=file %s %s\033[0m' to apply these formating changes\n\n" \
+run '\033[33m%s --style=file %s %s\033[0m' to apply these formatting changes\n\n" \
 "$GIT_CLANG_FORMAT" "$*" "$SOURCE_COMMIT"
 
 cat "$scratch"


### PR DESCRIPTION
I'm preparing the librocprim-dev package for Debian. As part of that process, I ran spellcheck over the repo. It didn't find any particularly meaningful errors, but I figured I'd submit fixes for those that it did catch.