### PR TITLE
Fix sphinx error for reduce by key entry

### DIFF
--- a/docs/device_ops/reduce.rst
+++ b/docs/device_ops/reduce.rst
@@ -29,4 +29,4 @@ segmented_reduce
 reduce_by_key
 ~~~~~~~~~~~~~
 
-.. doxygenfunction:: rocprim::reduce_by_key(void *temporary_storage, size_t &storage_size, KeysInputIterator keys_input, ValuesInputIterator values_input, unsigned int size, UniqueOutputIterator unique_output, AggregatesOutputIterator aggregates_output, UniqueCountOutputIterator unique_count_output, BinaryFunction reduce_op=BinaryFunction(), KeyCompareFunction key_compare_op=KeyCompareFunction(), hipStream_t stream=0, bool debug_synchronous=false)
+.. doxygenfunction:: rocprim::reduce_by_key(void *temporary_storage, size_t &storage_size, KeysInputIterator keys_input, ValuesInputIterator values_input, const size_t size, UniqueOutputIterator unique_output, AggregatesOutputIterator aggregates_output, UniqueCountOutputIterator unique_count_output, BinaryFunction reduce_op=BinaryFunction(), KeyCompareFunction key_compare_op=KeyCompareFunction(), hipStream_t stream=0, bool debug_synchronous=false)

--- a/rocprim/include/rocprim/device/device_reduce_by_key.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_by_key.hpp
@@ -410,12 +410,14 @@ hipError_t reduce_by_key_impl(void*                     temporary_storage,
 /// \param [in] reduce_op - binary operation function object that will be used for reduction.
 /// The signature of the function should be equivalent to the following:
 /// <tt>T f(const T &a, const T &b);</tt>. The signature does not need to have
-/// <tt>const &</tt>, but function object must not modify the objects passed to it.
+/// <tt>const &</tt>, but function object must not modify the objects passed to it and must not have
+/// any side effects since the function may be called on uninitalized data. 
 /// Default is BinaryFunction().
 /// \param [in] key_compare_op - binary operation function object that will be used to determine key equality.
 /// The signature of the function should be equivalent to the following:
 /// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
-/// <tt>const &</tt>, but function object must not modify the objects passed to it.
+/// <tt>const &</tt>, but function object must not modify the objects passed to it and must not have
+/// any side effects since the function may be called on uninitalized data.
 /// Default is KeyCompareFunction().
 /// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
 /// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel


### PR DESCRIPTION
This PR:
- Fixes the reduce by key entry not showing up in docs: [Broken](https://rocm.docs.amd.com/projects/rocPRIM/en/latest/device_ops/reduce.html#id3) vs. [fixed](https://advanced-micro-devices-demo--441.com.readthedocs.build/projects/rocPRIM/en/441/device_ops/reduce.html#id3).
- Documents the (soft) requirement that `reduce_by_key` requires an operator that does not have any side-effects.