### PR TITLE
Correctly match gfx90a in GenerateResourceSpec.cmake

### DIFF
--- a/cmake/GenerateResourceSpec.cmake
+++ b/cmake/GenerateResourceSpec.cmake
@@ -20,7 +20,7 @@ if(ROCMINFO_EXIT_CODE)
   message(FATAL_ERROR ${ROCMINFO_STDERR})
 endif()
 
-string(REGEX MATCHALL [[--(gfx[0-9]+)]]
+string(REGEX MATCHALL [[--(gfx[0-9]+a?)]]
   ROCMINFO_MATCHES
   ${ROCMINFO_STDOUT}
 )

--- a/cmake/GenerateResourceSpec.cmake
+++ b/cmake/GenerateResourceSpec.cmake
@@ -20,7 +20,7 @@ if(ROCMINFO_EXIT_CODE)
   message(FATAL_ERROR ${ROCMINFO_STDERR})
 endif()
 
-string(REGEX MATCHALL [[--(gfx[0-9]+a?)]]
+string(REGEX MATCHALL [[--(gfx[0-9a-f]+)]]
   ROCMINFO_MATCHES
   ${ROCMINFO_STDOUT}
 )


### PR DESCRIPTION
Currently it only matches numbers in gfx***.  gfx90a is the exception.  Fix will have to be applied to rocthrust and hipcub as well.