### PR TITLE
366827 - Disable file reorg backward compatibility support by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ if(NOT USE_HIP_CPU)
 endif()
 
 # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
-option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
+option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" OFF)
 if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_dir(
     "${PROJECT_SOURCE_DIR}/rocprim/include/rocprim"

--- a/install
+++ b/install
@@ -41,7 +41,7 @@ build_benchmark=false
 rocm_path=/opt/rocm
 build_relocatable=false
 build_address_sanitizer=false
-build_freorg_bkwdcomp=true
+build_freorg_bkwdcomp=false
 
 # #################################################
 # Parameter parsing


### PR DESCRIPTION
Changes Proposed
- File Reorg backward compatibility option set to OFF
- Backward Compatibility flag in install script set to false by default.