### PR TITLE
Revert googlebenchmark changes

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -161,8 +161,10 @@ if(BUILD_BENCHMARK)
     FetchContent_Declare(
       googlebench
       GIT_REPOSITORY https://github.com/google/benchmark.git
-      GIT_TAG        v1.6.1
+      GIT_TAG        d17ea665515f0c54d100c6fc973632431379f64b # v1.6.1
     )
+    set(HAVE_STD_REGEX ON)
+    set(RUN_HAVE_STD_REGEX 1)
     FetchContent_MakeAvailable(googlebench)
     if(NOT TARGET benchmark::benchmark)
       add_library(benchmark::benchmark ALIAS benchmark)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -161,7 +161,7 @@ if(BUILD_BENCHMARK)
     FetchContent_Declare(
       googlebench
       GIT_REPOSITORY https://github.com/google/benchmark.git
-      GIT_TAG        d17ea665515f0c54d100c6fc973632431379f64b # v1.6.1
+      GIT_TAG        v1.8.0
     )
     set(HAVE_STD_REGEX ON)
     set(RUN_HAVE_STD_REGEX 1)


### PR DESCRIPTION
The google benchmark version was changed in #434 . However the version it was updated to is broken on Windows, and there doesn't seem to be much attention to the issue, so opening this to revert to the previously used version.