### PR TITLE
double to half conversion workaround for test_block_reduce

### DIFF
--- a/test/rocprim/test_block_reduce.hpp
+++ b/test/rocprim/test_block_reduce.hpp
@@ -107,7 +107,8 @@ typed_test_def(suite_name_single, name_suffix, ReduceMultiplies)
     using T                     = typename TestFixture::input_type;
     using binary_op_type        = rocprim::multiplies<T>;
     constexpr size_t block_size = TestFixture::block_size;
-
+    using cast_type = typename test_utils::select_plus_operator_host<T>::cast_type;
+    
     // Given block size not supported
     if(block_size > test_utils::get_max_block_size())
     {
@@ -137,7 +138,7 @@ typed_test_def(suite_name_single, name_suffix, ReduceMultiplies)
                 auto idx = i * block_size + j;
                 value *= static_cast<double>(output[idx]);
             }
-            expected_reductions[i] = static_cast<T>(value);
+            expected_reductions[i] = static_cast<cast_type>(value);
         }
 
         // Preparing device


### PR DESCRIPTION
For the ReduceMultiplies test case.  Seeing test failures for _half on newer ROCm builds.