### PR TITLE
Escape right brace in regex

### DIFF
--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -561,7 +561,7 @@ public:
     static std::string format_name(std::string string)
     {
         format     format = get_format();
-        std::regex r("([A-z0-9]*):\\s*((?:custom_type<[A-z0-9,]*>)|[A-z:().<>\\s0-9]*)(}*)");
+        std::regex r("([A-z0-9]*):\\s*((?:custom_type<[A-z0-9,]*>)|[A-z:().<>\\s0-9]*)(\\}*)");
 
         // First we perform some checks
         bool checks[4] = {false};

--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -561,8 +561,7 @@ public:
     static std::string format_name(std::string string)
     {
         format     format = get_format();
-        std::regex r("([A-z0-9]*):\\s*((?:custom_type<[A-z0-9,]*>)|[A-z:().<>\\s0-9]*)(\\}*)");
-
+std::regex r("([A-z0-9]*):\\s*((?:custom_type<[A-z0-9,]*>)|[A-z:\\(\\)\\.<>\\s0-9]*)(\\}*)");
         // First we perform some checks
         bool checks[4] = {false};
         for(std::sregex_iterator i = std::sregex_iterator(string.begin(), string.end(), r);


### PR DESCRIPTION
In Windows, the regex in benchmark_utils causes a std::regex_error to be thrown at construction when running any of the benchmarks.  It comes from the right brace.  I'm not entirely sure how the right brace doesn't cause problems in Linux...it is a special regex character.