### PR TITLE
Temporarily disable printf on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Full documentation for rocPRIM is available at [https://codedocs.xyz/ROCmSoftwar
 - New block level `radix_rank` primitive.
 ### Changed
 - Improved the performance of `block_radix_sort` and `device_radix_sort`.
+### Known Issues
+- Disabled GPU error messages relating to incorrect warp operation usage with Navi GPUs on Windows, due to GPU printf performance issues on Windows. 
 
 ## [Unreleased rocPRIM-2.12.0 for ROCm 5.4.0]
 ### Changed

--- a/rocprim/include/rocprim/functional.hpp
+++ b/rocprim/include/rocprim/functional.hpp
@@ -31,6 +31,7 @@ BEGIN_ROCPRIM_NAMESPACE
 /// \addtogroup utilsmodule_functional
 /// @{
 
+#ifndef WIN32
 #define ROCPRIM_PRINT_ERROR_ONCE(message) \
 {                                          \
     unsigned int idx = threadIdx.x + (blockIdx.x * blockDim.x); \
@@ -39,6 +40,11 @@ BEGIN_ROCPRIM_NAMESPACE
     if (idx == 0)                                                        \
         printf("%s\n", #message);                                        \
 }
+#else	
+#warning "GPU printf warnings for invalid rocPRIM warp operations on Navi GPUs temporarily disabled due to performance issues with printf." 	
+#define ROCPRIM_PRINT_ERROR_ONCE(message) \
+{ }	
+#endif 
 
 template<class T>
 ROCPRIM_HOST_DEVICE inline

--- a/rocprim/include/rocprim/functional.hpp
+++ b/rocprim/include/rocprim/functional.hpp
@@ -41,7 +41,7 @@ BEGIN_ROCPRIM_NAMESPACE
         printf("%s\n", #message);                                        \
 }
 #else	
-#warning "GPU printf warnings for invalid rocPRIM warp operations on Navi GPUs temporarily disabled due to performance issues with printf." 	
+#warning "GPU printf warnings for invalid rocPRIM warp operations on Navi GPUs temporarily disabled, due to performance issues with printf." 	
 #define ROCPRIM_PRINT_ERROR_ONCE(message) \
 { }	
 #endif 


### PR DESCRIPTION
Calling printf in device code on Windows can lead to significant performance issues ultimately causing desktop display timeouts.  We currently potentially call printf for the warp operations, specifically for Navi cards if the user tries to use a warp size 64 configuration for the rocPRIM warp operations (Navi by default uses warp size 32).

Until the HIP runtime team fixes the printf performance issues on Windows, we should not use printf.  Adding a compile-time warning was the best solution I can think of, @nolmoonen @vince-streamhpc if there's a better solution you can think of I'm all ears.