### PR TITLE
Treat Doxygen warnings as errors

### DIFF
--- a/docs/.doxygen/Doxyfile
+++ b/docs/.doxygen/Doxyfile
@@ -722,7 +722,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = NO
+WARN_IF_UNDOCUMENTED   = YES
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters

--- a/docs/.doxygen/Doxyfile
+++ b/docs/.doxygen/Doxyfile
@@ -722,7 +722,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters
@@ -744,7 +744,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/docs/.doxygen/blockmodule.dox
+++ b/docs/.doxygen/blockmodule.dox
@@ -11,11 +11,11 @@
  */
 
 /**
- * \defgroup blockmodule_warp_load_functions
+ * \defgroup blockmodule_warp_load_functions Load Functions
  * \ingroup blockmodule
  */
 
 /**
- * \defgroup blockmodule_warp_store_functions
+ * \defgroup blockmodule_warp_store_functions Store Functions
  * \ingroup blockmodule
  */

--- a/docs/.doxygen/intrinsicsmodule.dox
+++ b/docs/.doxygen/intrinsicsmodule.dox
@@ -9,11 +9,11 @@
  */
 
 /**
- * \defgroup intrinsicsmodule_flat_id
+ * \defgroup intrinsicsmodule_flat_id Flat ID
  * \ingroup intrinsicsmodule
  */
 
 /**
- * \defgroup intrinsicsmodule_warp_id
+ * \defgroup intrinsicsmodule_warp_id Warp ID
  * \ingroup intrinsicsmodule
  */

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -411,6 +411,15 @@ public:
         scatter_to_blocked(input, output, ranks, storage);
     }
 
+    /// \brief Gathers items from a striped arrangement based on their ranks
+    /// across the thread block.
+    ///
+    /// \tparam U - [inferred] the output type.
+    /// \tparam Offset - [inferred] the rank type.
+    ///
+    /// \param [in] input - array that data is loaded from.
+    /// \param [out] output - array that data is loaded to.
+    /// \param [out] ranks - array that has rank of data.
     template<class U, class Offset>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void gather_from_striped(const T (&input)[ItemsPerThread],
@@ -476,6 +485,16 @@ public:
         }
     }
 
+    /// \brief Gathers items from a striped arrangement based on their ranks
+    /// across the thread block, using temporary storage.
+    ///
+    /// \tparam U - [inferred] the output type.
+    /// \tparam Offset - [inferred] the rank type.
+    ///
+    /// \param [in] input - array that data is loaded from.
+    /// \param [out] output - array that data is loaded to.
+    /// \param [out] ranks - array that has rank of data.
+    /// \param [in] storage - reference to a temporary storage object of type storage_type.
     template <class U, class Offset>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void gather_from_striped(const T (&input)[ItemsPerThread],

--- a/rocprim/include/rocprim/block/block_histogram.hpp
+++ b/rocprim/include/rocprim/block/block_histogram.hpp
@@ -32,10 +32,10 @@
 #include "detail/block_histogram_atomic.hpp"
 #include "detail/block_histogram_sort.hpp"
 
-BEGIN_ROCPRIM_NAMESPACE
-
 /// \addtogroup blockmodule
 /// @{
+
+BEGIN_ROCPRIM_NAMESPACE
 
 /// \brief Available algorithms for block_histogram primitive.
 enum class block_histogram_algorithm

--- a/rocprim/include/rocprim/block/block_load.hpp
+++ b/rocprim/include/rocprim/block/block_load.hpp
@@ -381,9 +381,6 @@ public:
     }
 };
 
-/// @}
-// end of group blockmodule
-
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 template<
@@ -887,5 +884,8 @@ public:
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 END_ROCPRIM_NAMESPACE
+
+/// @}
+// end of group blockmodule
 
 #endif // ROCPRIM_BLOCK_BLOCK_LOAD_HPP_

--- a/rocprim/include/rocprim/block/block_load_func.hpp
+++ b/rocprim/include/rocprim/block/block_load_func.hpp
@@ -28,10 +28,10 @@
 #include "../functional.hpp"
 #include "../types.hpp"
 
-BEGIN_ROCPRIM_NAMESPACE
-
 /// \addtogroup blockmodule
 /// @{
+
+BEGIN_ROCPRIM_NAMESPACE
 
 /// \brief Loads data from continuous memory into a blocked arrangement of items
 /// across the thread block.

--- a/rocprim/include/rocprim/block/block_radix_rank.hpp
+++ b/rocprim/include/rocprim/block/block_radix_rank.hpp
@@ -150,7 +150,7 @@ class block_radix_rank
         Algorithm>::template type<BlockSizeX, RadixBits, BlockSizeY, BlockSizeZ>;
 
 public:
-    /// \brief The number of digits each thead will process.
+    /// \brief The number of digits each thread will process.
     static constexpr unsigned int digits_per_thread = base_type::digits_per_thread;
 
     /// \brief Struct used to allocate a temporary memory that is required for thread

--- a/rocprim/include/rocprim/block/block_radix_rank.hpp
+++ b/rocprim/include/rocprim/block/block_radix_rank.hpp
@@ -203,6 +203,7 @@ public:
     ///     ...
     /// }
     /// \endcode
+    /// \endparblock
     template<typename Key, unsigned ItemsPerThread>
     ROCPRIM_DEVICE void rank_keys(const Key (&keys)[ItemsPerThread],
                                   unsigned int (&ranks)[ItemsPerThread],
@@ -277,6 +278,7 @@ public:
     ///     ...
     /// }
     /// \endcode
+    /// \endparblock
     template<typename Key, unsigned ItemsPerThread>
     ROCPRIM_DEVICE void rank_keys_desc(const Key (&keys)[ItemsPerThread],
                                        unsigned int (&ranks)[ItemsPerThread],
@@ -359,6 +361,7 @@ public:
     ///     ...
     /// }
     /// \endcode
+    /// \endparblock
     template<typename Key, unsigned ItemsPerThread, typename DigitExtractor>
     ROCPRIM_DEVICE void rank_keys(const Key (&keys)[ItemsPerThread],
                                   unsigned int (&ranks)[ItemsPerThread],
@@ -380,7 +383,6 @@ public:
     /// a key.
     /// \param [in] keys - reference to an array of keys provided by a thread.
     /// \param [out] ranks - reference to an array where the final ranks are written to.
-    /// \param [in] storage - reference to a temporary storage object of type \p storage_type.
     /// \param [in] digit_extractor - function object used to convert a key to a digit.
     /// The signature of the \p digit_extractor should be equivalent to the following:
     /// <tt>unsigned int f(const Key &key);</tt>. The signature does not need to have
@@ -445,6 +447,7 @@ public:
     ///     ...
     /// }
     /// \endcode
+    /// \endparblock
     template<typename Key, unsigned ItemsPerThread, typename DigitExtractor>
     ROCPRIM_DEVICE void rank_keys_desc(const Key (&keys)[ItemsPerThread],
                                        unsigned int (&ranks)[ItemsPerThread],
@@ -466,7 +469,6 @@ public:
     /// a key.
     /// \param [in] keys - reference to an array of keys provided by a thread.
     /// \param [out] ranks - reference to an array where the final ranks are written to.
-    /// \param [in] storage - reference to a temporary storage object of type \p storage_type.
     /// \param [in] digit_extractor - function object used to convert a key to a digit.
     /// The signature of the \p digit_extractor should be equivalent to the following:
     /// <tt>unsinged int f(const Key &key);</tt>. The signature does not need to have

--- a/rocprim/include/rocprim/block/block_radix_rank.hpp
+++ b/rocprim/include/rocprim/block/block_radix_rank.hpp
@@ -150,6 +150,7 @@ class block_radix_rank
         Algorithm>::template type<BlockSizeX, RadixBits, BlockSizeY, BlockSizeZ>;
 
 public:
+    /// \brief The number of digits each thead will process.
     static constexpr unsigned int digits_per_thread = base_type::digits_per_thread;
 
     /// \brief Struct used to allocate a temporary memory that is required for thread

--- a/rocprim/include/rocprim/block/block_shuffle.hpp
+++ b/rocprim/include/rocprim/block/block_shuffle.hpp
@@ -156,6 +156,7 @@ public:
         );
     }
 
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void offset(const size_t& flat_id,
                 T input,
@@ -184,6 +185,7 @@ public:
             output = storage_.prev[static_cast<size_t>(offset_tid)];
         }
     }
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /// \brief Shuffles data across threads in a block, offseted by the distance value.
     ///
@@ -222,6 +224,7 @@ public:
         );
     }
 
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void rotate(const size_t& flat_id,
                 T input,
@@ -250,6 +253,7 @@ public:
 
         output = storage_.prev[offset];
     }
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 
     /// \brief The thread block rotates a blocked arrange of input items,
@@ -286,6 +290,7 @@ public:
         );
     }
 
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void up(const size_t& flat_id,
@@ -320,7 +325,7 @@ public:
             prev[0] = storage_.prev[flat_id - 1];
         }
     }
-
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 
     /// \brief The thread block rotates a blocked arrange of input items,
@@ -343,6 +348,7 @@ public:
         );
     }
 
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void up(const size_t& flat_id,
@@ -367,6 +373,7 @@ public:
         // Update block prefix
         block_suffix = storage->prev[BlockSize - 1];
     }
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /// \brief The thread block rotates a blocked arrange of input items,
     /// shifting it down by one item
@@ -402,6 +409,7 @@ public:
         );
     }
 
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void down(const size_t& flat_id,
@@ -435,6 +443,7 @@ public:
           next[ItemsPerThread -1] = storage_.next[flat_id + 1];
         }
     }
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /// \brief The thread block rotates a blocked arrange of input items,
     /// shifting it down by one item
@@ -455,6 +464,7 @@ public:
         );
     }
 
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void down(const size_t& flat_id,
@@ -479,6 +489,7 @@ public:
         // Update block prefixstorage_->
         block_prefix = storage->next[0];
     }
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 };
 
 

--- a/rocprim/include/rocprim/block/block_shuffle.hpp
+++ b/rocprim/include/rocprim/block/block_shuffle.hpp
@@ -156,7 +156,16 @@ public:
         );
     }
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    /// \brief Shuffles data across threads in a block, offseted by the distance value.
+    ///
+    /// \par A thread with  threadId i receives data from a thread with threadIdx (i-distance), whre distance may be a negative value.
+    /// allocated by the method itself.
+    /// \par Any shuffle operation with invalid input or output threadIds are not carried out, i.e. threadId < 0 || threadId >= BlockSize.
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in] input - input data to be shuffled to another thread.
+    /// \param [out] output - reference to a output value, that receives data from another thread
+    /// \param [in] distance - The input threadId + distance = output threadId.
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void offset(const size_t& flat_id,
                 T input,
@@ -167,6 +176,17 @@ public:
         offset(flat_id, input, output, distance, storage);
     }
 
+    /// \brief Shuffles data across threads in a block, offseted by the distance value, using temporary storage.
+    ///
+    /// \par A thread with  threadId i receives data from a thread with threadIdx (i-distance), whre distance may be a negative value.
+    /// allocated by the method itself.
+    /// \par Any shuffle operation with invalid input or output threadIds are not carried out, i.e. threadId < 0 || threadId >= BlockSize.
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in] input - input data to be shuffled to another thread.
+    /// \param [out] output - reference to a output value, that receives data from another thread
+    /// \param [in] distance - The input threadId + distance = output threadId.
+    /// \param [in] storage - reference to a temporary storage object of type storage_type.
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void offset(const size_t& flat_id,
                 T input,
@@ -185,7 +205,6 @@ public:
             output = storage_.prev[static_cast<size_t>(offset_tid)];
         }
     }
-    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /// \brief Shuffles data across threads in a block, offseted by the distance value.
     ///
@@ -224,7 +243,16 @@ public:
         );
     }
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    /// \brief Shuffles data across threads in a block, offseted by the distance value.
+    ///
+    /// \par A thread with  threadId i receives data from a thread with threadIdx (i-distance)%BlockSize, whre distance may be a negative value.
+    /// allocated by the method itself.
+    /// \par Data is rotated around the block, using (input_threadId + distance) modulous BlockSize to ensure valid threadIds.
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in] input - input data to be shuffled to another thread.
+    /// \param [out] output - reference to a output value, that receives data from another thread
+    /// \param [in] distance - The input threadId + distance = output threadId.
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void rotate(const size_t& flat_id,
                 T input,
@@ -235,6 +263,17 @@ public:
         rotate(flat_id, input, output, distance, storage);
     }
 
+    /// \brief Shuffles data across threads in a block, offseted by the distance value, using temporary storage.
+    ///
+    /// \par A thread with  threadId i receives data from a thread with threadIdx (i-distance)%BlockSize, whre distance may be a negative value.
+    /// allocated by the method itself.
+    /// \par Data is rotated around the block, using (input_threadId + distance) modulous BlockSize to ensure valid threadIds.
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in] input - input data to be shuffled to another thread.
+    /// \param [out] output - reference to a output value, that receives data from another thread
+    /// \param [in] distance - The input threadId + distance = output threadId.
+    /// \param [in] storage - reference to a temporary storage object of type storage_type.
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void rotate(const size_t& flat_id,
                 T input,
@@ -253,7 +292,6 @@ public:
 
         output = storage_.prev[offset];
     }
-    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 
     /// \brief The thread block rotates a blocked arrange of input items,
@@ -290,7 +328,13 @@ public:
         );
     }
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    /// \brief The thread block rotates a blocked arrange of input items,
+    /// shifting it up by one item
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in]  input -  The calling thread's input items
+    /// \param [out] prev  -  The corresponding predecessor items (may be aliased to \p input).
+    /// The item \p prev[0] is not updated for <em>thread</em><sub>0</sub>.
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void up(const size_t& flat_id,
@@ -301,7 +345,14 @@ public:
         this->up(flat_id, input, prev, storage);
     }
 
-
+    /// \brief The thread block rotates a blocked arrange of input items,
+    /// shifting it up by one item, using temporary storage.
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in]  input -  The calling thread's input items
+    /// \param [out] prev  -  The corresponding predecessor items (may be aliased to \p input).
+    /// \param [in] storage - reference to a temporary storage object of type storage_type.
+    /// The item \p prev[0] is not updated for <em>thread</em><sub>0</sub>.
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void up(const size_t& flat_id,
@@ -325,7 +376,6 @@ public:
             prev[0] = storage_.prev[flat_id - 1];
         }
     }
-    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 
     /// \brief The thread block rotates a blocked arrange of input items,
@@ -348,7 +398,15 @@ public:
         );
     }
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    /// \brief The thread block rotates a blocked arrange of input items,
+    /// shifting it up by one item
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in]  input - The calling thread's input items
+    /// \param [out] prev  - The corresponding predecessor items (may be aliased to \p input).
+    /// The item \p prev[0] is not updated for <em>thread</em><sub>0</sub>.
+    /// \param [out] block_suffix - The item \p input[ItemsPerThread-1] from
+    /// <em>thread</em><sub><tt>BlockSize-1</tt></sub>, provided to all threads
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void up(const size_t& flat_id,
@@ -360,6 +418,16 @@ public:
         this->up(flat_id, input, prev, block_suffix, storage);
     }
 
+    /// \brief The thread block rotates a blocked arrange of input items,
+    /// shifting it up by one item, using temporary storage.
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in]  input - The calling thread's input items
+    /// \param [out] prev  - The corresponding predecessor items (may be aliased to \p input).
+    /// The item \p prev[0] is not updated for <em>thread</em><sub>0</sub>.
+    /// \param [out] block_suffix - The item \p input[ItemsPerThread-1] from
+    /// <em>thread</em><sub><tt>BlockSize-1</tt></sub>, provided to all threads
+    /// \param [in] storage - reference to a temporary storage object of type storage_type.
     template <int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void up(const size_t& flat_id,
@@ -373,7 +441,6 @@ public:
         // Update block prefix
         block_suffix = storage->prev[BlockSize - 1];
     }
-    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /// \brief The thread block rotates a blocked arrange of input items,
     /// shifting it down by one item
@@ -409,7 +476,13 @@ public:
         );
     }
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    /// \brief The thread block rotates a blocked arrange of input items,
+    /// shifting it down by one item
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in]  input -  The calling thread's input items
+    /// \param [out] next  -  The corresponding successor items (may be aliased to \p input).
+    /// The item \p prev[0] is not updated for <em>thread</em><sub>BlockSize - 1</sub>.
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void down(const size_t& flat_id,
@@ -420,6 +493,14 @@ public:
         this->down(flat_id, input, next, storage);
     }
 
+    /// \brief The thread block rotates a blocked arrange of input items,
+    /// shifting it down by one item, using temporary storage.
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in]  input -  The calling thread's input items
+    /// \param [out] next  -  The corresponding successor items (may be aliased to \p input).
+    /// The item \p prev[0] is not updated for <em>thread</em><sub>BlockSize - 1</sub>.
+    /// \param [in] storage - reference to a temporary storage object of type storage_type.
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void down(const size_t& flat_id,
@@ -443,7 +524,6 @@ public:
           next[ItemsPerThread -1] = storage_.next[flat_id + 1];
         }
     }
-    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /// \brief The thread block rotates a blocked arrange of input items,
     /// shifting it down by one item
@@ -464,7 +544,14 @@ public:
         );
     }
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    /// \brief The thread block rotates a blocked arrange of input items,
+    /// shifting it down by one item
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in]  input -  The calling thread's input items
+    /// \param [out] next  -  The corresponding successor items (may be aliased to \p input).
+    /// The item \p prev[0] is not updated for <em>thread</em><sub>BlockSize - 1</sub>.
+    /// \param [out] block_prefix -  The item \p input[0] from <em>thread</em><sub><tt>0</tt></sub>, provided to all threads
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void down(const size_t& flat_id,
@@ -476,6 +563,15 @@ public:
         this->down(flat_id, input, next, block_prefix, storage);
     }
 
+    /// \brief The thread block rotates a blocked arrange of input items,
+    /// shifting it down by one item, using temporary storage.
+    ///
+    /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
+    /// \param [in]  input -  The calling thread's input items
+    /// \param [out] next  -  The corresponding successor items (may be aliased to \p input).
+    /// The item \p prev[0] is not updated for <em>thread</em><sub>BlockSize - 1</sub>.
+    /// \param [out] block_prefix -  The item \p input[0] from <em>thread</em><sub><tt>0</tt></sub>, provided to all threads
+    /// \param [in] storage - reference to a temporary storage object of type storage_type.
     template <unsigned int ItemsPerThread>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void down(const size_t& flat_id,
@@ -489,7 +585,6 @@ public:
         // Update block prefixstorage_->
         block_prefix = storage->next[0];
     }
-    #endif // DOXYGEN_SHOULD_SKIP_THIS
 };
 
 

--- a/rocprim/include/rocprim/block/block_shuffle.hpp
+++ b/rocprim/include/rocprim/block/block_shuffle.hpp
@@ -121,8 +121,7 @@ public:
 
     /// \brief Shuffles data across threads in a block, offseted by the distance value.
     ///
-    /// \par A thread with  threadId i receives data from a thread with threadIdx (i-distance), whre distance may be a negative value.
-    /// allocated by the method itself.
+    /// \par A thread with threadIdx i receives data from a thread with threadIdx (i - distance), where distance may be a negative value.
     /// \par Any shuffle operation with invalid input or output threadIds are not carried out, i.e. threadId < 0 || threadId >= BlockSize.
     ///
     /// \param [in] input - input data to be shuffled to another thread.
@@ -158,8 +157,7 @@ public:
 
     /// \brief Shuffles data across threads in a block, offseted by the distance value.
     ///
-    /// \par A thread with  threadId i receives data from a thread with threadIdx (i-distance), whre distance may be a negative value.
-    /// allocated by the method itself.
+    /// \par A thread with threadIdx i receives data from a thread with threadIdx (i - distance), where distance may be a negative value.
     /// \par Any shuffle operation with invalid input or output threadIds are not carried out, i.e. threadId < 0 || threadId >= BlockSize.
     ///
     /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
@@ -178,8 +176,7 @@ public:
 
     /// \brief Shuffles data across threads in a block, offseted by the distance value, using temporary storage.
     ///
-    /// \par A thread with  threadId i receives data from a thread with threadIdx (i-distance), whre distance may be a negative value.
-    /// allocated by the method itself.
+    /// \par A thread with threadIdx i receives data from a thread with threadIdx (i - distance), where distance may be a negative value.
     /// \par Any shuffle operation with invalid input or output threadIds are not carried out, i.e. threadId < 0 || threadId >= BlockSize.
     ///
     /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
@@ -208,8 +205,7 @@ public:
 
     /// \brief Shuffles data across threads in a block, offseted by the distance value.
     ///
-    /// \par A thread with  threadId i receives data from a thread with threadIdx (i-distance)%BlockSize, whre distance may be a negative value.
-    /// allocated by the method itself.
+    /// \par A thread with threadIdx i receives data from a thread with threadIdx (i - distance) % BlockSize, where distance may be a negative value.
     /// \par Data is rotated around the block, using (input_threadId + distance) modulous BlockSize to ensure valid threadIds.
     ///
     /// \param [in] input - input data to be shuffled to another thread.
@@ -245,8 +241,7 @@ public:
 
     /// \brief Shuffles data across threads in a block, offseted by the distance value.
     ///
-    /// \par A thread with  threadId i receives data from a thread with threadIdx (i-distance)%BlockSize, whre distance may be a negative value.
-    /// allocated by the method itself.
+    /// \par A thread with threadIdx i receives data from a thread with threadIdx (i - distance) % BlockSize, where distance may be a negative value.
     /// \par Data is rotated around the block, using (input_threadId + distance) modulous BlockSize to ensure valid threadIds.
     ///
     /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id
@@ -265,8 +260,7 @@ public:
 
     /// \brief Shuffles data across threads in a block, offseted by the distance value, using temporary storage.
     ///
-    /// \par A thread with  threadId i receives data from a thread with threadIdx (i-distance)%BlockSize, whre distance may be a negative value.
-    /// allocated by the method itself.
+    /// \par A thread with threadIdx i receives data from a thread with threadIdx (i - distance) % BlockSize, where distance may be a negative value.
     /// \par Data is rotated around the block, using (input_threadId + distance) modulous BlockSize to ensure valid threadIds.
     ///
     /// \param [in] flat_id - flat thread ID obtained from rocprim::flat_block_thread_id

--- a/rocprim/include/rocprim/block/block_sort.hpp
+++ b/rocprim/include/rocprim/block/block_sort.hpp
@@ -184,6 +184,8 @@ public:
         base_type::sort(thread_key, compare_function);
     }
 
+    /// \brief This overload allows an array of \p ItemsPerThread keys to be passed in
+    /// so that each thread can process multiple items.
     template <class BinaryFunction = ::rocprim::less<Key>>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void sort(Key (&thread_keys)[ItemsPerThread],
@@ -242,6 +244,8 @@ public:
         base_type::sort(thread_key, storage, compare_function);
     }
 
+    /// \brief This overload allows arrays of \p ItemsPerThread keys
+    /// to be passed in so that each thread can process multiple items.
     template<class BinaryFunction = ::rocprim::less<Key>>
     ROCPRIM_DEVICE ROCPRIM_INLINE void sort(Key (&thread_keys)[ItemsPerThread],
                                             storage_type&  storage,
@@ -271,6 +275,8 @@ public:
         base_type::sort(thread_key, thread_value, compare_function);
     }
 
+    /// \brief This overload allows an array of \p ItemsPerThread keys and values 
+    /// to be passed in so that each thread can process multiple items.
     template<class BinaryFunction = ::rocprim::less<Key>>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void sort(Key (&thread_keys)[ItemsPerThread],
@@ -332,6 +338,8 @@ public:
         base_type::sort(thread_key, thread_value, storage, compare_function);
     }
 
+    /// \brief This overload allows an array of \p ItemsPerThread keys and values 
+    /// to be passed in so that each thread can process multiple items.
     template<class BinaryFunction = ::rocprim::less<Key>>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort(Key (&thread_keys)[ItemsPerThread],

--- a/rocprim/include/rocprim/block/block_store.hpp
+++ b/rocprim/include/rocprim/block/block_store.hpp
@@ -279,9 +279,6 @@ public:
     }
 };
 
-/// @}
-// end of group blockmodule
-
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 template<
@@ -556,5 +553,8 @@ public:
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 END_ROCPRIM_NAMESPACE
+
+/// @}
+// end of group blockmodule
 
 #endif // ROCPRIM_BLOCK_BLOCK_STORE_HPP_

--- a/rocprim/include/rocprim/block/block_store_func.hpp
+++ b/rocprim/include/rocprim/block/block_store_func.hpp
@@ -28,10 +28,10 @@
 #include "../functional.hpp"
 #include "../types.hpp"
 
-BEGIN_ROCPRIM_NAMESPACE
-
 /// \addtogroup blockmodule
 /// @{
+
+BEGIN_ROCPRIM_NAMESPACE
 
 /// \brief Stores a blocked arrangement of items from across the thread block
 /// into a blocked arrangement on continuous memory.

--- a/rocprim/include/rocprim/block/detail/block_reduce_raking_reduce.hpp
+++ b/rocprim/include/rocprim/block/detail/block_reduce_raking_reduce.hpp
@@ -60,6 +60,7 @@ private:
 // For large types reduces bank conflicts to minimum
 // by values sliced into int32_t and each slice stored continuously.
 // Treatment of []= operator by proxy objects
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<class T, int n>
 class fast_array<T, n, std::enable_if_t<(sizeof(T) > sizeof(int32_t))>>
 {
@@ -107,6 +108,7 @@ private:
 
     int32_t data[words_no * n];
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 template<class T,
          unsigned int BlockSizeX,

--- a/rocprim/include/rocprim/device/config_types.hpp
+++ b/rocprim/include/rocprim/device/config_types.hpp
@@ -155,6 +155,7 @@ using default_or_custom_config =
         Config
     >::type;
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 enum class target_arch : unsigned int
 {
     // This must be zero, to initialize the device -> architecture cache
@@ -168,6 +169,7 @@ enum class target_arch : unsigned int
     gfx1102 = 1102,
     unknown = std::numeric_limits<unsigned int>::max(),
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * \brief Checks if the first `n` characters of `rhs` are equal to `lhs`

--- a/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -356,7 +356,6 @@ struct [[deprecated("The UseLookback switch has been removed, as scan now only s
     static constexpr ::rocprim::block_scan_algorithm block_scan_method = BlockScanMethod;
     /// \brief Limit on the number of items for a single scan kernel launch.
     static constexpr unsigned int size_limit = SizeLimit;
-#endif
 
     constexpr scan_config()
         : ::rocprim::detail::scan_config_params{
@@ -365,6 +364,7 @@ struct [[deprecated("The UseLookback switch has been removed, as scan now only s
             BlockStoreMethod,
             BlockScanMethod
     } {};
+#endif
 };
 
 namespace detail

--- a/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -663,4 +663,7 @@ struct default_histogram_config_base
 
 END_ROCPRIM_NAMESPACE
 
+/// @}
+// end of group primitivesmodule_deviceconfigs
+
 #endif //ROCPRIM_DEVICE_DETAIL_CONFIG_HELPER_HPP_

--- a/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -321,7 +321,6 @@ struct scan_config_v2 : ::rocprim::detail::scan_config_params
 #endif
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // Doxygen seems to have trouble with the syntax used in this definition
 /// \brief Deprecated: Configuration of device-level scan primitives.
 ///
 /// \tparam BlockSize - number of threads in a block.
@@ -338,9 +337,12 @@ template<unsigned int                    BlockSize,
          ::rocprim::block_store_method   BlockStoreMethod,
          ::rocprim::block_scan_algorithm BlockScanMethod,
          unsigned int                    SizeLimit = ROCPRIM_GRID_SIZE_LIMIT>
-struct [[deprecated("The UseLookback switch has been removed, as scan now only supports the "
-                    "lookback-scan implementation. Use scan_config_v2 instead.")]] scan_config
-    : ::rocprim::detail::scan_config_params
+struct
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Doxygen seems to have trouble with the syntax used in this definition
+[[deprecated("The UseLookback switch has been removed, as scan now only supports the "
+                    "lookback-scan implementation. Use scan_config_v2 instead.")]] 
+#endif
+scan_config : ::rocprim::detail::scan_config_params
 {
     /// \brief Number of threads in a block.
     static constexpr unsigned int block_size = BlockSize;
@@ -365,7 +367,6 @@ struct [[deprecated("The UseLookback switch has been removed, as scan now only s
             BlockScanMethod
     } {};
 };
-#endif
 
 namespace detail
 {
@@ -459,12 +460,14 @@ template<unsigned int                    BlockSize,
          ::rocprim::block_store_method   BlockStoreMethod,
          ::rocprim::block_scan_algorithm BlockScanMethod,
          unsigned int                    SizeLimit = ROCPRIM_GRID_SIZE_LIMIT>
-struct [[deprecated(
+struct
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Doxygen seems to have trouble with the syntax used in this definition
+[[deprecated(
     "The UseLookback switch has been removed, as scan now only supports the lookback-scan "
-    "implementation. Use scan_by_key_config_v2 instead.")]] scan_by_key_config
-    : ::rocprim::detail::scan_by_key_config_params
+    "implementation. Use scan_by_key_config_v2 instead.")]]
+#endif
+scan_by_key_config : ::rocprim::detail::scan_by_key_config_params
 {
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
     /// \brief Number of threads in a block.
     static constexpr unsigned int block_size = BlockSize;
     /// \brief Number of items processed by each thread.
@@ -479,7 +482,6 @@ struct [[deprecated(
     static constexpr ::rocprim::block_scan_algorithm block_scan_method = BlockScanMethod;
     /// \brief Limit on the number of items for a single scan kernel launch.
     static constexpr unsigned int size_limit = SizeLimit;
-#endif
 
     constexpr scan_by_key_config()
         : ::rocprim::detail::scan_by_key_config_params{

--- a/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -321,6 +321,7 @@ struct scan_config_v2 : ::rocprim::detail::scan_config_params
 #endif
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Doxygen seems to have trouble with the syntax used in this definition
 /// \brief Deprecated: Configuration of device-level scan primitives.
 ///
 /// \tparam BlockSize - number of threads in a block.
@@ -341,7 +342,6 @@ struct [[deprecated("The UseLookback switch has been removed, as scan now only s
                     "lookback-scan implementation. Use scan_config_v2 instead.")]] scan_config
     : ::rocprim::detail::scan_config_params
 {
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
     /// \brief Number of threads in a block.
     static constexpr unsigned int block_size = BlockSize;
     /// \brief Number of items processed by each thread.
@@ -364,8 +364,8 @@ struct [[deprecated("The UseLookback switch has been removed, as scan now only s
             BlockStoreMethod,
             BlockScanMethod
     } {};
-#endif
 };
+#endif
 
 namespace detail
 {

--- a/rocprim/include/rocprim/device/detail/device_merge_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge_sort.hpp
@@ -512,6 +512,7 @@ struct block_sort_impl<Key,
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<typename Key, typename Value, unsigned int BlockSize, unsigned int ItemsPerThread>
 struct block_sort_impl<Key,
                        Value,
@@ -593,7 +594,6 @@ struct block_sort_impl<Key,
         }
     }
 };
-
 template<typename Key, typename Value, unsigned int BlockSize, unsigned int ItemsPerThread>
 struct block_sort_impl<Key,
                        Value,
@@ -675,6 +675,7 @@ struct block_sort_impl<Key,
         }
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 template<unsigned int         BlockSize,
          unsigned int         ItemsPerThread,

--- a/rocprim/include/rocprim/device/detail/device_partition.hpp
+++ b/rocprim/include/rocprim/device/detail/device_partition.hpp
@@ -43,12 +43,14 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 enum class select_method
 {
     flag = 0,
     predicate = 1,
     unique = 2
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 template<select_method SelectMethod,
          unsigned int  BlockSize,

--- a/rocprim/include/rocprim/device/detail/device_scan_common.hpp
+++ b/rocprim/include/rocprim/device/detail/device_scan_common.hpp
@@ -136,6 +136,7 @@ ROCPRIM_KERNEL
     init_lookback_scan_state(lookback_scan_state, number_of_blocks, flat_thread_id);
 }
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
     template <bool Exclusive,
               class BlockScan,
               class T,
@@ -213,6 +214,7 @@ ROCPRIM_KERNEL
                                    prefix_callback_op,
                                    scan_op);
     }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 } // namespace detail
 

--- a/rocprim/include/rocprim/device/device_adjacent_difference_config.hpp
+++ b/rocprim/include/rocprim/device/device_adjacent_difference_config.hpp
@@ -52,8 +52,8 @@ template <unsigned int       BlockSize,
           unsigned int       SizeLimit   = ROCPRIM_GRID_SIZE_LIMIT>
 struct adjacent_difference_config : kernel_config<BlockSize, ItemsPerThread, SizeLimit>
 {
-    static constexpr block_load_method  load_method  = LoadMethod;
-    static constexpr block_store_method store_method = StoreMethod;
+    static constexpr block_load_method  load_method  = LoadMethod; ///< input values are loaded using this method
+    static constexpr block_store_method store_method = StoreMethod; ///< input values are stored using this method
 };
 
 namespace detail

--- a/rocprim/include/rocprim/device/device_binary_search.hpp
+++ b/rocprim/include/rocprim/device/device_binary_search.hpp
@@ -85,6 +85,43 @@ hipError_t binary_search(void * temporary_storage,
 
 } // end of detail namespace
 
+/// \brief Performs a device-level lower bound check.
+///
+/// \par Overview
+/// Runs multiple lower bound checks in parallel (one for each \p needle in \p needles ).
+/// A lower bound check returns the index of the first element in \p haystack that
+/// causes \p compare_op(element,needle) to return false. If no item in \p haystack satisfies
+/// this criteria, then \p haystack_size is returned.
+/// Results are written by \p output.
+///
+/// \tparam Config - [optional] configuration information for the primitive. This can be 
+/// \p lower_bound_config or a custom class with the same members.
+/// \tparam HaystackIterator - Iterator type for items we'll be searching through (values).
+/// \tparam NeedlesIterator - Iterator type for items we are performing lower bound checks
+/// for (keys).
+/// \tparam OutputIterator - Iterator type for the output indices.
+/// \tparam CompareFunction [optional] A callable that can be used to compare two values.
+/// defaults to rocprim::less.
+///
+/// \param [in] temporary_storage - pointer to device-accessible temporary storage. When
+/// a null pointer is passed, the required allocation size (in bytes) is written to
+/// \p storage_size and the function returns without performing the search operation.
+/// \param [in,out] storage_size - reference to the size (in bytes) of \p temporary_storage.
+/// \param haystack [in] - iterator pointing to the beginning of the range to search through.
+/// \param needles [in] - iterator pointing to the first of the elements to perform lower
+/// bound checks on.
+/// \param output [out] - Iterator pointing to the beginning of the range where the results
+/// are to be stored.
+/// \param haystack_size [in] - the total number of values to search through.
+/// \param needles_size [in] - the total number of keys to perform lower bound checks for.
+/// \param compare_op [in] - binary operation function that will be used for comparison.
+/// The signature of the function should be equivalent to the following:
+/// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
+/// <tt>const &</tt>, but the function object must not modify the objects passed to it.
+/// The default value is \p CompareFunction().
+/// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
+/// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
+/// launch is forced in order to check for errors. Default value is \p false.
 template<
     class Config = default_config,
     class HaystackIterator,
@@ -124,6 +161,43 @@ hipError_t lower_bound(void * temporary_storage,
                                          debug_synchronous);
 }
 
+/// \brief Performs a device-level upper bound check.
+///
+/// \par Overview
+/// Runs multiple upper bound checks in parallel (one for each \p needle in \p needles ).
+/// An upper bound check returns the index of the first element in \p haystack that
+/// causes \p compare_op(needle,element) to return true. If no item in \p haystack satisfies
+/// this criteria, then \p haystack_size is returned.
+/// Results are written by \p output.
+///
+/// \tparam Config - [optional] configuration information for the primitive. This can be 
+/// \p upper_bound_config or a custom class with the same members.
+/// \tparam HaystackIterator - Iterator type for items we'll be searching through (values).
+/// \tparam NeedlesIterator - Iterator type for items we are performing upper bound checks
+/// for (keys).
+/// \tparam OutputIterator - Iterator type for the output indices.
+/// \tparam CompareFunction [optional] A callable that can be used to compare two values.
+/// defaults to rocprim::less.
+///
+/// \param [in] temporary_storage - pointer to device-accessible temporary storage. When
+/// a null pointer is passed, the required allocation size (in bytes) is written to
+/// \p storage_size and the function returns without performing the search operation.
+/// \param [in,out] storage_size - reference to the size (in bytes) of \p temporary_storage.
+/// \param haystack [in] - iterator pointing to the beginning of the range to search through.
+/// \param needles [in] - iterator pointing to the first of the elements to perform upper
+/// bound checks on.
+/// \param output [out] - Iterator pointing to the beginning of the range where the results
+/// are to be stored.
+/// \param haystack_size [in] - the total number of values to search through.
+/// \param needles_size [in] - the total number of keys to perform upper bound checks for.
+/// \param compare_op [in] - binary operation function that will be used for comparison.
+/// The signature of the function should be equivalent to the following:
+/// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
+/// <tt>const &</tt>, but the function object must not modify the objects passed to it.
+/// The default value is \p CompareFunction().
+/// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
+/// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
+/// launch is forced in order to check for errors. Default value is \p false.
 template<
     class Config = default_config,
     class HaystackIterator,
@@ -163,6 +237,39 @@ hipError_t upper_bound(void * temporary_storage,
                                          debug_synchronous);
 }
 
+/// \brief Performs a device-level parallel binary search.
+///
+/// \par Overview
+/// Runs multiple binary searches in parallel. The result is a sequence of bools,
+/// where each bool indicates if the corresponding search succeeded (the key was found)
+/// or not. Results are written by \p output.
+///
+/// \tparam Config - [optional] configuration information for the primitive. This can be 
+/// \p binary_search_config or a custom class with the same members.
+/// \tparam HaystackIterator - Iterator type for items we'll be searching through (values).
+/// \tparam NeedlesIterator - Iterator type for item we are searching for (keys).
+/// \tparam OutputIterator - Iterator type for the output bools.
+/// \tparam CompareFunction [optional] A callable that can be used to compare two values.
+/// defaults to rocprim::less.
+///
+/// \param [in] temporary_storage - pointer to device-accessible temporary storage. When
+/// a null pointer is passed, the required allocation size (in bytes) is written to
+/// \p storage_size and the function returns without performing the search operation.
+/// \param [in,out] storage_size - reference to the size (in bytes) of \p temporary_storage.
+/// \param haystack [in] - iterator pointing to the beginning of the range to search through.
+/// \param needles [in] - iterator pointing to the first of the elements to find.
+/// \param output [out] - Iterator pointing to the beginning of the range where the results
+/// are to be stored.
+/// \param haystack_size [in] - the total number of values to search through.
+/// \param needles_size [in] - the total number of keys to search for.
+/// \param compare_op [in] - binary operation function that will be used for comparison.
+/// The signature of the function should be equivalent to the following:
+/// <tt>bool f(const T &a, const T &b);</tt>. The signature does not need to have
+/// <tt>const &</tt>, but the function object must not modify the objects passed to it.
+/// The default value is \p CompareFunction().
+/// \param [in] stream - [optional] HIP stream object. Default is \p 0 (default stream).
+/// \param [in] debug_synchronous - [optional] If true, synchronization after every kernel
+/// launch is forced in order to check for errors. Default value is \p false.
 template<
     class Config = default_config,
     class HaystackIterator,

--- a/rocprim/include/rocprim/device/device_binary_search.hpp
+++ b/rocprim/include/rocprim/device/device_binary_search.hpp
@@ -88,7 +88,7 @@ hipError_t binary_search(void * temporary_storage,
 /// \brief Performs a device-level lower bound check.
 ///
 /// \par Overview
-/// Runs multiple lower bound checks in parallel (one for each \p needle in \p needles ).
+/// Runs multiple lower bound checks in parallel (one for each \p needle in <tt>needles</tt>).
 /// A lower bound check returns the index of the first element in \p haystack that
 /// causes \p compare_op(element,needle) to return false. If no item in \p haystack satisfies
 /// this criteria, then \p haystack_size is returned.
@@ -164,7 +164,7 @@ hipError_t lower_bound(void * temporary_storage,
 /// \brief Performs a device-level upper bound check.
 ///
 /// \par Overview
-/// Runs multiple upper bound checks in parallel (one for each \p needle in \p needles ).
+/// Runs multiple upper bound checks in parallel (one for each \p needle in <tt>needles</tt>).
 /// An upper bound check returns the index of the first element in \p haystack that
 /// causes \p compare_op(needle,element) to return true. If no item in \p haystack satisfies
 /// this criteria, then \p haystack_size is returned.

--- a/rocprim/include/rocprim/device/device_reduce_by_key_config.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_by_key_config.hpp
@@ -56,12 +56,28 @@ template<unsigned int         BlockSize,
          unsigned int         SizeLimit        = ROCPRIM_GRID_SIZE_LIMIT>
 struct reduce_by_key_config_v2
 {
+    /// Number of threads in a block.
     static constexpr unsigned int         block_size         = BlockSize;
+
+    /// Number of tiles (`BlockSize` * `ItemsPerThread` items) to process per block
     static constexpr unsigned int         tiles_per_block    = TilesPerBlock;
+
+    /// Number of items processed by each thread per tile. 
     static constexpr unsigned int         items_per_thread   = ItemsPerThread;
+
+    /// A rocprim::block_load_method emum value indicating how the keys should be loaded.
+    /// Defaults to block_load_method::block_load_transpose
     static constexpr block_load_method    load_keys_method   = LoadKeysMethod;
+
+    /// A rocprim::block_load_method emum value indicating how the values should be loaded.
+    /// Defaults to block_load_method::block_load_transpose
     static constexpr block_load_method    load_values_method = LoadValuesMethod;
+
+    /// A rocprim::block_scan_algorithm enum value indicating how the reduction should
+    /// be done. Defaults to block_scan_algorithm::using_warp_scan
     static constexpr block_scan_algorithm scan_algorithm     = ScanAlgorithm;
+
+    /// Maximum possible number of values. Defaults to ROCPRIM_GRID_SIZE_LIMIT.
     static constexpr unsigned int         size_limit         = SizeLimit;
 };
 

--- a/rocprim/include/rocprim/functional.hpp
+++ b/rocprim/include/rocprim/functional.hpp
@@ -31,6 +31,8 @@ BEGIN_ROCPRIM_NAMESPACE
 /// \addtogroup utilsmodule_functional
 /// @{
 
+/// \brief Prints the supplied error message only once (using only one of the active threads).
+/// \note Currently, this is not defined for Navi devices.
 #if ROCPRIM_NAVI
 ROCPRIM_PRAGMA_MESSAGE("GPU printf warnings for invalid rocPRIM warp operations on Navi GPUs "
                        "temporarily disabled, due to performance issues with printf.")
@@ -47,6 +49,7 @@ ROCPRIM_PRAGMA_MESSAGE("GPU printf warnings for invalid rocPRIM warp operations 
         }
 #endif
 
+/// \brief Returns the maximum of its arguments.
 template<class T>
 ROCPRIM_HOST_DEVICE inline
 constexpr T max(const T& a, const T& b)
@@ -54,6 +57,7 @@ constexpr T max(const T& a, const T& b)
     return a < b ? b : a;
 }
 
+/// \brief Returns the minimum of its arguments.
 template<class T>
 ROCPRIM_HOST_DEVICE inline
 constexpr T min(const T& a, const T& b)
@@ -61,6 +65,7 @@ constexpr T min(const T& a, const T& b)
     return a < b ? a : b;
 }
 
+/// \brief Swaps two values.
 template<class T>
 ROCPRIM_HOST_DEVICE inline
 void swap(T& a, T& b)
@@ -70,9 +75,11 @@ void swap(T& a, T& b)
     b = c;
 }
 
+/// \brief Returns true if a < b. Otherwise returns false.
 template<class T = void>
 struct less
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
     {
@@ -80,6 +87,7 @@ struct less
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct less<void>
 {
@@ -90,10 +98,13 @@ struct less<void>
         return a < b;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns true if a <= b. Otherwise returns false.
 template<class T = void>
 struct less_equal
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
     {
@@ -101,6 +112,7 @@ struct less_equal
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct less_equal<void>
 {
@@ -111,10 +123,13 @@ struct less_equal<void>
         return a <= b;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns true if a > b. Otherwise returns false.
 template<class T = void>
 struct greater
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
     {
@@ -122,6 +137,7 @@ struct greater
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct greater<void>
 {
@@ -132,10 +148,13 @@ struct greater<void>
         return a > b;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns true if a >= b. Otherwise returns false.
 template<class T = void>
 struct greater_equal
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
     {
@@ -143,6 +162,7 @@ struct greater_equal
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct greater_equal<void>
 {
@@ -153,10 +173,13 @@ struct greater_equal<void>
         return a >= b;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns true if a == b. Otherwise returns false.
 template<class T = void>
 struct equal_to
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
     {
@@ -164,6 +187,7 @@ struct equal_to
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct equal_to<void>
 {
@@ -174,10 +198,13 @@ struct equal_to<void>
         return a == b;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns true if a != b. Otherwise returns false.
 template<class T = void>
 struct not_equal_to
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
     {
@@ -185,6 +212,7 @@ struct not_equal_to
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct not_equal_to<void>
 {
@@ -195,10 +223,13 @@ struct not_equal_to<void>
         return a != b;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns a + b.
 template<class T = void>
 struct plus
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a, const T& b) const
     {
@@ -206,6 +237,7 @@ struct plus
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct plus<void>
 {
@@ -216,10 +248,13 @@ struct plus<void>
         return a + b;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns a - b.
 template<class T = void>
 struct minus
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a, const T& b) const
     {
@@ -227,6 +262,7 @@ struct minus
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct minus<void>
 {
@@ -237,10 +273,13 @@ struct minus<void>
         return a - b;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns a * b.
 template<class T = void>
 struct multiplies
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a, const T& b) const
     {
@@ -248,6 +287,7 @@ struct multiplies
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct multiplies<void>
 {
@@ -258,10 +298,13 @@ struct multiplies<void>
         return a * b;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns the maximum of its arguments.
 template<class T = void>
 struct maximum
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a, const T& b) const
     {
@@ -269,6 +312,7 @@ struct maximum
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct maximum<void>
 {
@@ -279,10 +323,13 @@ struct maximum<void>
         return a < b ? b : a;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns the minimum of its arguments.
 template<class T = void>
 struct minimum
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a, const T& b) const
     {
@@ -290,6 +337,7 @@ struct minimum
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct minimum<void>
 {
@@ -300,10 +348,13 @@ struct minimum<void>
         return a < b ? a : b;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+/// \brief Functor that returns its argument.
 template<class T = void>
 struct identity
 {
+    /// \brief Invocation operator
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a) const
     {
@@ -311,6 +362,7 @@ struct identity
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
 template<>
 struct identity<void>
 {
@@ -321,6 +373,7 @@ struct identity<void>
         return a;
     }
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * \brief Statically determine log2(N), rounded up.
@@ -375,13 +428,13 @@ struct Equals <A, A>
     };
 };
 
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
 template <int A>
 struct Int2Type
 {
    enum {VALUE = A};
 };
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// @}
 // end of group utilsmodule_functional

--- a/rocprim/include/rocprim/functional.hpp
+++ b/rocprim/include/rocprim/functional.hpp
@@ -87,10 +87,12 @@ struct less
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Returns true if a < b. Otherwise returns false.
+/// This version is a specialization for type void.
 template<>
 struct less<void>
 {
+    /// \brief Invocation operator
     template<class T, class U>
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const U& b) const
@@ -98,7 +100,6 @@ struct less<void>
         return a < b;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns true if a <= b. Otherwise returns false.
 template<class T = void>
@@ -112,10 +113,12 @@ struct less_equal
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns true if a <= b. Otherwise returns false.
+/// This version is a specialization for type void.
 template<>
 struct less_equal<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
@@ -123,7 +126,6 @@ struct less_equal<void>
         return a <= b;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns true if a > b. Otherwise returns false.
 template<class T = void>
@@ -137,10 +139,12 @@ struct greater
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns true if a > b. Otherwise returns false.
+/// This version is a specialization for type void.
 template<>
 struct greater<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
@@ -148,7 +152,6 @@ struct greater<void>
         return a > b;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns true if a >= b. Otherwise returns false.
 template<class T = void>
@@ -162,10 +165,12 @@ struct greater_equal
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns true if a >= b. Otherwise returns false.
+/// This version is a specialization for type void.
 template<>
 struct greater_equal<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
@@ -173,7 +178,6 @@ struct greater_equal<void>
         return a >= b;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns true if a == b. Otherwise returns false.
 template<class T = void>
@@ -187,10 +191,12 @@ struct equal_to
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns true if a == b. Otherwise returns false.
+/// This version is a specialization for type void.
 template<>
 struct equal_to<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
@@ -198,7 +204,6 @@ struct equal_to<void>
         return a == b;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns true if a != b. Otherwise returns false.
 template<class T = void>
@@ -212,10 +217,12 @@ struct not_equal_to
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns true if a != b. Otherwise returns false.
+/// This version is a specialization for type void.
 template<>
 struct not_equal_to<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
@@ -223,7 +230,6 @@ struct not_equal_to<void>
         return a != b;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns a + b.
 template<class T = void>
@@ -237,10 +243,12 @@ struct plus
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns a + b.
+/// This version is a specialization for type void.
 template<>
 struct plus<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a, const T& b) const
@@ -248,7 +256,6 @@ struct plus<void>
         return a + b;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns a - b.
 template<class T = void>
@@ -262,10 +269,12 @@ struct minus
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns a - b.
+/// This version is a specialization for type void.
 template<>
 struct minus<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a, const T& b) const
@@ -273,7 +282,6 @@ struct minus<void>
         return a - b;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns a * b.
 template<class T = void>
@@ -287,10 +295,12 @@ struct multiplies
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns a * b.
+/// This version is a specialization for type void.
 template<>
 struct multiplies<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a, const T& b) const
@@ -298,7 +308,6 @@ struct multiplies<void>
         return a * b;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns the maximum of its arguments.
 template<class T = void>
@@ -312,10 +321,12 @@ struct maximum
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns the maximum of its arguments.
+/// This version is a specialization for type void.
 template<>
 struct maximum<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a, const T& b) const
@@ -323,7 +334,6 @@ struct maximum<void>
         return a < b ? b : a;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns the minimum of its arguments.
 template<class T = void>
@@ -337,10 +347,12 @@ struct minimum
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns the minimum of its arguments.
+/// This version is a specialization for type void.
 template<>
 struct minimum<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a, const T& b) const
@@ -348,7 +360,6 @@ struct minimum<void>
         return a < b ? a : b;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Functor that returns its argument.
 template<class T = void>
@@ -362,10 +373,12 @@ struct identity
     }
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized version
+/// \brief Functor that returns its argument.
+/// This version is a specialization for type void.
 template<>
 struct identity<void>
 {
+    /// \brief Invocation operator
     template <typename T>
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T& a) const
@@ -373,7 +386,6 @@ struct identity<void>
         return a;
     }
 };
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * \brief Statically determine log2(N), rounded up.

--- a/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -153,6 +153,8 @@ unsigned int warp_id()
     return flat_block_thread_id()/device_warp_size();
 }
 
+/// \brief Returns warp id in a block (tile), given the flat (linear, 1D) thread identifier in a multidimensional tile (block).
+/// \param flat_id - the flat id that should be used to compute the warp id.
 ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int warp_id(unsigned int flat_id)
 {

--- a/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -110,6 +110,7 @@ unsigned int flat_block_thread_id()
         + threadIdx.x;
 }
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 /// \brief Returns flat (linear, 1D) thread identifier in a multidimensional block (tile). Use template parameters to optimize 1D or 2D kernels.
 template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSizeZ>
 ROCPRIM_DEVICE ROCPRIM_INLINE
@@ -135,6 +136,7 @@ auto flat_block_thread_id()
     return threadIdx.x + (threadIdx.y * blockDim.x) +
            (threadIdx.z * blockDim.y * blockDim.x);
 }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Returns flat (linear, 1D) thread identifier in a multidimensional tile (block).
 ROCPRIM_DEVICE ROCPRIM_INLINE
@@ -157,6 +159,7 @@ unsigned int warp_id(unsigned int flat_id)
     return flat_id/device_warp_size();
 }
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 /// \brief Returns warp id in a block (tile). Use template parameters to optimize 1D or 2D kernels.
 /// \ingroup intrinsicsmodule_warp_id
 template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSizeZ>
@@ -165,6 +168,7 @@ unsigned int warp_id()
 {
     return flat_block_thread_id<BlockSizeX, BlockSizeY, BlockSizeZ>()/device_warp_size();
 }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// \brief Returns flat (linear, 1D) block identifier in a multidimensional grid.
 /// \ingroup intrinsicsmodule_flat_id
@@ -176,6 +180,7 @@ unsigned int flat_block_id()
         + blockIdx.x;
 }
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSizeZ>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 auto flat_block_id()
@@ -200,6 +205,7 @@ auto flat_block_id()
     return blockIdx.x + (blockIdx.y * gridDim.x) +
            (blockIdx.z * gridDim.y * gridDim.x);
 }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 // Sync
 

--- a/rocprim/include/rocprim/intrinsics/warp.hpp
+++ b/rocprim/include/rocprim/intrinsics/warp.hpp
@@ -120,7 +120,7 @@ int warp_all(int predicate)
 /**
  * This function computes a lane mask of active lanes in the warp which which have
  * the same value for <tt>label</tt> as the lane which calls the function. The bit at
- * index \p i in the lane mask is set if the thread of lane \i calls this function
+ * index \p i in the lane mask is set if the thread of lane \p i calls this function
  * with the same value <tt>label</tt>. Only the least-significant \p LabelBits bits
  * are taken into account when labels are considered to be equal.
  */
@@ -147,7 +147,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE lane_mask_type match_any(unsigned int label)
 /**
  * This function computes a lane mask of active lanes in the warp which which have
  * the same value for <tt>label</tt> as the lane which calls the function. The bit at
- * index \p i in the lane mask is set if the thread of lane \i calls this function
+ * index \p i in the lane mask is set if the thread of lane \p i calls this function
  * with the same value <tt>label</tt>. Only the least-significant \p LabelBits bits
  * are taken into account when labels are considered to be equal.
  */

--- a/rocprim/include/rocprim/iterator/arg_index_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/arg_index_iterator.hpp
@@ -94,6 +94,7 @@ public:
     {
     }
 
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS
     ROCPRIM_HOST_DEVICE inline
     arg_index_iterator& operator++()
     {
@@ -102,7 +103,6 @@ public:
         return *this;
     }
 
-    //! \skip_doxy_start
     ROCPRIM_HOST_DEVICE inline
     arg_index_iterator operator++(int)
     {
@@ -212,13 +212,14 @@ public:
     {
         return os;
     }
-    //! \skip_doxy_end
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 private:
     InputIterator iterator_;
     difference_type offset_;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<
     class InputIterator,
     class Difference,
@@ -231,7 +232,7 @@ operator+(typename arg_index_iterator<InputIterator, Difference, InputValueType>
 {
     return iterator + distance;
 }
-
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// make_arg_index_iterator creates a arg_index_iterator using \p iterator as
 /// the underlying iterator and \p offset as the position (index) of \p iterator

--- a/rocprim/include/rocprim/iterator/constant_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/constant_iterator.hpp
@@ -82,7 +82,7 @@ public:
     ROCPRIM_HOST_DEVICE inline
     ~constant_iterator() = default;
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS
     ROCPRIM_HOST_DEVICE inline
     value_type operator*() const
     {
@@ -167,7 +167,7 @@ public:
         return value_;
     }
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS
     ROCPRIM_HOST_DEVICE inline
     bool operator==(constant_iterator other) const
     {

--- a/rocprim/include/rocprim/iterator/constant_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/constant_iterator.hpp
@@ -82,7 +82,7 @@ public:
     ROCPRIM_HOST_DEVICE inline
     ~constant_iterator() = default;
 
-    //! \skip_doxy_start
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     ROCPRIM_HOST_DEVICE inline
     value_type operator*() const
     {
@@ -156,7 +156,7 @@ public:
     {
         return static_cast<difference_type>(index_ - other.index_);
     }
-    //! \skip_doxy_end
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /// Constant_iterator is not writable, so we don't return reference,
     /// just something convertible to reference. That matches requirement
@@ -167,7 +167,7 @@ public:
         return value_;
     }
 
-    //! \skip_doxy_start
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     ROCPRIM_HOST_DEVICE inline
     bool operator==(constant_iterator other) const
     {
@@ -209,7 +209,7 @@ public:
         os << "[" << iter.value_ << "]";
         return os;
     }
-    //! \skip_doxy_end
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 private:
     inline
@@ -222,6 +222,7 @@ private:
     size_t index_;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<
     class ValueType,
     class Difference
@@ -233,6 +234,7 @@ operator+(typename constant_iterator<ValueType, Difference>::difference_type dis
 {
     return iter + distance;
 }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// make_constant_iterator creates a constant_iterator with its initial value
 /// set to \p value.

--- a/rocprim/include/rocprim/iterator/counting_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/counting_iterator.hpp
@@ -87,7 +87,7 @@ public:
     {
     }
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS
     ROCPRIM_HOST_DEVICE inline
     counting_iterator& operator++()
     {

--- a/rocprim/include/rocprim/iterator/counting_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/counting_iterator.hpp
@@ -87,7 +87,7 @@ public:
     {
     }
 
-    //! \skip_doxy_start
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     ROCPRIM_HOST_DEVICE inline
     counting_iterator& operator++()
     {
@@ -212,7 +212,7 @@ public:
         os << "[" << iter.value_ << "]";
         return os;
     }
-    //! \skip_doxy_end
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 private:
     template<class T>
@@ -231,6 +231,7 @@ private:
     value_type value_;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<
     class Incrementable,
     class Difference
@@ -242,6 +243,7 @@ operator+(typename counting_iterator<Incrementable, Difference>::difference_type
 {
     return iter + distance;
 }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// make_counting_iterator creates a counting_iterator with its initial value
 /// set to \p value.

--- a/rocprim/include/rocprim/iterator/discard_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/discard_iterator.hpp
@@ -88,7 +88,7 @@ public:
     ROCPRIM_HOST_DEVICE inline
     ~discard_iterator() = default;
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS
     ROCPRIM_HOST_DEVICE inline
     discard_iterator& operator++()
     {

--- a/rocprim/include/rocprim/iterator/discard_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/discard_iterator.hpp
@@ -230,9 +230,9 @@ make_discard_iterator(size_t index = 0)
     return discard_iterator(index);
 }
 
+END_ROCPRIM_NAMESPACE
+
 /// @}
 // end of group iteratormodule
-
-END_ROCPRIM_NAMESPACE
 
 #endif // ROCPRIM_ITERATOR_DISCARD_ITERATOR_HPP_

--- a/rocprim/include/rocprim/iterator/discard_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/discard_iterator.hpp
@@ -43,6 +43,7 @@ BEGIN_ROCPRIM_NAMESPACE
 class discard_iterator
 {
 public:
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // Skip internal implementation details.
     struct discard_value
     {
         ROCPRIM_HOST_DEVICE inline
@@ -62,6 +63,7 @@ public:
             return *this;
         }
     };
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
     /// The type of the value that can be obtained by dereferencing the iterator.
     using value_type = discard_value;
@@ -86,7 +88,7 @@ public:
     ROCPRIM_HOST_DEVICE inline
     ~discard_iterator() = default;
 
-    //! \skip_doxy_start
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     ROCPRIM_HOST_DEVICE inline
     discard_iterator& operator++()
     {
@@ -204,12 +206,13 @@ public:
     {
         return os;
     }
-    //! \skip_doxy_end
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 private:
     mutable size_t index_;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 ROCPRIM_HOST_DEVICE inline
 discard_iterator
 operator+(typename discard_iterator::difference_type distance,
@@ -217,6 +220,7 @@ operator+(typename discard_iterator::difference_type distance,
 {
     return iterator + distance;
 }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// make_discard_iterator creates a discard_iterator using optional
 /// index parameter \p index.

--- a/rocprim/include/rocprim/iterator/reverse_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/reverse_iterator.hpp
@@ -66,7 +66,7 @@ public:
     ROCPRIM_HOST_DEVICE
     reverse_iterator(SourceIterator source_iterator) : source_iterator_(source_iterator) {}
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS
     ROCPRIM_HOST_DEVICE
     reverse_iterator& operator++()
     {

--- a/rocprim/include/rocprim/iterator/reverse_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/reverse_iterator.hpp
@@ -62,10 +62,11 @@ public:
     /// The category of the iterator.
     using iterator_category = std::random_access_iterator_tag;
 
+    /// \brief Constructs a new reverse_iterator using the supplied source.
     ROCPRIM_HOST_DEVICE
     reverse_iterator(SourceIterator source_iterator) : source_iterator_(source_iterator) {}
 
-    //! \skip_doxy_start
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     ROCPRIM_HOST_DEVICE
     reverse_iterator& operator++()
     {
@@ -176,12 +177,13 @@ public:
     {
         return other.source_iterator_ >= source_iterator_;
     }
-    //! \skip_doxy_end
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 private:
     SourceIterator source_iterator_;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<class SourceIterator>
 ROCPRIM_HOST_DEVICE reverse_iterator<SourceIterator>
                     operator+(typename reverse_iterator<SourceIterator>::difference_type distance,
@@ -189,6 +191,7 @@ ROCPRIM_HOST_DEVICE reverse_iterator<SourceIterator>
 {
     return iterator + distance;
 }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// make_reverse_iterator creates a \p reverse_iterator wrapping \p source_iterator.
 ///

--- a/rocprim/include/rocprim/iterator/reverse_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/reverse_iterator.hpp
@@ -203,9 +203,9 @@ ROCPRIM_HOST_DEVICE reverse_iterator<SourceIterator>
     return reverse_iterator<SourceIterator>(source_iterator);
 }
 
+END_ROCPRIM_NAMESPACE
+
 /// @}
 // end of group iteratormodule
-
-END_ROCPRIM_NAMESPACE
 
 #endif // ROCPRIM_ITERATOR_REVERSE_ITERATOR_HPP_

--- a/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -360,8 +360,6 @@ operator+(typename texture_cache_iterator<T, Difference>::difference_type distan
 
 END_ROCPRIM_NAMESPACE
 
-END_ROCPRIM_NAMESPACE
-
 /// @}
 // end of group iteratormodule
 

--- a/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -347,9 +347,9 @@ operator+(typename texture_cache_iterator<T, Difference>::difference_type distan
     return iterator + distance;
 }
 
+END_ROCPRIM_NAMESPACE
+
 /// @}
 // end of group iteratormodule
-
-END_ROCPRIM_NAMESPACE
 
 #endif // ROCPRIM_ITERATOR_TEXTURE_CACHE_ITERATOR_HPP_

--- a/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -157,6 +157,14 @@ public:
     {
     }
 
+    /// \brief Creates a \p hipTextureObject_t and binds this iterator to it.
+    ///
+    /// \tparam Texture data pointer type
+    ///
+    /// \param ptr - pointer to the texture data on the device
+    /// \param bytes - size of the texture data (in bytes)
+    /// \param texture_offset - an offset from ptr to load texture data from
+    /// (Defaults to 0)
     template<class Qualified>
     inline
     hipError_t bind_texture(Qualified* ptr,
@@ -180,13 +188,14 @@ public:
         return hipCreateTextureObject(&texture_object, &resourse_desc, &texture_desc, NULL);
     }
 
+    /// \brief Destroys the texture object that this iterator points at.
     inline
     hipError_t unbind_texture()
     {
         return hipDestroyTextureObject(texture_object);
     }
 
-    //! \skip_doxy_start
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     ROCPRIM_HOST_DEVICE inline
     texture_cache_iterator& operator++()
     {
@@ -325,7 +334,7 @@ public:
     {
         return os;
     }
-    //! \skip_doxy_end
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 private:
     using texture_type = typename ::rocprim::detail::match_texture_type<T>::type;
@@ -335,6 +344,7 @@ private:
     hipTextureObject_t texture_object;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<
     class T,
     class Difference
@@ -346,6 +356,9 @@ operator+(typename texture_cache_iterator<T, Difference>::difference_type distan
 {
     return iterator + distance;
 }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+END_ROCPRIM_NAMESPACE
 
 END_ROCPRIM_NAMESPACE
 

--- a/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -195,7 +195,7 @@ public:
         return hipDestroyTextureObject(texture_object);
     }
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS
     ROCPRIM_HOST_DEVICE inline
     texture_cache_iterator& operator++()
     {

--- a/rocprim/include/rocprim/iterator/transform_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/transform_iterator.hpp
@@ -91,7 +91,7 @@ public:
     {
     }
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS
     ROCPRIM_HOST_DEVICE inline
     transform_iterator& operator++()
     {

--- a/rocprim/include/rocprim/iterator/transform_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/transform_iterator.hpp
@@ -91,7 +91,7 @@ public:
     {
     }
 
-    //! \skip_doxy_start
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
     ROCPRIM_HOST_DEVICE inline
     transform_iterator& operator++()
     {
@@ -213,13 +213,14 @@ public:
     {
         return os;
     }
-    //! \skip_doxy_end
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 private:
     InputIterator iterator_;
     UnaryFunction transform_;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<
     class InputIterator,
     class UnaryFunction,
@@ -232,6 +233,7 @@ operator+(typename transform_iterator<InputIterator, UnaryFunction, ValueType>::
 {
     return iterator + distance;
 }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// make_transform_iterator creates a transform_iterator using \p iterator as
 /// the underlying iterator and \p transform as the unary function.

--- a/rocprim/include/rocprim/iterator/transform_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/transform_iterator.hpp
@@ -254,9 +254,9 @@ make_transform_iterator(InputIterator iterator, UnaryFunction transform)
     return transform_iterator<InputIterator, UnaryFunction>(iterator, transform);
 }
 
+END_ROCPRIM_NAMESPACE
+
 /// @}
 // end of group iteratormodule
-
-END_ROCPRIM_NAMESPACE
 
 #endif // ROCPRIM_ITERATOR_TRANSFORM_ITERATOR_HPP_

--- a/rocprim/include/rocprim/iterator/zip_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/zip_iterator.hpp
@@ -317,9 +317,9 @@ make_zip_iterator(IteratorTuple iterator_tuple)
     return zip_iterator<IteratorTuple>(iterator_tuple);
 }
 
+END_ROCPRIM_NAMESPACE
+
 /// @}
 // end of group iteratormodule
-
-END_ROCPRIM_NAMESPACE
 
 #endif // ROCPRIM_ITERATOR_ZIP_ITERATOR_HPP_

--- a/rocprim/include/rocprim/iterator/zip_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/zip_iterator.hpp
@@ -158,7 +158,7 @@ public:
     {
     }
 
-    //! \skip_doxy_start
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS
     ROCPRIM_HOST_DEVICE inline
     zip_iterator& operator++()
     {
@@ -287,12 +287,13 @@ public:
     {
         return os;
     }
-    //! \skip_doxy_end
+    #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 private:
     IteratorTuple iterator_tuple_;
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<class IteratorTuple>
 ROCPRIM_HOST_DEVICE inline
 zip_iterator<IteratorTuple>
@@ -301,6 +302,7 @@ operator+(typename zip_iterator<IteratorTuple>::difference_type distance,
 {
     return iterator + distance;
 }
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /// make_zip_iterator creates a zip_iterator using \p iterator_tuple as
 /// the underlying tuple of iterator.

--- a/rocprim/include/rocprim/rocprim.hpp
+++ b/rocprim/include/rocprim/rocprim.hpp
@@ -67,6 +67,7 @@
 #include "device/device_select.hpp"
 #include "device/device_transform.hpp"
 
+/// \brief The top level rocPRIM namespace.
 BEGIN_ROCPRIM_NAMESPACE
 
 /// \brief Returns version of rocPRIM library.

--- a/rocprim/include/rocprim/thread/thread_load.hpp
+++ b/rocprim/include/rocprim/thread/thread_load.hpp
@@ -34,6 +34,7 @@
 
 BEGIN_ROCPRIM_NAMESPACE
 
+/// \brief These enum values are used to specify caching behaviour on load
 enum cache_load_modifier : int
 {
     load_default,   ///< Default (no modifier)

--- a/rocprim/include/rocprim/thread/thread_operators.hpp
+++ b/rocprim/include/rocprim/thread/thread_operators.hpp
@@ -36,8 +36,10 @@
 
 BEGIN_ROCPRIM_NAMESPACE
 
+/// \brief Functor that tests for equality.
 struct equality
 {
+    /// \brief Invocation operator
     template<class T>
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
@@ -46,8 +48,10 @@ struct equality
     }
 };
 
+/// \brief Functor that tests for inequality.
 struct inequality
 {
+    /// \brief Invocation operator
     template<class T>
     ROCPRIM_HOST_DEVICE inline
     constexpr bool operator()(const T& a, const T& b) const
@@ -56,14 +60,21 @@ struct inequality
     }
 };
 
+/// \brief Functor that tests for inequality using a user-supplied equality comparator.
 template <class EqualityOp>
 struct inequality_wrapper
 {
-    EqualityOp op;
+    EqualityOp op; ///< A binary equality comparator (see constructor for details).
 
+    /// \brief Constructs the wrapper using the provided equality comparator.
+    /// \param op - a binary equality comparator.
+    /// The signature of the function should be equivalent to the following:
+    /// <tt>T f(const T &a, const T &b);</tt>. The signature does not need to have
+    /// <tt>const &</tt>, but function object must not modify the objects passed to it.
     ROCPRIM_HOST_DEVICE inline
     inequality_wrapper(EqualityOp op) : op(op) {}
 
+    /// \brief Invocation operator
     template<class T>
     ROCPRIM_HOST_DEVICE inline
     bool operator()(const T &a, const T &b)
@@ -72,8 +83,10 @@ struct inequality_wrapper
     }
 };
 
+/// \brief Functor that returns the sum of its arguments.
 struct sum
 {
+    /// \brief Invocation operator
     template<class T>
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T &a, const T &b) const
@@ -82,8 +95,10 @@ struct sum
     }
 };
 
+/// \brief Functor that returns the maximum of its arguments.
 struct max
 {
+    /// \brief Invocation operator
     template<class T>
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T &a, const T &b) const
@@ -92,8 +107,10 @@ struct max
     }
 };
 
+/// \brief Functor that returns the minimum of its arguments.
 struct min
 {
+    /// \brief Invocation operator
     template<class T>
     ROCPRIM_HOST_DEVICE inline
     constexpr T operator()(const T &a, const T &b) const
@@ -102,8 +119,14 @@ struct min
     }
 };
 
+/// \brief Functor that returns the "arg max" of the given key-value pairs.
+///
+/// The "arg max" of a key-value pair is defined as:
+/// - b: if b's value is larger, or if the values are equal but b's key is smaller.
+/// - a: otherwise
 struct arg_max
 {
+    /// \brief Invocation operator
     template<
         class Key,
         class Value
@@ -117,8 +140,14 @@ struct arg_max
     }
 };
 
+/// \brief Functor that returns the "arg min" of the given key-value pairs.
+///
+/// The "arg min" of a key-value pair is defined as:
+/// - b: if b's value is smaller, or if the values are equal but b's key is smaller.
+/// - a: otherwise
 struct arg_min
 {
+    /// \brief Invocation operator (see struct description for details)
     template<
         class Key,
         class Value

--- a/rocprim/include/rocprim/thread/thread_scan.hpp
+++ b/rocprim/include/rocprim/thread/thread_scan.hpp
@@ -62,8 +62,8 @@ BEGIN_ROCPRIM_NAMESPACE
      typename    ScanOp>
  ROCPRIM_DEVICE ROCPRIM_INLINE
  T thread_scan_exclusive(
-     T                   inclusive,
-     T                   exclusive,
+     T                   inclusive,              ///< [in] Initial value for inclusive aggregate
+     T                   exclusive,              ///< [in] Initial value for exclusive aggregate
      T                   *input,                 ///< [in] Input array
      T                   *output,                ///< [out] Output array (may be aliased to \p input)
      ScanOp              scan_op,                ///< [in] Binary scan operator
@@ -79,7 +79,6 @@ BEGIN_ROCPRIM_NAMESPACE
 
      return inclusive;
  }
-
 
 
  /// \brief Perform a sequential exclusive prefix scan over \p LENGTH elements of the \p input array.  The aggregate is returned.
@@ -155,7 +154,7 @@ BEGIN_ROCPRIM_NAMESPACE
      typename    ScanOp>
  ROCPRIM_DEVICE ROCPRIM_INLINE
  T thread_scan_inclusive(
-     T                   inclusive,
+     T                   inclusive,              ///< [in] Initial value for inclusive aggregate
      T                   *input,                 ///< [in] Input array
      T                   *output,                ///< [out] Output array (may be aliased to \p input)
      ScanOp              scan_op,                ///< [in] Binary scan operator

--- a/rocprim/include/rocprim/thread/thread_store.hpp
+++ b/rocprim/include/rocprim/thread/thread_store.hpp
@@ -35,6 +35,7 @@
 
 BEGIN_ROCPRIM_NAMESPACE
 
+/// \brief These enum values are used to specify caching behaviour on store
 enum cache_store_modifier
 {
     store_default,   ///< Default (no modifier)

--- a/rocprim/include/rocprim/type_traits.hpp
+++ b/rocprim/include/rocprim/type_traits.hpp
@@ -104,12 +104,16 @@ struct is_compound
         !is_fundamental<T>::value
     > {};
 
+/// \brief Used to retrieve a type that can be treated as unsigned version of the template parameter.
+/// \tparam T - The signed type to find an unsigned equivalent for.
+/// \tparam size - the desired size (in bytes) of the unsigned type
 template<typename T, int size = 0>
 struct get_unsigned_bits_type
 {
-  typedef typename get_unsigned_bits_type<T,sizeof(T)>::unsigned_type unsigned_type;
+  typedef typename get_unsigned_bits_type<T,sizeof(T)>::unsigned_type unsigned_type; ///< Typedefed to the unsigned type.
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip specialized versions
 template<typename T>
 struct get_unsigned_bits_type<T,1>
 {
@@ -135,7 +139,9 @@ struct get_unsigned_bits_type<T,8>
 {
   typedef uint64_t unsigned_type;
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<typename T, typename UnsignedBits>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 auto TwiddleIn(UnsignedBits key)
@@ -189,6 +195,7 @@ auto TwiddleOut(UnsignedBits key)
     static const UnsignedBits   HIGH_BIT    = UnsignedBits(1) << ((sizeof(UnsignedBits) * 8) - 1);
     return key ^ HIGH_BIT;
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 
 END_ROCPRIM_NAMESPACE

--- a/rocprim/include/rocprim/type_traits.hpp
+++ b/rocprim/include/rocprim/type_traits.hpp
@@ -96,7 +96,7 @@ struct is_scalar
     > {};
 
 /// \brief Behaves like std::is_compound, but also supports half-precision
-/// floating point type (\ref rocprim::half). `value` for \ref rocprim::half is `false`.
+/// floating point type (\ref rocprim::half). `value` for rocprim::half is `false`.
 template<class T>
 struct is_compound
     : std::integral_constant<
@@ -129,7 +129,6 @@ struct get_unsigned_bits_type<T,4>
 {
   typedef uint32_t unsigned_type;
 };
-
 
 template<typename T>
 struct get_unsigned_bits_type<T,8>

--- a/rocprim/include/rocprim/types.hpp
+++ b/rocprim/include/rocprim/types.hpp
@@ -138,6 +138,7 @@ struct empty_type {};
 /// as nop replacement for the HIP-CPU back-end
 struct empty_binary_op
 {
+    /// \brief Invocation operator.
     constexpr empty_type operator()(const empty_type&, const empty_type&) const { return empty_type{}; }
 };
 
@@ -152,18 +153,25 @@ using bfloat16 = ::hip_bfloat16;
 // TODO: introduce a ROCPRIM-specific macro to query this
 #define __AMDGCN_WAVEFRONT_SIZE 64
 #endif
+/// \brief The lane_mask_type is an integer that contains one bit per thread.
+///
+/// The total number of bits is equal to the total number of threads in a
+/// warp. Used to for warp-level operations.
+/// \note This is defined only on the device side.
 #if __AMDGCN_WAVEFRONT_SIZE == 32
 using lane_mask_type = unsigned int;
 #elif __AMDGCN_WAVEFRONT_SIZE == 64
 using lane_mask_type = unsigned long long int;
 #endif
 
+/// \brief Native half-precision floating point type
 #ifdef __HIP_CPU_RT__
 using native_half = half;
 #else
 using native_half = _Float16;
 #endif
 
+/// \brief native bfloat16 type
 #ifdef __HIP_CPU_RT__
 // TODO: Find a better type
 using native_bfloat16 = bfloat16;

--- a/rocprim/include/rocprim/types/double_buffer.hpp
+++ b/rocprim/include/rocprim/types/double_buffer.hpp
@@ -28,6 +28,11 @@
 
 BEGIN_ROCPRIM_NAMESPACE
 
+/// \brief This class provides an convenient way to do double buffering
+///
+/// It tracks two versions of the buffer ("current" and "alternate"),
+/// which can be accessed with functions of the same name.
+/// You can also swap the buffers.
 template<class T>
 class double_buffer
 {
@@ -37,6 +42,8 @@ class double_buffer
 
 public:
 
+    /// \brief Constructs an empty double buffer object, initializing the 
+    /// buffer pointers to nullptr.
     ROCPRIM_HOST_DEVICE inline
     double_buffer()
     {
@@ -45,6 +52,10 @@ public:
         buffers[1] = nullptr;
     }
 
+    /// \brief Contructs a double buffer object using the supplied buffer pointers.
+    ///
+    /// \param current - Pointer to the buffer to designate as "current" (in use).
+    /// \param alternate - Pointer to the buffer to designate as "alternate" (not in use)
     ROCPRIM_HOST_DEVICE inline
     double_buffer(T * current, T * alternate)
     {
@@ -53,18 +64,21 @@ public:
         buffers[1] = alternate;
     }
 
+    /// \brief Returns a pointer to the current buffer.
     ROCPRIM_HOST_DEVICE inline
     T * current() const
     {
         return buffers[selector];
     }
 
+    /// \brief Returns a pointer to the alternate buffer.
     ROCPRIM_HOST_DEVICE inline
     T * alternate() const
     {
         return buffers[selector ^ 1];
     }
 
+    /// \brief Swaps the current and alternate buffers.
     ROCPRIM_HOST_DEVICE inline
     void swap()
     {

--- a/rocprim/include/rocprim/types/future_value.hpp
+++ b/rocprim/include/rocprim/types/future_value.hpp
@@ -55,19 +55,25 @@ template <typename T, typename Iter = T*>
 class future_value
 {
 public:
-    using value_type    = T;
-    using iterator_type = Iter;
+    using value_type    = T; ///< The type of the value this future will store.
+    using iterator_type = Iter; ///< An iterator type that can point at the \p value_type.
 
+    /// \brief Constructs a future value
+    /// \param iter - An iterator that will point to the value when it becomes available.
     explicit ROCPRIM_HOST_DEVICE future_value(const Iter iter)
         : iter_ {iter}
     {
     }
 
+    /// \brief Returns the value by dereferencing the iterator that the constructor was passed.
+    /// \note The value must be available at the point this is called.
     ROCPRIM_HOST_DEVICE operator T()
     {
         return *iter_;
     }
 
+    /// \brief Returns the value by dereferencing the iterator that the constructor was passed.
+    /// \note The value must be available at the point this is called.
     ROCPRIM_HOST_DEVICE operator T() const
     {
         return *iter_;

--- a/rocprim/include/rocprim/types/integer_sequence.hpp
+++ b/rocprim/include/rocprim/types/integer_sequence.hpp
@@ -49,6 +49,9 @@ class integer_sequence
     }
 };
 
+/// \brief Compile-time sequence of indices
+///
+/// This is a helper alias template built on top on \p integer_sequence .
 template<size_t... Ints>
 using index_sequence = integer_sequence<size_t, Ints...>;
 
@@ -79,12 +82,20 @@ struct make_integer_sequence_impl<T, 0>
 
 } // end detail namespace
 
+/// \brief Generates a compile time integer sequence.
+/// \tparam T - the integer type to use
+/// \tparam N - the number of values to generate
 template<class T, T N>
 using make_integer_sequence = typename detail::make_integer_sequence_impl<T, N>::type;
 
+/// \brief Generates a compile time index sequence using type size_t.
+/// \tparam N - the number of values to generate
 template<size_t N>
 using make_index_sequence = make_integer_sequence<size_t, N>;
 
+/// \brief Generates a compile time integer sequence whose length is equal
+/// to the length of the supplied template parameter pack.
+/// \tparam T - template parameter pack
 template<class... T>
 using index_sequence_for = make_index_sequence<sizeof...(T)>;
 #endif

--- a/rocprim/include/rocprim/types/key_value_pair.hpp
+++ b/rocprim/include/rocprim/types/key_value_pair.hpp
@@ -28,6 +28,7 @@
 
 BEGIN_ROCPRIM_NAMESPACE
 
+/// \brief Convenience struct that allows you to store key-value pairs as a composite entity.
 template<
     class Key_,
     class Value_
@@ -39,11 +40,11 @@ struct key_value_pair
     using Value = Value_;
     #endif
 
-    using key_type = Key_;
-    using value_type = Value_;
+    using key_type = Key_; ///< the key's type
+    using value_type = Value_; ///< the value's type
 
-    key_type key;
-    value_type value;
+    key_type key; ///< the stored key
+    value_type value; ///< the stored value
 
     ROCPRIM_HOST_DEVICE inline
     key_value_pair() = default;
@@ -51,11 +52,14 @@ struct key_value_pair
     ROCPRIM_HOST_DEVICE inline
     ~key_value_pair() = default;
 
+    /// \brief Constructs a key-value pair using the supplied values.
     ROCPRIM_HOST_DEVICE inline
     key_value_pair(const key_type key, const value_type value) : key(key), value(value)
     {
     }
 
+    /// \brief Returns true if the given key-value pair is not equal to this one.
+    /// Otherwise returns false.
     ROCPRIM_HOST_DEVICE inline
     bool operator !=(const key_value_pair& kvb)
     {

--- a/rocprim/include/rocprim/types/tuple.hpp
+++ b/rocprim/include/rocprim/types/tuple.hpp
@@ -589,7 +589,7 @@ public:
     }
 
     /// \brief Converting constructor. Initializes each element of the tuple
-    /// with the corresponding value in \p ::rocprim::detail::custom_forward<UTypes>(values).
+    /// with the corresponding value in \p rocprim::detail::custom_forward<UTypes>(values).
     ///
     /// This overload only participates in overload resolution if:
     /// * <tt>sizeof...(Types) == sizeof...(UTypes)</tt>,
@@ -704,7 +704,7 @@ public:
     /// \param other tuple to replace the contents of this tuple
     template<class... UTypes>
     tuple& operator=(const tuple<UTypes...>& other) noexcept;
-    /// \brief For all \p i, assigns \p ::rocprim::detail::custom_forward<Ui>(get<i>(other)) to \p rocprim::get<i>(*this).
+    /// \brief For all \p i, assigns \p rocprim::detail::custom_forward<Ui>(get<i>(other)) to \p rocprim::get<i>(*this).
     /// \param other tuple to replace the contents of this tuple
     template<class... UTypes>
     tuple& operator=(tuple<UTypes...>&& other) noexcept;

--- a/rocprim/include/rocprim/types/tuple.hpp
+++ b/rocprim/include/rocprim/types/tuple.hpp
@@ -153,6 +153,9 @@ struct tuple_element<I, const volatile T>
     using type = typename std::add_cv<typename tuple_element<I, T>::type>::type;
 };
 
+/// @brief \brief This is an alias used for convenience. It represents tuple_element<I, T>::type.
+/// @tparam T - type of the elements contained in the tuple
+/// @tparam I - size of the tuple (number of elements)
 template <size_t I, class T>
 using tuple_element_t = typename tuple_element<I, T>::type;
 

--- a/rocprim/include/rocprim/warp/warp_load.hpp
+++ b/rocprim/include/rocprim/warp/warp_load.hpp
@@ -86,10 +86,10 @@ enum class warp_load_method
 ///
 /// \par Overview
 /// * The \p warp_load class has a number of different methods to load data:
-///   * [warp_load_direct](\ref ::warp_load_method::warp_load_direct)
-///   * [warp_load_striped](\ref ::warp_load_method::warp_load_striped)
-///   * [warp_load_vectorize](\ref ::warp_load_method::warp_load_vectorize)
-///   * [warp_load_transpose](\ref ::warp_load_method::warp_load_transpose)
+///   * [warp_load_direct](\ref warp_load_method::warp_load_direct)
+///   * [warp_load_striped](\ref warp_load_method::warp_load_striped)
+///   * [warp_load_vectorize](\ref warp_load_method::warp_load_vectorize)
+///   * [warp_load_transpose](\ref warp_load_method::warp_load_transpose)
 ///
 /// \par Example:
 /// \parblock
@@ -152,7 +152,7 @@ public:
     ///
     /// \param [in] input - the input iterator to load from.
     /// \param [out] items - array that data is loaded to.
-    /// \param [in] storage - temporary storage for inputs.
+    /// \param [in] - temporary storage for inputs.
     ///
     /// \par Overview
     /// * The type \p T must be such that an object of type \p InputIterator
@@ -180,7 +180,7 @@ public:
     /// \param [in] input - the input iterator to load from.
     /// \param [out] items - array that data is loaded to.
     /// \param [in] valid - maximum range of valid numbers to load.
-    /// \param [in] storage - temporary storage for inputs.
+    /// \param [in] - temporary storage for inputs.
     ///
     /// \par Overview
     /// * The type \p T must be such that an object of type \p InputIterator
@@ -210,7 +210,7 @@ public:
     /// \param [out] items - array that data is loaded to.
     /// \param [in] valid - maximum range of valid numbers to load.
     /// \param [in] out_of_bounds - default value assigned to out-of-bound items.
-    /// \param [in] storage - temporary storage for inputs.
+    /// \param [in] - temporary storage for inputs.
     ///
     /// \par Overview
     /// * The type \p T must be such that an object of type \p InputIterator
@@ -235,9 +235,6 @@ public:
                                   out_of_bounds);
     }
 };
-
-/// @}
-// end of group warpmodule
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -454,5 +451,8 @@ public:
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 END_ROCPRIM_NAMESPACE
+
+/// @}
+// end of group warpmodule
 
 #endif // ROCPRIM_WARP_WARP_LOAD_HPP_

--- a/rocprim/include/rocprim/warp/warp_store.hpp
+++ b/rocprim/include/rocprim/warp/warp_store.hpp
@@ -152,9 +152,8 @@ public:
     /// \tparam OutputIterator - [inferred] an iterator type for output (can be a simple
     /// pointer.
     ///
-    /// \param [out] block_output - the output iterator to store to.
+    /// \param [out] output - the output iterator to store to.
     /// \param [in] items - array that data is read from.
-    /// \param [in] storage - temporary storage for outputs.
     ///
     /// \par Overview
     /// * The type \p T must be such that an object of type \p OutputIterator
@@ -184,10 +183,9 @@ public:
     /// \tparam OutputIterator - [inferred] an iterator type for output (can be a simple
     /// pointer.
     ///
-    /// \param [out] block_output - the output iterator to store to.
+    /// \param [out] output - the output iterator to store to.
     /// \param [in] items - array that data is read from.
     /// \param [in] valid - maximum range of valid numbers to read.
-    /// \param [in] storage - temporary storage for outputs.
     ///
     /// \par Overview
     /// * The type \p T must be such that an object of type \p OutputIterator
@@ -211,9 +209,6 @@ public:
         block_store_direct_blocked(flat_id, output, items, valid);
     }
 };
-
-/// @}
-// end of group warpmodule
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -369,5 +364,8 @@ public:
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 END_ROCPRIM_NAMESPACE
+
+/// @}
+// end of group warpmodule
 
 #endif // ROCPRIM_WARP_WARP_STORE_HPP_


### PR DESCRIPTION
Treat Doxygen warnings as errors
* Turned on WARN_AS_ERROR in the Doxyfile
* Added missing documentation for some items (since it now generates errors)
* Fixed scenarios generating warnings when the documentation is built:
  - Corrected outdated \ref references
  - Moved group start/end braces to fix balancing errors
  - Sometimes we implement multiple overloaded versions of a function/struct, and enable only one of them at compile
     time using std::enable_if. Doxygen can't always see this, and issues warnings about inconsistent function/struct
     definitions. Worked around this using "#ifndef DOXYGEN_SHOULD_SKIP_THIS".
  - Corrected missing/extra parameter documentation