### PR TITLE
Lookback state fixes

### DIFF
--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -881,13 +881,13 @@ struct onesweep_lookback_state
 
     ROCPRIM_DEVICE ROCPRIM_INLINE static onesweep_lookback_state load(onesweep_lookback_state* ptr)
     {
-        underlying_type state = ::rocprim::detail::atomic_add(&ptr->state, 0);
+        underlying_type state = ::rocprim::detail::atomic_load(&ptr->state);
         return onesweep_lookback_state(state);
     }
 
     ROCPRIM_DEVICE ROCPRIM_INLINE void store(onesweep_lookback_state* ptr) const
     {
-        ::rocprim::detail::atomic_exch(&ptr->state, this->state);
+        ::rocprim::detail::atomic_store(&ptr->state, this->state);
     }
 };
 

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -361,7 +361,6 @@ public:
 
         // atomic_add(..., 0) is used to load values atomically
         flag = ::rocprim::detail::atomic_add(&prefixes_flags[padding + block_id], 0);
-        ::rocprim::detail::memory_fence_device();
         while(flag == PREFIX_EMPTY)
         {
             if (UseSleep)
@@ -377,8 +376,8 @@ public:
             }
 
             flag = ::rocprim::detail::atomic_add(&prefixes_flags[padding + block_id], 0);
-            ::rocprim::detail::memory_fence_device();
         }
+        ::rocprim::detail::memory_fence_device();
 
         if(flag == PREFIX_PARTIAL)
             value = prefixes_partial_values[padding + block_id];

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -126,6 +126,16 @@ public:
         return hipSuccess;
     }
 
+    [[deprecated(
+        "Please use the overload returns an error code, this function assumes the default"
+        " stream and silently ignores errors.")]] ROCPRIM_HOST static inline lookback_scan_state
+        create(void* temp_storage, const unsigned int number_of_blocks)
+    {
+        lookback_scan_state result;
+        (void)create(result, temp_storage, number_of_blocks, /*default stream*/ 0);
+        return result;
+    }
+
     ROCPRIM_HOST static inline hipError_t get_storage_size(const unsigned int number_of_blocks,
                                                            const hipStream_t  stream,
                                                            size_t&            storage_size)
@@ -138,6 +148,15 @@ public:
         return error;
     }
 
+    [[deprecated("Please use the overload returns an error code, this function assumes the default"
+                 " stream and silently ignores errors.")]] ROCPRIM_HOST static inline size_t
+        get_storage_size(const unsigned int number_of_blocks)
+    {
+        size_t result;
+        (void)get_storage_size(number_of_blocks, /*default stream*/ 0, result);
+        return result;
+    }
+
     ROCPRIM_HOST static inline hipError_t
         get_temp_storage_layout(const unsigned int            number_of_blocks,
                                 const hipStream_t             stream,
@@ -147,6 +166,16 @@ public:
         hipError_t error        = get_storage_size(number_of_blocks, stream, storage_size);
         layout = detail::temp_storage::layout{storage_size, alignof(prefix_underlying_type)};
         return error;
+    }
+
+    [[deprecated("Please use the overload returns an error code, this function assumes the default"
+                 " stream and silently ignores errors.")]] ROCPRIM_HOST static inline detail::
+        temp_storage::layout
+        get_temp_storage_layout(const unsigned int number_of_blocks)
+    {
+        detail::temp_storage::layout result;
+        (void)get_temp_storage_layout(number_of_blocks, /*default stream*/ 0, result);
+        return result;
     }
 
     ROCPRIM_DEVICE ROCPRIM_INLINE
@@ -306,6 +335,16 @@ public:
         return error;
     }
 
+    [[deprecated(
+        "Please use the overload returns an error code, this function assumes the default"
+        " stream and silently ignores errors.")]] ROCPRIM_HOST static inline lookback_scan_state
+        create(void* temp_storage, const unsigned int number_of_blocks)
+    {
+        lookback_scan_state result;
+        (void)create(result, temp_storage, number_of_blocks, /*default stream*/ 0);
+        return result;
+    }
+
     ROCPRIM_HOST static inline hipError_t get_storage_size(const unsigned int number_of_blocks,
                                                            const hipStream_t  stream,
                                                            size_t&            storage_size)
@@ -320,6 +359,15 @@ public:
         return error;
     }
 
+    [[deprecated("Please use the overload returns an error code, this function assumes the default"
+                 " stream and silently ignores errors.")]] ROCPRIM_HOST static inline size_t
+        get_storage_size(const unsigned int number_of_blocks)
+    {
+        size_t result;
+        (void)get_storage_size(number_of_blocks, /*default stream*/ 0, result);
+        return result;
+    }
+
     ROCPRIM_HOST static inline hipError_t
         get_temp_storage_layout(const unsigned int            number_of_blocks,
                                 const hipStream_t             stream,
@@ -330,6 +378,16 @@ public:
         hipError_t error        = get_storage_size(number_of_blocks, stream, storage_size);
         layout                  = detail::temp_storage::layout{storage_size, alignment};
         return error;
+    }
+
+    [[deprecated("Please use the overload returns an error code, this function assumes the default"
+                 " stream and silently ignores errors.")]] ROCPRIM_HOST static inline detail::
+        temp_storage::layout
+        get_temp_storage_layout(const unsigned int number_of_blocks)
+    {
+        detail::temp_storage::layout result;
+        (void)get_temp_storage_layout(number_of_blocks, /*default stream*/ 0, result);
+        return result;
     }
 
     ROCPRIM_DEVICE ROCPRIM_INLINE void initialize_prefix(const unsigned int block_id,

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -440,7 +440,7 @@ public:
             flag = ::rocprim::detail::atomic_load(&prefixes_flags[padding + block_id]);
         }
 #if ROCPRIM_DETAIL_LOOKBACK_SCAN_STATE_WITHOUT_SLOW_FENCES
-        __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");
+        rocprim::detail::atomic_fence_acquire_order_only();
 
         const auto* values = static_cast<const value_underlying_type*>(
             flag == PREFIX_PARTIAL ? prefixes_partial_values : prefixes_complete_values);

--- a/rocprim/include/rocprim/intrinsics/atomic.hpp
+++ b/rocprim/include/rocprim/intrinsics/atomic.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -73,6 +73,27 @@ namespace detail
     unsigned long long atomic_exch(unsigned long long * address, unsigned long long value)
     {
         return ::atomicExch(address, value);
+    }
+
+    ROCPRIM_DEVICE ROCPRIM_INLINE unsigned int atomic_load(const unsigned int* address)
+    {
+        return __hip_atomic_load(address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    }
+
+    ROCPRIM_DEVICE ROCPRIM_INLINE unsigned long long atomic_load(const unsigned long long* address)
+    {
+        return __hip_atomic_load(address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    }
+
+    ROCPRIM_DEVICE ROCPRIM_INLINE void atomic_store(unsigned int* address, unsigned int value)
+    {
+        __hip_atomic_store(address, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    }
+
+    ROCPRIM_DEVICE ROCPRIM_INLINE void atomic_store(unsigned long long* address,
+                                                    unsigned long long  value)
+    {
+        __hip_atomic_store(address, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
     }
 }
 

--- a/rocprim/include/rocprim/intrinsics/atomic.hpp
+++ b/rocprim/include/rocprim/intrinsics/atomic.hpp
@@ -113,6 +113,20 @@ namespace detail
         // Wait until all vmem operations complete (s_waitcnt vmcnt(0))
         __builtin_amdgcn_s_waitcnt(/*vmcnt*/ 0 | (/*exp_cnt*/ 0x7 << 4) | (/*lgkmcnt*/ 0xf << 8));
     }
+
+    /// \brief Make sure visible operations are complete
+    ///
+    /// Ensure that following visible reads are not reordered before preceding atomic operations
+    /// Similarly to atomic_fence_release_vmem_order_only() this function provides no visibility
+    /// guarantees, visiblity of reads must be guaranteed in other wise (like reading *through*
+    /// caches)
+    ///
+    /// This is a dangerous internal function not meant for users, and only meant to be used by
+    /// developers that know what they are doing.
+    ROCPRIM_DEVICE ROCPRIM_INLINE void atomic_fence_acquire_order_only()
+    {
+        __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "workgroup");
+    }
 }
 
 END_ROCPRIM_NAMESPACE

--- a/test/rocprim/test_device_adjacent_difference.cpp
+++ b/test/rocprim/test_device_adjacent_difference.cpp
@@ -360,7 +360,7 @@ private:
         {
             if(value != current_index_)
             {
-                rocprim::detail::atomic_exch(incorrect_flag_, 1);
+                rocprim::detail::atomic_store(incorrect_flag_, 1);
             }
             if(current_index_ % SamplingRate == 0)
             {

--- a/test/rocprim/test_device_partition.cpp
+++ b/test/rocprim/test_device_partition.cpp
@@ -961,7 +961,7 @@ public:
         const size_t expected_index = is_mod ? value / modulo_ : size_ - value + value / modulo_;
         if(current_index_ != expected_index)
         {
-            rocprim::detail::atomic_exch(incorrect_flag_, 1);
+            rocprim::detail::atomic_store(incorrect_flag_, 1);
         }
         return *this;
     }
@@ -990,7 +990,7 @@ public:
         const size_t expected_index = value / modulo_;
         if(!is_mod || current_index_ != expected_index)
         {
-            rocprim::detail::atomic_exch(incorrect_flag_, 1);
+            rocprim::detail::atomic_store(incorrect_flag_, 1);
         }
         return *this;
     }
@@ -1025,7 +1025,7 @@ public:
         const size_t expected_index = value / modulo_ - value / (modulo_exclude_ * modulo_) - 1;
         if(!is_mod || current_index_ != expected_index)
         {
-            rocprim::detail::atomic_exch(incorrect_flag_, 1);
+            rocprim::detail::atomic_store(incorrect_flag_, 1);
         }
         return *this;
     }
@@ -1057,7 +1057,7 @@ public:
         const size_t expected_index = value - value / modulo_ - 1;
         if(is_mod || current_index_ != expected_index)
         {
-            rocprim::detail::atomic_exch(incorrect_flag_, 1);
+            rocprim::detail::atomic_store(incorrect_flag_, 1);
         }
         return *this;
     }

--- a/test/rocprim/test_device_scan.cpp
+++ b/test/rocprim/test_device_scan.cpp
@@ -1312,7 +1312,7 @@ struct check_value_inclusive
         const size_t expected_sum = (run_start + current_index_) * index_in_run / 2;
         if(value != expected_sum)
         {
-            rocprim::detail::atomic_exch(rocprim::get<1>(args_), 1);
+            rocprim::detail::atomic_store(rocprim::get<1>(args_), 1);
         }
         return value;
     }
@@ -1337,7 +1337,7 @@ struct check_value_exclusive
             = rocprim::get<1>(args_) + (run_start + current_index_ - 1) * index_in_run / 2;
         if(value != expected_sum)
         {
-            rocprim::detail::atomic_exch(rocprim::get<2>(args_), 1);
+            rocprim::detail::atomic_store(rocprim::get<2>(args_), 1);
         }
         return value;
     }


### PR DESCRIPTION
- Restore and deprecate the interal APIs `lookback_scan_state::{create,get_storage_size,get_storage_layout}`
- Provide an alternative synchronization method in large value lookback scan for the MI300 that bypasses cache, this has been shown to be crucial for performance for the algorithms that use lookback_scan (scan, select, partition etc.)