### PR TITLE
Fix device_radix_sort for key/value types of 64 bytes

### DIFF
--- a/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -76,7 +76,7 @@ constexpr unsigned int merge_sort_items_per_thread(const unsigned int item_scale
 }
 constexpr unsigned int merge_sort_block_size(const unsigned int item_scale)
 {
-    if(item_scale <= 64)
+    if(item_scale <= 32)
     {
         return 128;
     }


### PR DESCRIPTION
@stanleytsang-amd Sorry for bugging you again, you will see a small compilation error thrown when building rocThrust, due to the last PR. This fixes that.