### PR TITLE
Update exclusion list for CI testing

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -31,7 +31,7 @@ def runTestCommand (platform, project)
     def testCommand = "ctest --output-on-failure "
     def testCommandExcludeRegex = /(rocprim.device_scan)/
     def testCommandExclude = "--exclude-regex \"${testCommandExcludeRegex}\""
-    //def hmmExcludeRegex = ''
+    def hmmExcludeRegex = ''
     def hmmTestCommandExclude = "--exclude-regex \"${hmmExcludeRegex}\""
     def hmmTestCommand = ''
     if (platform.jenkinsLabel.contains('gfx90a'))

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -29,9 +29,9 @@ def runTestCommand (platform, project)
     String sudo = auxiliary.sudo(platform.jenkinsLabel)
 
     def testCommand = "ctest --output-on-failure "
-    def testCommandExcludeRegex = /(rocprim.device_reduce_by_key|rocprim.device_radix_sort)/
+    def testCommandExcludeRegex = /(rocprim.device_scan)/
     def testCommandExclude = "--exclude-regex \"${testCommandExcludeRegex}\""
-    def hmmExcludeRegex = /(rocprim.device_scan|rocprim.device_reduce_by_key|rocprim.block_sort_bitonic|rocprim.device_merge|rocprim.device_merge_sort|rocprim.device_partition|rocprim.device_segmented_radix_sort|rocprim.device_segmented_scan)/
+    //def hmmExcludeRegex = ''
     def hmmTestCommandExclude = "--exclude-regex \"${hmmExcludeRegex}\""
     def hmmTestCommand = ''
     if (platform.jenkinsLabel.contains('gfx90a'))


### PR DESCRIPTION
Temporarily disable device_scan due to possible compiler bug on Navi3x; restore tests that are fixed