### PR TITLE
Fix changelog for 5.5/5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log for rocPRIM
 
-Full documentation for rocPRIM is available at [https://codedocs.xyz/ROCmSoftwarePlatform/rocPRIM/](https://codedocs.xyz/ROCmSoftwarePlatform/rocPRIM/)
+Full documentation for rocPRIM is available at [https://rocprim.readthedocs.io/en/latest/](https://rocprim.readthedocs.io/en/latest/)
 
 ## [Unreleased rocPRIM-2.13.0 for ROCm 5.5.0]
 ### Added
@@ -12,8 +12,9 @@ Full documentation for rocPRIM is available at [https://codedocs.xyz/ROCmSoftwar
 - Improved the performance of `device_merge_sort`.
 ### Known Issues
 - Disabled GPU error messages relating to incorrect warp operation usage with Navi GPUs on Windows, due to GPU printf performance issues on Windows.
+- When `ROCPRIM_DISABLE_LOOKBACK_SCAN` is set, `device_scan` fails for input sizes bigger than `scan_config::size_limit`, which defaults to `std::numeric_limits<unsigned int>::max()`.
 
-## [Unreleased rocPRIM-2.12.0 for ROCm 5.4.0]
+## [rocPRIM-2.12.0 for ROCm 5.4.0]
 ### Changed
 - `device_partition`, `device_unique`, and `device_reduce_by_key` now support problem
   sizes larger than 2^32 items.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ included configurations user should define macro `ROCPRIM_TARGET_ARCH` to `803` 
 should be optimized for gfx803 GCN version, or to `900` for gfx900.
 
 ## Documentation
-The latest rocPRIM documentation and API description can be found [here](https://codedocs.xyz/ROCmSoftwarePlatform/rocPRIM/).
+The latest rocPRIM documentation and API description can be found [here](https://rocprim.readthedocs.io/en/latest/).
 
 It can also be build using the following commands
 


### PR DESCRIPTION
Small PR to add a known issue concerning `device_scan` to the changelog for the next release (whether that be 5.5 or 5.6), and update the links to the documentation. This is (provisionally) the last changeset targeting ROCm 5.