### PR TITLE
Fix toolchain-windows.cmake for HIP SDK

### DIFF
--- a/rmake.py
+++ b/rmake.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-""" Copyright (c) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+""" Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 Manage build and installation"""
 
 import re

--- a/rmake.py
+++ b/rmake.py
@@ -75,6 +75,12 @@ def delete_dir(dir_path) :
         #print( linux_path )
         run_cmd( "rm" , f"-rf {linux_path}")
 
+def cmake_path(os_path):
+    if os.name == "nt":
+        return os_path.replace("\\", "/")
+    else:
+        return os.path.realpath(os_path)     
+        
 def config_cmd():
     global args
     global OS_info
@@ -87,7 +93,9 @@ def config_cmd():
     cmake_platform_opts = []
     if (OS_info["ID"] == 'windows'):
         # we don't have ROCM on windows but have hip, ROCM can be downloaded if required
-        rocm_path = os.getenv( 'ROCM_PATH', "C:/hipsdk/rocm-cmake-master") #C:/hip") # rocm/Utils/cmake-rocm4.2.0"
+        # CMAKE_PREFIX_PATH set to rocm_path and HIP_PATH set BY SDK Installer
+        raw_rocm_path = cmake_path(os.getenv('HIP_PATH', "C:/hip"))
+        rocm_path = f'"{raw_rocm_path}"' # guard against spaces in path
         cmake_executable = "cmake.exe"
         toolchain = os.path.join( src_path, "toolchain-windows.cmake" )
         #set CPACK_PACKAGING_INSTALL_PREFIX= defined as blank as it is appended to end of path for archive creation

--- a/rmake.py
+++ b/rmake.py
@@ -76,7 +76,7 @@ def delete_dir(dir_path) :
         run_cmd( "rm" , f"-rf {linux_path}")
 
 def cmake_path(os_path):
-    if OS_info == "nt":
+    if OS_info["ID"] == "windows":
         return os_path.replace("\\", "/")
     else:
         return os.path.realpath(os_path)     

--- a/rmake.py
+++ b/rmake.py
@@ -76,7 +76,7 @@ def delete_dir(dir_path) :
         run_cmd( "rm" , f"-rf {linux_path}")
 
 def cmake_path(os_path):
-    if os.name == "nt":
+    if OS_info == "nt":
         return os_path.replace("\\", "/")
     else:
         return os.path.realpath(os_path)     

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -3,7 +3,10 @@
 # Ninja doesn't support platform
 #set(CMAKE_GENERATOR_PLATFORM x64)
 
-if (DEFINED ENV{HIP_DIR})
+if (DEFINED ENV{HIP_PATH})
+  file(TO_CMAKE_PATH "$ENV{HIP_PATH}" HIP_DIR)
+  set(rocm_bin "${HIP_DIR}/bin")
+elseif (DEFINED ENV{HIP_DIR})
   file(TO_CMAKE_PATH "$ENV{HIP_DIR}" HIP_DIR)
   set(rocm_bin "${HIP_DIR}/bin")
 else()

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -18,7 +18,7 @@ set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
 set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
 
 if (NOT python)
-  set(python "python") # take default for windows
+  set(python "python3") # take default for windows
 endif()
 
 # our usage flags

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -14,20 +14,11 @@ else()
   set(rocm_bin "C:/hip/bin")
 endif()
 
-#set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc.bat")
-#set(CMAKE_C_COMPILER "${rocm_bin}/hipcc.bat")
 set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
 set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
 
-#set(CMAKE_CXX_LINKER "${rocm_bin}/hipcc.bat" )
-
-# TODO remove, just to speed up slow cmake
-set(CMAKE_C_COMPILER_WORKS 1)
-set(CMAKE_CXX_COMPILER_WORKS 1)
-#
-
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include -IC:/hip/lib/clang/12.0.0 -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${HIP_DIR}/include -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
 
 # flags for clang direct use
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility")
@@ -36,8 +27,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatib
 
 # flags for clang direct use with hip
 # -x hip causes linker error
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x hip -IC:/hip/include/hip -D__HIP_PLATFORM_HCC__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${HIP_DIR}/include/hip -D__HIP_PLATFORM_HCC__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x hip -IC:/hip/include/hip -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
 
 if (DEFINED ENV{VCPKG_PATH})
   file(TO_CMAKE_PATH "$ENV{VCPKG_PATH}" VCPKG_PATH)

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -17,17 +17,17 @@ endif()
 set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
 set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
 
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include -IC:/hip/lib/clang/12.0.0 -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
+if (NOT python)
+  set(python "python") # take default for windows
+endif()
+
+# our usage flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
 
 # flags for clang direct use
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility")
 # -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
 
-# flags for clang direct use with hip
-# -x hip causes linker error
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x hip -IC:/hip/include/hip -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
 
 if (DEFINED ENV{VCPKG_PATH})
@@ -36,8 +36,3 @@ else()
   set(VCPKG_PATH "C:/github/vcpkg")
 endif()
 include("${VCPKG_PATH}/scripts/buildsystems/vcpkg.cmake")
-# set(GTEST_DIR "C:/rocm/Utils/GTestMSVC")
-# set(GTEST_INCLUDE_DIR "${GTEST_DIR}/include")
-# set(GTEST_LIBRARY "${GTEST_DIR}/lib/Release/gtest.lib")
-# set(GTEST_MAIN_LIBRARY "${GTEST_DIR}/lib/Release/gtest_main.lib")
-# set(GTEST_LIBRARIES "${GTEST_DIR}/lib/Release/gtest.lib;${GTEST_DIR}/lib/Release/gtest_main.lib")


### PR DESCRIPTION
Removing unnecessary cmake flags, explicit references to "C:\Program Files\..." which trip up cmake, and old comments.