### PR TITLE
HIP SDK compatibility

### DIFF
--- a/rmake.py
+++ b/rmake.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-""" Copyright (c) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+""" Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 Manage build and installation"""
 
 import re

--- a/rmake.py
+++ b/rmake.py
@@ -75,6 +75,12 @@ def delete_dir(dir_path) :
         #print( linux_path )
         run_cmd( "rm" , f"-rf {linux_path}")
 
+def cmake_path(os_path):
+    if os.name == "nt":
+        return os_path.replace("\\", "/")
+    else:
+        return os.path.realpath(os_path)     
+        
 def config_cmd():
     global args
     global OS_info
@@ -87,7 +93,9 @@ def config_cmd():
     cmake_platform_opts = []
     if (OS_info["ID"] == 'windows'):
         # we don't have ROCM on windows but have hip, ROCM can be downloaded if required
-        rocm_path = os.getenv( 'ROCM_PATH', "C:/hipsdk/rocm-cmake-master") #C:/hip") # rocm/Utils/cmake-rocm4.2.0"
+        # CMAKE_PREFIX_PATH set to rocm_path and HIP_PATH set BY SDK Installer
+        raw_rocm_path = cmake_path(os.getenv('HIP_PATH', "C:/hip"))
+        rocm_path = f'"{raw_rocm_path}"' # guard against spaces in path
         cmake_executable = "cmake.exe"
         toolchain = os.path.join( src_path, "toolchain-windows.cmake" )
         #set CPACK_PACKAGING_INSTALL_PREFIX= defined as blank as it is appended to end of path for archive creation

--- a/rmake.py
+++ b/rmake.py
@@ -76,7 +76,7 @@ def delete_dir(dir_path) :
         run_cmd( "rm" , f"-rf {linux_path}")
 
 def cmake_path(os_path):
-    if OS_info == "nt":
+    if OS_info["ID"] == "windows":
         return os_path.replace("\\", "/")
     else:
         return os.path.realpath(os_path)     

--- a/rmake.py
+++ b/rmake.py
@@ -76,7 +76,7 @@ def delete_dir(dir_path) :
         run_cmd( "rm" , f"-rf {linux_path}")
 
 def cmake_path(os_path):
-    if os.name == "nt":
+    if OS_info == "nt":
         return os_path.replace("\\", "/")
     else:
         return os.path.realpath(os_path)     

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -3,7 +3,10 @@
 # Ninja doesn't support platform
 #set(CMAKE_GENERATOR_PLATFORM x64)
 
-if (DEFINED ENV{HIP_DIR})
+if (DEFINED ENV{HIP_PATH})
+  file(TO_CMAKE_PATH "$ENV{HIP_PATH}" HIP_DIR)
+  set(rocm_bin "${HIP_DIR}/bin")
+elseif (DEFINED ENV{HIP_DIR})
   file(TO_CMAKE_PATH "$ENV{HIP_DIR}" HIP_DIR)
   set(rocm_bin "${HIP_DIR}/bin")
 else()


### PR DESCRIPTION
Previously we did not account for spaces in the HIP installation path in Windows (ie. C:\Program Files, etc).