### PR TITLE
Fixes to get rocPRIM benchmarks building on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ endif()
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker search and installed rpath")
 
+# Set CXX flags
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(BUILD_SHARED_LIBS OFF) # don't build client dependencies as shared
 if(NOT USE_HIP_CPU)
   # Get dependencies (required here to get rocm-cmake)
@@ -98,11 +103,6 @@ if(BUILD_CODE_COVERAGE)
   add_compile_options(-fprofile-arcs -ftest-coverage)
   add_link_options(--coverage)
 endif()
-
-# Set CXX flags
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(USE_HIP_CPU)
   # Get dependencies

--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -464,6 +464,7 @@ inline const char* Traits<long long>::name()
 {
     return "int64_t";
 }
+// On MSVC `int64_t` and `long long` are the same, leading to multiple definition errors
 #ifndef WIN32
 template <>
 inline const char* Traits<int64_t>::name() { return "int64_t"; }

--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -464,8 +464,10 @@ inline const char* Traits<long long>::name()
 {
     return "int64_t";
 }
+#ifndef WIN32
 template <>
 inline const char* Traits<int64_t>::name() { return "int64_t"; }
+#endif
 template <>
 inline const char* Traits<float>::name() { return "float"; }
 template <>

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -163,6 +163,8 @@ if(BUILD_BENCHMARK)
       GIT_REPOSITORY https://github.com/google/benchmark.git
       GIT_TAG        d17ea665515f0c54d100c6fc973632431379f64b # v1.6.1
     )
+    set(HAVE_STD_REGEX ON)
+    set(RUN_HAVE_STD_REGEX 1)
     FetchContent_MakeAvailable(googlebench)
     if(NOT TARGET benchmark::benchmark)
       add_library(benchmark::benchmark ALIAS benchmark)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -163,7 +163,6 @@ if(BUILD_BENCHMARK)
       GIT_REPOSITORY https://github.com/google/benchmark.git
       GIT_TAG        d17ea665515f0c54d100c6fc973632431379f64b # v1.6.1
     )
-    set(CMAKE_CXX_STANDARD 14 CACHE INTERNAL "CXX standard")
     FetchContent_MakeAvailable(googlebench)
     if(NOT TARGET benchmark::benchmark)
       add_library(benchmark::benchmark ALIAS benchmark)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -163,6 +163,7 @@ if(BUILD_BENCHMARK)
       GIT_REPOSITORY https://github.com/google/benchmark.git
       GIT_TAG        d17ea665515f0c54d100c6fc973632431379f64b # v1.6.1
     )
+    set(CMAKE_CXX_STANDARD 14 CACHE INTERNAL "CXX standard")
     FetchContent_MakeAvailable(googlebench)
     if(NOT TARGET benchmark::benchmark)
       add_library(benchmark::benchmark ALIAS benchmark)

--- a/rmake.py
+++ b/rmake.py
@@ -152,7 +152,7 @@ def config_cmd():
         cmake_options.append( f"-DBUILD_TEST=ON -DBUILD_DIR={build_dir}" )
 
     if args.build_clients:
-        cmake_options.append( f"-DBUILD_TEST=ON -DBUILD_EXAMPLE=ON -DBUILD_DIR={build_dir}" )
+        cmake_options.append( f"-DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DBUILD_EXAMPLE=ON -DBUILD_DIR={build_dir}" )
 
     cmake_options.append( f"-DAMDGPU_TARGETS={args.gpu_architecture}" )
 


### PR DESCRIPTION
- In MSVC it seems as though int64_t and long long are the same, which leads to multiple definition errors for Traits<> in benchmark_utils
- Explicitly setting the C++ standard to 14 seems to be required in Windows for building the benchmarks, otherwise C++14-related build errors occur
- Enabling benchmark build by default on Windows so any future build errors get caught in CI