### PR TITLE
Force inline some functions in block sort

### DIFF
--- a/rocprim/include/rocprim/device/detail/device_merge_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge_sort.hpp
@@ -350,14 +350,15 @@ struct block_sort_impl
              typename ValuesInputIterator,
              typename ValuesOutputIterator,
              typename BinaryFunction>
-    ROCPRIM_DEVICE void sort(const unsigned int   valid_in_last_block,
-                             const bool           is_incomplete_block,
-                             KeysInputIterator    keys_input,
-                             KeysOutputIterator   keys_output,
-                             ValuesInputIterator  values_input,
-                             ValuesOutputIterator values_output,
-                             BinaryFunction       compare_function,
-                             storage_type&        storage)
+    ROCPRIM_DEVICE  ROCPRIM_FORCE_INLINE
+    void sort(const unsigned int   valid_in_last_block,
+              const bool           is_incomplete_block,
+              KeysInputIterator    keys_input,
+              KeysOutputIterator   keys_output,
+              ValuesInputIterator  values_input,
+              ValuesOutputIterator values_output,
+              BinaryFunction       compare_function,
+              storage_type&        storage)
     {
         // By default, the block sort algorithm is not stable. We can make it stable
         // by adding an index to each key.
@@ -386,7 +387,8 @@ struct block_sort_impl
 
         // Special compare function that enforces sorting is stable.
         auto stable_compare_function
-            = [compare_function](const stable_key_type& a, const stable_key_type& b) mutable
+            = [compare_function](const stable_key_type& a,
+                                 const stable_key_type& b) ROCPRIM_FORCE_INLINE mutable
         {
             const bool ab = compare_function(rocprim::get<0>(a), rocprim::get<0>(b));
             return ab


### PR DESCRIPTION
The compiler team is working on removing the always inline flag in hipcc.  A performance regression is found in an application that ends up calling the block sort algorithm in rocprim due to some missing inlining opportunities on a few functions due to code size issues and that in turn prevents the compiler from being able to inline the compare function, which is critical to the performance of the sort algorithm. This patch adds the always inline attribute to those intermediate functions in sort to expose the inlining opportunity of the compare function.