### PR TITLE
Update supported data type table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@ Documentation for rocPRIM is available at
 * Build issues with `rmake.py` on Windows when using VS 2017 15.8 or later (due to a breaking fix with
   extended aligned storage)
 
+### Known Issues
+
+* The `block_histogram` test fails with 8 bit integers
+* The `block_exchange` test fails with 8 bit integers, 16 bit integers and `rocprim::half`
+* The `device_histogram` and `device_reduce_by_key` tests fail with `rocprim::half` and `rocprim::bfloat16`
+* The `device_run_lenght_encode`, `warp_exchange` and `warp_load` tests fail with `rocprim::half`
+
 ## rocPRIM-3.0.0 for ROCm 6.0.0
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,13 +83,10 @@ Documentation for rocPRIM is available at
 
 * Build issues with `rmake.py` on Windows when using VS 2017 15.8 or later (due to a breaking fix with
   extended aligned storage)
+* Fix tests for `block_histogram`, `block_exchange`, `device_histogram` and `device_reduce_by_key` for various types
 
 ### Known Issues
-
-* The `block_histogram` test fails with 8 bit integers
-* The `block_exchange` test fails with 8 bit integers, 16 bit integers and `rocprim::half`
-* The `device_histogram` and `device_reduce_by_key` tests fail with `rocprim::half` and `rocprim::bfloat16`
-* The `device_run_lenght_encode`, `warp_exchange` and `warp_load` tests fail with `rocprim::half`
+* `device_run_length_encode`, `warp_exchange` and `warp_load` tests fail with `rocprim::half`
 
 ## rocPRIM-3.0.0 for ROCm 6.0.0
 

--- a/docs/reference/data-type-support.rst
+++ b/docs/reference/data-type-support.rst
@@ -15,52 +15,35 @@ The following table shows the supported input and output datatypes.
     :name: supported-input-output-types
 
     *
-      - Input/Output Types
-      - Library Data Type
+      - Type
       - Support
     *
       - int8
-      - int8_t
-      - ⚠️
-    *
-      - float8
-      - Not Supported
-      - ❌
-    *
-      - bfloat8
-      - Not Supported
-      - ❌
+      - ✅
     *
       - int16
-      - int16_t
+      - ✅
+    *
+      - int32
+      - ✅
+    *
+      - int64
+      - ✅
+    *
+      - float8
       - ❌
     *
       - float16
-      - rocprim::half
-      - ⚠️
+      - ✅
     *
       - bfloat16      
-      - rocprim::bfloat16
-      - ⚠️
-    *
-      - int32
-      - int
       - ✅
     *
       - tensorfloat32
-      - Not Supported
       - ❌
     *
       - float32
-      - float
       - ✅
     *
       - float64
-      - double
       - ✅
-
-The ⚠️ means that the data type is mostly supported, but there are some API tests, that do not work.
-
-  * The ``block_histogram`` test fails with ``int8``.
-  * The ``device_histogram`` and ``device_reduce_by_key`` doesn't work with ``rocprim::half`` and ``rocprim::bfloat16``.
-  * The ``device_run_length_encode``, ``warp_exchange`` and ``warp_load`` doesn't work with ``rocprim::half``.


### PR DESCRIPTION
16 bit integers are supported. Removed the note about some tests not passing, as this does not belong in the documentation, and should be fixed instead