### PR TITLE
Directly use __builtin_amdgcn_fence

### DIFF
--- a/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -222,13 +222,10 @@ void syncthreads()
 ROCPRIM_DEVICE ROCPRIM_INLINE
 void wave_barrier()
 {
-    __atomic_work_item_fence(__CLK_LOCAL_MEM_FENCE,
-                             __memory_order_release,
-                             __memory_scope_sub_group);
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, "wavefront");
     __builtin_amdgcn_wave_barrier();
-    __atomic_work_item_fence(__CLK_LOCAL_MEM_FENCE,
-                             __memory_order_acquire,
-                             __memory_scope_sub_group);
+    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "wavefront");
+
 }
 
 namespace detail


### PR DESCRIPTION
This was relying on an implementation detail of the HIP headers which has been removed.