### PR TITLE
constructs value_type(first[mid]) to fix thrust::upper_bound/thrust::lower_bound errors

### DIFF
--- a/rocprim/include/rocprim/device/detail/device_binary_search.hpp
+++ b/rocprim/include/rocprim/device/detail/device_binary_search.hpp
@@ -46,7 +46,7 @@ Size lower_bound_n(RandomAccessIterator first,
     while(left < right)
     {
         const Size mid = get_binary_search_middle(left, right);
-        if(compare_op(first[mid], value))
+        if(compare_op(typename std::iterator_traits<RandomAccessIterator>::value_type(first[mid]), value))
         {
             left = mid + 1;
         }
@@ -70,7 +70,7 @@ Size upper_bound_n(RandomAccessIterator first,
     while(left < right)
     {
         const Size mid = get_binary_search_middle(left, right);
-        if(compare_op(value, first[mid]))
+        if(compare_op(value, typename std::iterator_traits<RandomAccessIterator>::value_type(first[mid])))
         {
             right = mid;
         }


### PR DESCRIPTION
This PR constructs `value_type(first[mid])` to fix compilation errors when called from `thrust::lower_bound` / `thrust::upper_bound`.

Minimal reproducer:
```
#define THRUST_DEVICE_SYSTEM 5
#include <thrust/tuple.h>
#include <thrust/device_vector.h>
#include <thrust/binary_search.h>

int main(int argc, char** argv)
{
    thrust::device_vector<thrust::tuple<int,int>> haystack, needles;

    haystack.push_back(thrust::make_tuple(1,1));
    haystack.push_back(thrust::make_tuple(2,2));
    haystack.push_back(thrust::make_tuple(3,3));

    needles.push_back(thrust::make_tuple(2,3));

    thrust::device_vector<int> indexes(needles.size());

    thrust::lower_bound(haystack.begin(), haystack.end(), needles.begin(), needles.end(), indexes.begin());
    thrust::lower_bound(haystack.begin(), haystack.end(), needles.begin(), needles.end(), indexes.begin());

    return 0;
}
```

Using the current version of rocPRIM, the above test will trigger errors like the following:
```
/rocPRIM/rocprim/include/rocprim/intrinsics/../detail/../functional.hpp:83:18: error: invalid operands to binary expression ('const thrust::device_reference<thrust::tuple<int, int>>' and 'const thrust::tuple<int, int>')
        return a < b;
               ~ ^ ~
/rocPRIM/rocprim/include/rocprim/device/detail/device_binary_search.hpp:49:12: note: in instantiation of function template specialization 'rocprim::less<>::operator()<thrust::device_reference<thrust::tuple<int, int>>, thrust::tuple<int, int>>' requested here
        if(compare_op(first[mid], value))
           ^
/rocPRIM/rocprim/include/rocprim/device/detail/device_binary_search.hpp:91:16: note: in instantiation of function template specialization 'rocprim::detail::lower_bound_n<thrust::detail::normal_iterator<thrust::device_ptr<thrust::tuple<int, int>>>, unsigned long, thrust::tuple<int, int>, rocprim::less<>>' requested here
        return lower_bound_n(haystack, size, value, compare_op);
```

and
```
/rocPRIM/rocprim/include/rocprim/intrinsics/../detail/../functional.hpp:83:18: error: invalid operands to binary expression ('const thrust::tuple<int, int>' and 'const thrust::device_reference<thrust::tuple<int, int>>')
        return a < b;
               ~ ^ ~
/rocPRIM/rocprim/include/rocprim/device/detail/device_binary_search.hpp:73:12: note: in instantiation of function template specialization 'rocprim::less<>::operator()<thrust::tuple<int, int>, thrust::device_reference<thrust::tuple<int, int>>>' requested here
        if(compare_op(value, first[mid]))
           ^
/rocPRIM/rocprim/include/rocprim/device/detail/device_binary_search.hpp:101:16: note: in instantiation of function template specialization 'rocprim::detail::upper_bound_n<thrust::detail::normal_iterator<thrust::device_ptr<thrust::tuple<int, int>>>, unsigned long, thrust::tuple<int, int>, rocprim::less<>>' requested here
        return upper_bound_n(haystack, size, value, compare_op);
```

The changes proposed in this PR eliminate the above errors.