### PR TITLE
Fix cpp-check reported issues

### DIFF
--- a/benchmark/benchmark_block_sort.parallel.hpp
+++ b/benchmark/benchmark_block_sort.parallel.hpp
@@ -187,11 +187,11 @@ public:
     static constexpr unsigned int warmup_size       = 5;
     static constexpr bool         debug_synchronous = false;
 
-    auto dispatch_block_sort(std::false_type /*stable_sort*/,
+    static auto dispatch_block_sort(std::false_type /*stable_sort*/,
                              size_t            size,
                              const hipStream_t stream,
                              KeyType*          d_input,
-                             KeyType*          d_output) const
+                             KeyType*          d_output)
     {
         hipLaunchKernelGGL(
             HIP_KERNEL_NAME(
@@ -204,11 +204,11 @@ public:
             d_output);
     }
 
-    auto dispatch_block_sort(std::true_type /*stable_sort*/,
+    static auto dispatch_block_sort(std::true_type /*stable_sort*/,
                              size_t            size,
                              const hipStream_t stream,
                              KeyType*          d_input,
-                             KeyType*          d_output) const
+                             KeyType*          d_output)
     {
         hipLaunchKernelGGL(HIP_KERNEL_NAME(stable_sort_kernel<KeyType,
                                                               ValueType,

--- a/benchmark/benchmark_device_memory.cpp
+++ b/benchmark/benchmark_device_memory.cpp
@@ -419,26 +419,14 @@ void run_benchmark_memcpy(benchmark::State& state,
                            size_t size,
                            const hipStream_t stream)
 {
-    std::vector<T> input;
-    if(std::is_floating_point<T>::value)
-    {
-        input = get_random_data<T>(size, (T)-1000, (T)+1000);
-    }
-    else
-    {
-        input = get_random_data<T>(
-            size,
-            std::numeric_limits<T>::min(),
-            std::numeric_limits<T>::max()
-        );
-    }
+    // Allocate device buffers
+    // Note: since this benchmark only tests memcpy performance between device buffers,
+    // we don't really need to copy data into these from the host - whatever happens
+    // to be in memory will suffice.
     T * d_input;
     T * d_output;
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_input), size * sizeof(T)));
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_output), size * sizeof(T)));
-
-    // Copy input from host to device
-    HIP_CHECK(hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
 
     // Warm-up
     for(size_t i = 0; i < 10; i++)

--- a/benchmark/benchmark_device_memory.cpp
+++ b/benchmark/benchmark_device_memory.cpp
@@ -420,9 +420,9 @@ void run_benchmark_memcpy(benchmark::State& state,
                            const hipStream_t stream)
 {
     // Allocate device buffers
-    // Note: since this benchmark only tests memcpy performance between device buffers,
-    // we don't really need to copy data into these from the host - whatever happens
-    // to be in memory will suffice.
+    // Note: since this benchmark only tests performance by memcpying between device buffers,
+    // we don't really need to transfer data into these from the host - whatever happens
+    // to be in device memory will do.
     T * d_input;
     T * d_output;
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_input), size * sizeof(T)));

--- a/benchmark/benchmark_device_memory.cpp
+++ b/benchmark/benchmark_device_memory.cpp
@@ -65,7 +65,7 @@ template<class T, unsigned int ItemsPerThread, unsigned int BlockSize>
 struct operation<no_operation, T, ItemsPerThread, BlockSize>
 {
     ROCPRIM_HOST_DEVICE inline
-    void operator()(T (&)[ItemsPerThread], void* = nullptr, unsigned int = 0, T* = nullptr)
+    void operator()(T (&)[ItemsPerThread], void* = nullptr, unsigned int = 0, T* = nullptr) const
     {
         // No operation
     }
@@ -80,7 +80,7 @@ struct operation<custom_operation, T, ItemsPerThread, BlockSize>
     ROCPRIM_HOST_DEVICE inline
     void operator()(T (&input)[ItemsPerThread],
                     void* shared_storage = nullptr, unsigned int shared_storage_size = 0,
-                    T* global_mem_output = nullptr)
+                    T* global_mem_output = nullptr) const
     {
         (void) shared_storage;
         (void) shared_storage_size;
@@ -105,7 +105,7 @@ struct operation<block_scan, T, ItemsPerThread, BlockSize>
     ROCPRIM_HOST_DEVICE inline
     void operator()(T (&input)[ItemsPerThread],
                     void* shared_storage = nullptr, unsigned int shared_storage_size = 0,
-                    T* global_mem_output = nullptr)
+                    T* global_mem_output = nullptr) const
     {
         (void) global_mem_output;
         using block_scan_type = typename rocprim::block_scan<
@@ -436,6 +436,10 @@ void run_benchmark_memcpy(benchmark::State& state,
     T * d_output;
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_input), size * sizeof(T)));
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_output), size * sizeof(T)));
+
+    // Copy input from host to device
+    HIP_CHECK(hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
+
     // Warm-up
     for(size_t i = 0; i < 10; i++)
     {

--- a/benchmark/benchmark_device_memory.cpp
+++ b/benchmark/benchmark_device_memory.cpp
@@ -427,7 +427,6 @@ void run_benchmark_memcpy(benchmark::State& state,
     T * d_output;
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_input), size * sizeof(T)));
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_output), size * sizeof(T)));
-
     // Warm-up
     for(size_t i = 0; i < 10; i++)
     {

--- a/benchmark/benchmark_device_radix_sort_onesweep.parallel.hpp
+++ b/benchmark/benchmark_device_radix_sort_onesweep.parallel.hpp
@@ -49,6 +49,8 @@ constexpr const char* radix_rank_algorithm_name(rp::block_radix_rank_algorithm a
             return "block_radix_rank_algorithm::basic_memoize";
         case rp::block_radix_rank_algorithm::match: return "block_radix_rank_algorithm::match";
     }
+
+    return ""; // unknown algorithm
 }
 
 template<typename Config>
@@ -403,7 +405,7 @@ struct device_radix_sort_onesweep_benchmark_generator
                       RadixRankAlgorithm,
                       std::enable_if_t<(!is_buildable<ItemsPerThread, RadixRankAlgorithm>())>>
     {
-        void operator()(std::vector<std::unique_ptr<config_autotune_interface>>&) {}
+        void operator()(std::vector<std::unique_ptr<config_autotune_interface>>&) const {}
     };
 
     template<rocprim::block_radix_rank_algorithm RadixRankAlgorithm>

--- a/benchmark/benchmark_device_select.cpp
+++ b/benchmark/benchmark_device_select.cpp
@@ -51,7 +51,6 @@ void run_flagged_benchmark(benchmark::State& state,
 {
     std::vector<T> input;
     std::vector<FlagType> flags = get_random_data01<FlagType>(size, true_probability);
-    std::vector<unsigned int> selected_count_output(1);
     if(std::is_floating_point<T>::value)
     {
         input = get_random_data<T>(size, T(-1000), T(1000));
@@ -181,7 +180,6 @@ void run_selectop_benchmark(benchmark::State& state,
                             float true_probability)
 {
     std::vector<T> input = get_random_data<T>(size, T(0), T(1000));
-    std::vector<unsigned int> selected_count_output(1);
 
     auto select_op = [true_probability] __device__ (const T& value) -> bool
     {
@@ -308,7 +306,6 @@ void run_unique_benchmark(benchmark::State& state,
             input[i] = op(acc, input01[i]);
         }
     }
-    std::vector<unsigned int> selected_count_output(1);
     auto equality_op = rocprim::equal_to<T>();
 
     T * d_input;

--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -428,7 +428,7 @@ public:
         static format storage = human;
         return storage;
     }
-    static void set_format(std::string argument)
+    static void set_format(const std::string& argument)
     {
         format result = human;
         if(argument == "json")

--- a/benchmark/benchmark_warp_exchange.cpp
+++ b/benchmark/benchmark_warp_exchange.cpp
@@ -52,7 +52,7 @@ struct BlockedToStripedOp
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void operator()(warp_exchange_type warp_exchange,
                     T (&items)[ItemsPerThread],
-                    typename warp_exchange_type::storage_type& storage)
+                    typename warp_exchange_type::storage_type& storage) const
     {
         warp_exchange.blocked_to_striped(items, items, storage);
     }
@@ -68,7 +68,7 @@ struct StripedToBlockedOp
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void operator()(warp_exchange_type warp_exchange,
                     T (&items)[ItemsPerThread],
-                    typename warp_exchange_type::storage_type& storage)
+                    typename warp_exchange_type::storage_type& storage) const
     {
         warp_exchange.striped_to_blocked(items, items, storage);
     }
@@ -84,7 +84,7 @@ struct BlockedToStripedShuffleOp
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void operator()(warp_exchange_type warp_exchange,
                     T (&items)[ItemsPerThread],
-                    typename warp_exchange_type::storage_type& /*storage*/)
+                    typename warp_exchange_type::storage_type& /*storage*/) const
     {
         warp_exchange.blocked_to_striped_shuffle(items, items);
     }
@@ -100,7 +100,7 @@ struct StripedToBlockedShuffleOp
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void operator()(warp_exchange_type warp_exchange,
                     T (&items)[ItemsPerThread],
-                    typename warp_exchange_type::storage_type& /*storage*/)
+                    typename warp_exchange_type::storage_type& /*storage*/) const
     {
         warp_exchange.striped_to_blocked_shuffle(items, items);
     }
@@ -118,7 +118,7 @@ struct ScatterToStripedOp
     void operator()(warp_exchange_type warp_exchange,
                     T (&thread_data)[ItemsPerThread],
                     const OffsetT (&ranks)[ItemsPerThread],
-                    typename warp_exchange_type::storage_type& storage)
+                    typename warp_exchange_type::storage_type& storage) const
     {
         warp_exchange.scatter_to_striped(thread_data, thread_data, ranks, storage);
     }

--- a/benchmark/cmdparser.hpp
+++ b/benchmark/cmdparser.hpp
@@ -96,7 +96,7 @@ namespace cli {
                 CmdBase(name, alternative, description, required, dominant, ArgumentCountChecker<T>::Variadic) {
             }
 
-            virtual bool parse(std::ostream& output, std::ostream& error) {
+            virtual bool parse(std::ostream& output, std::ostream& error) override {
                 try {
                     CallbackArgs args { arguments, output, error };
                     value = callback(args);
@@ -106,7 +106,7 @@ namespace cli {
                 }
             }
 
-            virtual std::string print_value() const {
+            virtual std::string print_value() const override {
                 return "";
             }
 
@@ -118,10 +118,10 @@ namespace cli {
         class CmdArgument final : public CmdBase {
         public:
             explicit CmdArgument(const std::string& name, const std::string& alternative, const std::string& description, bool required, bool dominant) :
-                CmdBase(name, alternative, description, required, dominant, ArgumentCountChecker<T>::Variadic) {
+                CmdBase(name, alternative, description, required, dominant, ArgumentCountChecker<T>::Variadic), value(T()) {
             }
 
-            virtual bool parse(std::ostream&, std::ostream&) {
+            virtual bool parse(std::ostream&, std::ostream&) override {
                 try {
                     value = Parser::parse(arguments, value);
                     return true;
@@ -130,7 +130,7 @@ namespace cli {
                 }
             }
 
-            virtual std::string print_value() const {
+            virtual std::string print_value() const override {
                 return stringify(value);
             }
 
@@ -306,7 +306,7 @@ namespace cli {
         }
 
         template<typename T>
-        void set_optional(const std::string& name, const std::string& alternative, T defaultValue, const std::string& description = "", bool dominant = false) {
+        void set_optional(const std::string& name, const std::string& alternative, const T& defaultValue, const std::string& description = "", bool dominant = false) {
             auto command = new CmdArgument<T> { name, alternative, description, false, dominant };
             command->value = defaultValue;
             _commands.push_back(command);

--- a/test/hip/test_hip_async_copy.cpp
+++ b/test/hip/test_hip_async_copy.cpp
@@ -51,12 +51,12 @@ struct PinnedAllocator
         HIP_CHECK(hipHostFree(ptr));
     }
 
-    bool operator==(const PinnedAllocator&)
+    bool operator==(const PinnedAllocator&) const
     {
         return true;
     }
 
-    bool operator!=(const PinnedAllocator& other)
+    bool operator!=(const PinnedAllocator& other) const
     {
         return !(*this == other);
     }

--- a/test/rocprim/bounds_checking_iterator.hpp
+++ b/test/rocprim/bounds_checking_iterator.hpp
@@ -91,7 +91,7 @@ public:
     }
 
     ROCPRIM_HOST_DEVICE inline
-    reference operator[](difference_type n) const
+    reference operator[](const difference_type& n) const
     {
         if(((ptr_ + n) < start_ptr_) || ((ptr_ + n) >= start_ptr_ + size_))
         {
@@ -101,28 +101,28 @@ public:
     }
 
     ROCPRIM_HOST_DEVICE inline
-    bounds_checking_iterator operator+(difference_type distance) const
+    bounds_checking_iterator operator+(const difference_type& distance) const
     {
         auto i = ptr_ + distance;
         return bounds_checking_iterator(i, start_ptr_, out_of_bounds_flag_, size_);
     }
 
     ROCPRIM_HOST_DEVICE inline
-    bounds_checking_iterator& operator+=(difference_type distance)
+    bounds_checking_iterator& operator+=(const difference_type& distance)
     {
         ptr_ += distance;
         return *this;
     }
 
     ROCPRIM_HOST_DEVICE inline
-    bounds_checking_iterator operator-(difference_type distance) const
+    bounds_checking_iterator operator-(const difference_type& distance) const
     {
         auto i = ptr_ - distance;
         return bounds_checking_iterator(i, start_ptr_, out_of_bounds_flag_, size_);
     }
 
     ROCPRIM_HOST_DEVICE inline
-    bounds_checking_iterator& operator-=(difference_type distance)
+    bounds_checking_iterator& operator-=(const difference_type& distance)
     {
         ptr_ -= distance;
         return *this;

--- a/test/rocprim/identity_iterator.hpp
+++ b/test/rocprim/identity_iterator.hpp
@@ -83,34 +83,34 @@ public:
     }
 
     ROCPRIM_HOST_DEVICE inline
-    reference operator[](difference_type n) const
+    reference operator[](const difference_type& n) const
     {
         return *(ptr_ + n);
     }
 
     ROCPRIM_HOST_DEVICE inline
-    identity_iterator operator+(difference_type distance) const
+    identity_iterator operator+(const difference_type& distance) const
     {
         auto i = ptr_ + distance;
         return identity_iterator(i);
     }
 
     ROCPRIM_HOST_DEVICE inline
-    identity_iterator& operator+=(difference_type distance)
+    identity_iterator& operator+=(const difference_type& distance)
     {
         ptr_ += distance;
         return *this;
     }
 
     ROCPRIM_HOST_DEVICE inline
-    identity_iterator operator-(difference_type distance) const
+    identity_iterator operator-(const difference_type& distance) const
     {
         auto i = ptr_ - distance;
         return identity_iterator(i);
     }
 
     ROCPRIM_HOST_DEVICE inline
-    identity_iterator& operator-=(difference_type distance)
+    identity_iterator& operator-=(const difference_type& distance)
     {
         ptr_ -= distance;
         return *this;

--- a/test/rocprim/test_block_discontinuity.kernels.hpp
+++ b/test/rocprim/test_block_discontinuity.kernels.hpp
@@ -27,7 +27,7 @@ template<class T>
 struct custom_flag_op1
 {
     ROCPRIM_HOST_DEVICE
-    bool operator()(const T& a, const T& b, unsigned int b_index)
+    bool operator()(const T& a, const T& b, unsigned int b_index) const
     {
         return (a == b) || (b_index % 10 == 0);
     }

--- a/test/rocprim/test_block_reduce.kernels.hpp
+++ b/test/rocprim/test_block_reduce.kernels.hpp
@@ -145,7 +145,7 @@ struct static_run_valid
 {
     static void run(std::vector<T>& output,
                     std::vector<T>& output_reductions,
-                    std::vector<T>& expected_reductions,
+                    const std::vector<T>& expected_reductions,
                     T* device_output,
                     T* device_output_reductions,
                     const unsigned int valid_items,

--- a/test/rocprim/test_device_adjacent_difference.cpp
+++ b/test/rocprim/test_device_adjacent_difference.cpp
@@ -365,11 +365,11 @@ public:
         : current_index_(0), incorrect_flag_(incorrect_flag), counter_(counter)
     {}
 
-    __device__ bool operator==(const check_output_iterator& rhs)
+    __device__ bool operator==(const check_output_iterator& rhs) const
     {
         return current_index_ == rhs.current_index_;
     }
-    __device__ bool operator!=(const check_output_iterator& rhs)
+    __device__ bool operator!=(const check_output_iterator& rhs) const
     {
         return !(*this == rhs);
     }
@@ -377,7 +377,7 @@ public:
     {
         return reference(incorrect_flag_, current_index_, counter_);
     }
-    __device__ reference operator[](const difference_type distance)
+    __device__ reference operator[](const difference_type distance) const
     {
         return *(*this + distance);
     }

--- a/test/rocprim/test_device_partition.cpp
+++ b/test/rocprim/test_device_partition.cpp
@@ -739,11 +739,11 @@ public:
         : current_index_(0), modulo_(modulo), size_(size), incorrect_flag_(incorrect_flag)
     {}
 
-    ROCPRIM_HOST_DEVICE bool operator==(const check_modulo_iterator& rhs)
+    ROCPRIM_HOST_DEVICE bool operator==(const check_modulo_iterator& rhs) const
     {
         return current_index_ == rhs.current_index_;
     }
-    ROCPRIM_HOST_DEVICE bool operator!=(const check_modulo_iterator& rhs)
+    ROCPRIM_HOST_DEVICE bool operator!=(const check_modulo_iterator& rhs) const
     {
         return !(*this == rhs);
     }
@@ -751,16 +751,16 @@ public:
     {
         return value_type(current_index_, modulo_, size_, incorrect_flag_);
     }
-    ROCPRIM_HOST_DEVICE reference operator[](const difference_type distance) const
+    ROCPRIM_HOST_DEVICE reference operator[](const difference_type& distance) const
     {
         return *(*this + distance);
     }
-    ROCPRIM_HOST_DEVICE check_modulo_iterator& operator+=(const difference_type rhs)
+    ROCPRIM_HOST_DEVICE check_modulo_iterator& operator+=(const difference_type& rhs)
     {
         current_index_ += rhs;
         return *this;
     }
-    ROCPRIM_HOST_DEVICE check_modulo_iterator& operator-=(const difference_type rhs)
+    ROCPRIM_HOST_DEVICE check_modulo_iterator& operator-=(const difference_type& rhs)
     {
         current_index_ -= rhs;
         return *this;
@@ -769,11 +769,11 @@ public:
     {
         return current_index_ - rhs.current_index_;
     }
-    ROCPRIM_HOST_DEVICE check_modulo_iterator operator+(const difference_type rhs) const
+    ROCPRIM_HOST_DEVICE check_modulo_iterator operator+(const difference_type& rhs) const
     {
         return check_modulo_iterator(*this) += rhs;
     }
-    ROCPRIM_HOST_DEVICE check_modulo_iterator operator-(const difference_type rhs) const
+    ROCPRIM_HOST_DEVICE check_modulo_iterator operator-(const difference_type& rhs) const
     {
         return check_modulo_iterator(*this) -= rhs;
     }

--- a/test/rocprim/test_device_scan.cpp
+++ b/test/rocprim/test_device_scan.cpp
@@ -826,12 +826,12 @@ public:
     __host__ __device__ single_index_iterator& operator=(const single_index_iterator&) = default;
 
     // clang-format off
-    __host__ __device__ bool operator==(const single_index_iterator& rhs) { return index_ == rhs.index_; }
-    __host__ __device__ bool operator!=(const single_index_iterator& rhs) { return !(this == rhs);       }
+    __host__ __device__ bool operator==(const single_index_iterator& rhs) const { return index_ == rhs.index_; }
+    __host__ __device__ bool operator!=(const single_index_iterator& rhs) const { return !(this == rhs);       }
 
     __host__ __device__ reference operator*() { return value_type{value_, index_ == expected_index_}; }
 
-    __host__ __device__ reference operator[](const difference_type distance) { return *(*this + distance); }
+    __host__ __device__ reference operator[](const difference_type distance) const { return *(*this + distance); }
 
     __host__ __device__ single_index_iterator& operator+=(const difference_type rhs) { index_ += rhs; return *this; }
     __host__ __device__ single_index_iterator& operator-=(const difference_type rhs) { index_ -= rhs; return *this; }
@@ -1047,11 +1047,11 @@ public:
     ROCPRIM_HOST_DEVICE
     check_run_iterator(const args_t args) : current_index_(0), args_(args) {}
 
-    ROCPRIM_HOST_DEVICE bool operator==(const check_run_iterator& rhs)
+    ROCPRIM_HOST_DEVICE bool operator==(const check_run_iterator& rhs) const
     {
         return current_index_ == rhs.current_index_;
     }
-    ROCPRIM_HOST_DEVICE bool operator!=(const check_run_iterator& rhs)
+    ROCPRIM_HOST_DEVICE bool operator!=(const check_run_iterator& rhs) const
     {
         return !(*this == rhs);
     }
@@ -1059,7 +1059,7 @@ public:
     {
         return value_type{current_index_, args_};
     }
-    ROCPRIM_HOST_DEVICE reference operator[](const difference_type distance)
+    ROCPRIM_HOST_DEVICE reference operator[](const difference_type distance) const
     {
         return *(*this + distance);
     }

--- a/test/rocprim/test_intrinsics.cpp
+++ b/test/rocprim/test_intrinsics.cpp
@@ -445,14 +445,14 @@ TYPED_TEST(RocprimIntrinsicsTests, ShuffleIndex)
 
             // Calculate expected results on host
             std::vector<T> expected(size, test_type_helper<T>::zero());
-            for(size_t i = 0; i < input.size()/logical_warp_size; i++)
+            for(size_t j = 0; j < input.size()/logical_warp_size; j++)
             {
-                int src_lane = src_lanes[i];
-                for(size_t j = 0; j < logical_warp_size; j++)
+                int src_lane = src_lanes[j];
+                for(size_t k = 0; k < logical_warp_size; k++)
                 {
-                    size_t index = j + logical_warp_size * i;
+                    size_t index = k + logical_warp_size * j;
                     if(src_lane >= int(logical_warp_size) || src_lane < 0) src_lane = index;
-                    expected[index] = input[src_lane + logical_warp_size * i];
+                    expected[index] = input[src_lane + logical_warp_size * j];
                 }
             }
 
@@ -490,9 +490,9 @@ TYPED_TEST(RocprimIntrinsicsTests, ShuffleIndex)
                 )
             );
 
-            for(size_t i = 0; i < output.size(); i++)
+            for(size_t j = 0; j < output.size(); j++)
             {
-                ASSERT_EQ(output[i], expected[i]) << "where index = " << i;
+                ASSERT_EQ(output[j], expected[j]) << "where index = " << j;
             }
         }
         hipFree(device_data);
@@ -941,7 +941,7 @@ TYPED_TEST(RocprimIntrinsicsTests, WarpPermute)
 
 template<unsigned int LabelBits>
 __global__ void match_any_kernel(max_lane_mask_type* output,
-                                 unsigned int*       input,
+                                 const unsigned int*       input,
                                  max_lane_mask_type  active_lanes)
 {
     const unsigned int index = blockIdx.x * blockDim.x + threadIdx.x;
@@ -1052,7 +1052,7 @@ TEST(RocprimIntrinsicsTests, MatchAny)
 }
 
 __global__ void
-    ballot_kernel(max_lane_mask_type* output, unsigned int* input, max_lane_mask_type active_lanes)
+    ballot_kernel(max_lane_mask_type* output, const unsigned int* input, max_lane_mask_type active_lanes)
 {
     const unsigned int index = blockIdx.x * blockDim.x + threadIdx.x;
 

--- a/test/rocprim/test_utils_custom_test_types.hpp
+++ b/test/rocprim/test_utils_custom_test_types.hpp
@@ -64,10 +64,9 @@ struct custom_test_type
 
     template<class U>
     ROCPRIM_HOST_DEVICE inline
-        custom_test_type(const custom_test_type<U>& other)
+        custom_test_type(const custom_test_type<U>& other) :
+            x(static_cast<T>(other.x)), y(static_cast<T>(other.y))
     {
-        x = static_cast<T>(other.x);
-        y = static_cast<T>(other.y);
     }
 
     ROCPRIM_HOST_DEVICE inline

--- a/test/rocprim/test_utils_data_generation.hpp
+++ b/test/rocprim/test_utils_data_generation.hpp
@@ -337,7 +337,7 @@ inline auto get_random_data(size_t size, typename T::value_type min, typename T:
         data.begin(), data.end(),
         [&]()
         {
-            T result;
+            T result = 0;
             for(size_t i = 0; i < T::size; i++)
             {
                 result.values[i] = distribution(gen);

--- a/test/rocprim/test_utils_sort_comparator.hpp
+++ b/test/rocprim/test_utils_sort_comparator.hpp
@@ -109,7 +109,7 @@ struct key_comparator<Key,
 template<class Key, class Value, bool Descending, unsigned int StartBit, unsigned int EndBit>
 struct key_value_comparator
 {
-    bool operator()(const std::pair<Key, Value>& lhs, const std::pair<Key, Value>& rhs)
+    bool operator()(const std::pair<Key, Value>& lhs, const std::pair<Key, Value>& rhs) const
     {
         return key_comparator<Key, Descending, StartBit, EndBit>()(lhs.first, rhs.first);
     }

--- a/test/rocprim/test_warp_exchange.cpp
+++ b/test/rocprim/test_warp_exchange.cpp
@@ -56,7 +56,7 @@ struct BlockedToStripedOp
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void operator()(warp_exchange_type warp_exchange,
                     T (&thread_data)[ItemsPerThread],
-                    typename warp_exchange_type::storage_type& storage)
+                    typename warp_exchange_type::storage_type& storage) const
     {
         warp_exchange.blocked_to_striped(thread_data, thread_data, storage);
     }
@@ -72,7 +72,7 @@ struct BlockedToStripedShuffleOp
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void operator()(warp_exchange_type warp_exchange,
                     T (&thread_data)[ItemsPerThread],
-                    typename warp_exchange_type::storage_type& /*storage*/)
+                    typename warp_exchange_type::storage_type& /*storage*/) const
     {
         warp_exchange.blocked_to_striped_shuffle(thread_data, thread_data);
     }
@@ -88,7 +88,7 @@ struct StripedToBlockedOp
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void operator()(warp_exchange_type warp_exchange,
                     T (&thread_data)[ItemsPerThread],
-                    typename warp_exchange_type::storage_type& storage)
+                    typename warp_exchange_type::storage_type& storage) const
     {
         warp_exchange.striped_to_blocked(thread_data, thread_data, storage);
     }
@@ -104,7 +104,7 @@ struct StripedToBlockedShuffleOp
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void operator()(warp_exchange_type warp_exchange,
                     T (&thread_data)[ItemsPerThread],
-                    typename warp_exchange_type::storage_type& /*storage*/)
+                    typename warp_exchange_type::storage_type& /*storage*/) const
     {
         warp_exchange.striped_to_blocked_shuffle(thread_data, thread_data);
     }
@@ -122,7 +122,7 @@ struct ScatterToStripedOp
     void operator()(warp_exchange_type warp_exchange,
                     T (&thread_data)[ItemsPerThread],
                     OffsetT (&positions)[ItemsPerThread],
-                    typename warp_exchange_type::storage_type& storage)
+                    typename warp_exchange_type::storage_type& storage) const
     {
         warp_exchange.scatter_to_striped(thread_data, thread_data, positions, storage);
     }

--- a/test/rocprim/test_warp_reduce.hpp
+++ b/test/rocprim/test_warp_reduce.hpp
@@ -66,7 +66,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -185,7 +185,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -309,7 +309,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSumValid)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -430,7 +430,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSumValid)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -552,7 +552,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceCustomStruct)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -684,7 +684,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -839,7 +839,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, TailSegmentedReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }

--- a/test/rocprim/test_warp_scan.hpp
+++ b/test/rocprim/test_warp_scan.hpp
@@ -66,7 +66,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -188,7 +188,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -332,7 +332,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -457,7 +457,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -609,7 +609,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -767,7 +767,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -946,7 +946,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }

--- a/test/rocprim/test_warp_sort.hpp
+++ b/test/rocprim/test_warp_sort.hpp
@@ -54,7 +54,7 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, Sort)
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -152,7 +152,7 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, SortKeyInt)
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }


### PR DESCRIPTION
Fixed a number of issues that static the analysis tool picked up:
 - Made some functions const since they don't modify member state
 - Made some parameters const, since they're never modified
 - Made some functions static (for performance), since they don't require access to the class instance
 - Fixes for several benchmark/test functions:
    - Removed unused variable declarations
    - Added missing input data transfer from host to device 
    - Added default return value for one overlooked execution path 
    - Added some member variables to constructor initializer list 
    - Added override keyword in several places 
    - Fixed up item placeholders in some printf statements