### PR TITLE
Use gcnArchName instead of deprecated gcnArch

### DIFF
--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -468,7 +468,7 @@ inline hipError_t is_sleep_scan_state_used(bool& use_sleep)
 #else
     const int asicRevision = 0;
 #endif
-    use_sleep = strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2;
+    use_sleep = std::string(prop.gcnArchName).find("908") != std::string::npos && asicRevision < 2;
     return hipSuccess;
 }
 

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -468,7 +468,6 @@ inline hipError_t is_sleep_scan_state_used(bool& use_sleep)
 #else
     const int asicRevision = 0;
 #endif
-    
     use_sleep = strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2;
     return hipSuccess;
 }

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -21,6 +21,7 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_LOOKBACK_SCAN_STATE_HPP_
 #define ROCPRIM_DEVICE_DETAIL_LOOKBACK_SCAN_STATE_HPP_
 
+#include <string.h>
 #include <type_traits>
 
 #include "../../functional.hpp"
@@ -468,7 +469,8 @@ inline hipError_t is_sleep_scan_state_used(bool& use_sleep)
 #else
     const int asicRevision = 0;
 #endif
-    use_sleep = prop.gcnArch == 908 && asicRevision < 2;
+    
+    use_sleep = strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2;
     return hipSuccess;
 }
 

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -21,7 +21,6 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_LOOKBACK_SCAN_STATE_HPP_
 #define ROCPRIM_DEVICE_DETAIL_LOOKBACK_SCAN_STATE_HPP_
 
-#include <string.h>
 #include <type_traits>
 
 #include "../../functional.hpp"

--- a/rocprim/include/rocprim/device/device_partition.hpp
+++ b/rocprim/include/rocprim/device/device_partition.hpp
@@ -256,7 +256,7 @@ hipError_t partition_impl(void * temporary_storage,
             start = std::chrono::high_resolution_clock::now();
         }
 
-        if (prop.gcnArch == 908 && asicRevision < 2)
+        if (strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(init_lookback_scan_state_kernel<offset_scan_state_with_sleep_type>),
@@ -284,7 +284,7 @@ hipError_t partition_impl(void * temporary_storage,
 
         grid_size = current_number_of_blocks;
 
-        if (prop.gcnArch == 908 && asicRevision < 2)
+        if (strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(partition_kernel<SelectMethod, OnlySelected, config>),

--- a/rocprim/include/rocprim/device/device_partition.hpp
+++ b/rocprim/include/rocprim/device/device_partition.hpp
@@ -256,7 +256,7 @@ hipError_t partition_impl(void * temporary_storage,
             start = std::chrono::high_resolution_clock::now();
         }
 
-        if (strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2)
+        if(std::string(prop.gcnArchName).find("908") != std::string::npos && asicRevision < 2)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(init_lookback_scan_state_kernel<offset_scan_state_with_sleep_type>),
@@ -284,7 +284,7 @@ hipError_t partition_impl(void * temporary_storage,
 
         grid_size = current_number_of_blocks;
 
-        if (strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2)
+        if(std::string(prop.gcnArchName).find("908") != std::string::npos && asicRevision < 2)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(partition_kernel<SelectMethod, OnlySelected, config>),

--- a/rocprim/include/rocprim/device/device_scan.hpp
+++ b/rocprim/include/rocprim/device/device_scan.hpp
@@ -287,7 +287,7 @@ inline auto scan_impl(void*               temporary_storage,
                 std::cout << "items_per_block " << items_per_block << '\n';
             }
 
-            if (strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2)
+            if(std::string(prop.gcnArchName).find("908") != std::string::npos && asicRevision < 2)
             {
                 hipLaunchKernelGGL(
                     HIP_KERNEL_NAME(init_lookback_scan_state_kernel<scan_state_with_sleep_type>),
@@ -312,7 +312,7 @@ inline auto scan_impl(void*               temporary_storage,
 
             if(debug_synchronous) start = std::chrono::high_resolution_clock::now();
             grid_size = number_of_blocks;
-            if (strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2)
+            if(std::string(prop.gcnArchName).find("908") != std::string::npos && asicRevision < 2)
             {
                 hipLaunchKernelGGL(
                     HIP_KERNEL_NAME(

--- a/rocprim/include/rocprim/device/device_scan.hpp
+++ b/rocprim/include/rocprim/device/device_scan.hpp
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <iterator>
+#include <string.h>
 #include <type_traits>
 
 #include "../config.hpp"
@@ -287,7 +288,7 @@ inline auto scan_impl(void*               temporary_storage,
                 std::cout << "items_per_block " << items_per_block << '\n';
             }
 
-            if (prop.gcnArch == 908 && asicRevision < 2)
+            if (strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2)
             {
                 hipLaunchKernelGGL(
                     HIP_KERNEL_NAME(init_lookback_scan_state_kernel<scan_state_with_sleep_type>),
@@ -312,7 +313,7 @@ inline auto scan_impl(void*               temporary_storage,
 
             if(debug_synchronous) start = std::chrono::high_resolution_clock::now();
             grid_size = number_of_blocks;
-            if (prop.gcnArch == 908 && asicRevision < 2)
+            if (strcmp(prop.gcnArchName, "908") == 0 && asicRevision < 2)
             {
                 hipLaunchKernelGGL(
                     HIP_KERNEL_NAME(

--- a/rocprim/include/rocprim/device/device_scan.hpp
+++ b/rocprim/include/rocprim/device/device_scan.hpp
@@ -23,7 +23,6 @@
 
 #include <iostream>
 #include <iterator>
-#include <string.h>
 #include <type_traits>
 
 #include "../config.hpp"


### PR DESCRIPTION
We've been advised internally that the gcnArch property in hipDeviceProp_t will be completely removed in ROCm 6.0, as it cannot support full alphanumeric architecture names (ie "gfx90a").  