### PR TITLE
Temporarily skip hipGraph version of LargeIndices test

### DIFF
--- a/test/rocprim/test_device_adjacent_difference.cpp
+++ b/test/rocprim/test_device_adjacent_difference.cpp
@@ -460,25 +460,10 @@ TYPED_TEST_SUITE(RocprimDeviceAdjacentDifferenceLargeTests,
 
 TYPED_TEST(RocprimDeviceAdjacentDifferenceLargeTests, LargeIndices)
 {
-    const int device_id = test_common_utils::obtain_device_from_ctest();
-
-#ifdef _WIN32
     if (TestFixture::use_graphs)
-    {
-        // Skip this test on Navi2x/3x on Windows, since check_output_iterator does not appear to work there.
-        hipDeviceProp_t props;
-        HIP_CHECK(hipGetDeviceProperties(&props, device_id));
-        std::string deviceName = std::string(props.gcnArchName);
-        if(deviceName.rfind("gfx1030", 0) == 0 ||
-           deviceName.rfind("gfx1100", 0) == 0 ||
-           deviceName.rfind("gfx1101", 0) == 0 ||
-           deviceName.rfind("gfx1102", 0) == 0)
-        {
-            // This is a Navi2x/3x device, so skip this test
-            GTEST_SKIP() << "Temporarily skipping test on Windows for on gfx1030, gfx1100, gfx1101, gfx1102";
-        }
-    }
-#endif
+        GTEST_SKIP() << "Temporarily skipping test within hipGraphs. Will re-enable when issues with atomics inside graphs are resolved.";
+
+    const int device_id = test_common_utils::obtain_device_from_ctest();
 
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));


### PR DESCRIPTION
Currently there appear to be some problems calling the atomicAdd function within hipGraphs on some architectures. The atomicAdd function is called within the device_adjacent_difference algorithm's LargeIndices test (check_output class) to increment a counter value. As a result, the hipGraph version of the test fails when called on affected architectures.

This change temporarily skips the hipGraph version of the test. We can re-enable it when the root cause has been addressed.