### PR TITLE
Undo breaking change in segmented radix sort config

### DIFF
--- a/benchmark/benchmark_device_segmented_radix_sort_keys.cpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_keys.cpp
@@ -285,6 +285,7 @@ int main(int argc, char* argv[])
     // Add benchmarks
     std::vector<benchmark::internal::Benchmark*> benchmarks;
 #ifdef BENCHMARK_CONFIG_TUNING
+    (void)min_size;
     const int parallel_instance  = parser.get<int>("parallel_instance");
     const int parallel_instances = parser.get<int>("parallel_instances");
     config_autotune_register::register_benchmark_subset(benchmarks,

--- a/benchmark/benchmark_device_segmented_radix_sort_keys.parallel.hpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_keys.parallel.hpp
@@ -291,16 +291,15 @@ struct device_segmented_radix_sort_benchmark_generator
                                     rocprim::segmented_radix_sort_config<
                                         LongBits,
                                         ShortBits,
-                                        BlockSize,
-                                        ItemsPerThread,
-                                        EnableUnpartitionedWarpSort,
+                                        rocprim::kernel_config<BlockSize, ItemsPerThread>,
                                         rocprim::WarpSortConfig<LogicalWarpSizeSmall / 2,
                                                                 ItemsPerThread / 2,
                                                                 BlockSize,
                                                                 PartitioningThreshold,
                                                                 LogicalWarpSizeSmall,
                                                                 ItemsPerThread,
-                                                                BlockSize>>>>());
+                                                                BlockSize>,
+                                        EnableUnpartitionedWarpSort>>>());
                         }
                     };
 
@@ -321,15 +320,15 @@ struct device_segmented_radix_sort_benchmark_generator
                     }
                     else
                     {
-                        storage.emplace_back(std::make_unique<device_segmented_radix_sort_benchmark<
-                                                 Key,
-                                                 rocprim::segmented_radix_sort_config<
-                                                     LongBits,
-                                                     ShortBits,
-                                                     BlockSize,
-                                                     ItemsPerThread,
-                                                     EnableUnpartitionedWarpSort,
-                                                     rocprim::DisabledWarpSortConfig>>>());
+                        storage.emplace_back(
+                            std::make_unique<device_segmented_radix_sort_benchmark<
+                                Key,
+                                rocprim::segmented_radix_sort_config<
+                                    LongBits,
+                                    ShortBits,
+                                    rocprim::kernel_config<BlockSize, ItemsPerThread>,
+                                    rocprim::DisabledWarpSortConfig,
+                                    EnableUnpartitionedWarpSort>>>());
                     }
                 }
             };

--- a/benchmark/benchmark_device_segmented_radix_sort_pairs.cpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_pairs.cpp
@@ -309,6 +309,7 @@ int main(int argc, char* argv[])
     // Add benchmarks
     std::vector<benchmark::internal::Benchmark*> benchmarks;
 #ifdef BENCHMARK_CONFIG_TUNING
+    (void)min_size;
     const int parallel_instance  = parser.get<int>("parallel_instance");
     const int parallel_instances = parser.get<int>("parallel_instances");
     config_autotune_register::register_benchmark_subset(benchmarks,

--- a/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.hpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.hpp
@@ -330,16 +330,15 @@ struct device_segmented_radix_sort_benchmark_generator
                                     rocprim::segmented_radix_sort_config<
                                         LongBits,
                                         ShortBits,
-                                        BlockSize,
-                                        ItemsPerThread,
-                                        EnableUnpartitionedWarpSort,
+                                        rocprim::kernel_config<BlockSize, ItemsPerThread>,
                                         rocprim::WarpSortConfig<LogicalWarpSizeSmall / 2,
                                                                 ItemsPerThread / 2,
                                                                 BlockSize,
                                                                 PartitioningThreshold,
                                                                 LogicalWarpSizeSmall,
                                                                 ItemsPerThread,
-                                                                BlockSize>>>>());
+                                                                BlockSize>,
+                                        EnableUnpartitionedWarpSort>>>());
                         }
                     };
 
@@ -360,16 +359,16 @@ struct device_segmented_radix_sort_benchmark_generator
                     }
                     else
                     {
-                        storage.emplace_back(std::make_unique<device_segmented_radix_sort_benchmark<
-                                                 Key,
-                                                 Value,
-                                                 rocprim::segmented_radix_sort_config<
-                                                     LongBits,
-                                                     ShortBits,
-                                                     BlockSize,
-                                                     ItemsPerThread,
-                                                     EnableUnpartitionedWarpSort,
-                                                     rocprim::DisabledWarpSortConfig>>>());
+                        storage.emplace_back(
+                            std::make_unique<device_segmented_radix_sort_benchmark<
+                                Key,
+                                Value,
+                                rocprim::segmented_radix_sort_config<
+                                    LongBits,
+                                    ShortBits,
+                                    rocprim::kernel_config<BlockSize, ItemsPerThread>,
+                                    rocprim::DisabledWarpSortConfig,
+                                    EnableUnpartitionedWarpSort>>>());
                     }
                 }
             };

--- a/rocprim/include/rocprim/device/detail/config/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/config/device_segmented_radix_sort.hpp
@@ -54,12 +54,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int
@@ -74,12 +73,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = short
@@ -94,12 +92,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -114,12 +111,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -134,12 +130,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -154,12 +149,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int
@@ -174,12 +168,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = short
@@ -194,12 +187,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -214,12 +206,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -234,12 +225,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int64_t
@@ -252,12 +242,11 @@ struct default_segmented_radix_sort_config<
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
     : segmented_radix_sort_config<6,
                                   4,
-                                  256,
-                                  8,
-                                  1,
+                                  kernel_config<256, 8>,
                                   typename std::conditional<1,
                                                             WarpSortConfig<4, 4, 256, 5, 8, 8, 256>,
-                                                            DisabledWarpSortConfig>::type>
+                                                            DisabledWarpSortConfig>::type,
+                                  1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -270,12 +259,11 @@ struct default_segmented_radix_sort_config<
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
     : segmented_radix_sort_config<6,
                                   4,
-                                  256,
-                                  8,
-                                  1,
+                                  kernel_config<256, 8>,
                                   typename std::conditional<1,
                                                             WarpSortConfig<4, 4, 256, 5, 8, 8, 256>,
-                                                            DisabledWarpSortConfig>::type>
+                                                            DisabledWarpSortConfig>::type,
+                                  1>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -289,12 +277,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -309,12 +296,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -328,12 +314,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -348,12 +333,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -368,12 +352,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -388,12 +371,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -408,12 +390,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -428,12 +409,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           3,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -448,12 +428,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int
@@ -468,12 +447,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = short
@@ -488,12 +466,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -508,12 +485,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -528,12 +504,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -548,12 +523,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int
@@ -568,12 +542,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          8,
-          1,
+          kernel_config<256, 8>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 4, 256, 5, 32, 8, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = short
@@ -588,12 +561,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -608,12 +580,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          8,
-          1,
+          kernel_config<256, 8>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 4, 256, 5, 32, 8, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = empty_type
@@ -628,12 +599,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -647,12 +617,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          4,
-          1,
+          kernel_config<256, 4>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 2, 256, 5, 16, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -666,12 +635,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          4,
-          1,
+          kernel_config<256, 4>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 2, 256, 5, 16, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -684,12 +652,11 @@ struct default_segmented_radix_sort_config<
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
     : segmented_radix_sort_config<6,
                                   4,
-                                  256,
-                                  8,
-                                  1,
+                                  kernel_config<256, 8>,
                                   typename std::conditional<1,
                                                             WarpSortConfig<4, 4, 256, 5, 8, 8, 256>,
-                                                            DisabledWarpSortConfig>::type>
+                                                            DisabledWarpSortConfig>::type,
+                                  1>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -704,12 +671,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          4,
-          1,
+          kernel_config<256, 4>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 2, 256, 5, 16, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -722,12 +688,11 @@ struct default_segmented_radix_sort_config<
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
     : segmented_radix_sort_config<4,
                                   4,
-                                  256,
-                                  8,
-                                  1,
+                                  kernel_config<256, 8>,
                                   typename std::conditional<1,
                                                             WarpSortConfig<4, 4, 256, 5, 8, 8, 256>,
-                                                            DisabledWarpSortConfig>::type>
+                                                            DisabledWarpSortConfig>::type,
+                                  1>
 {};
 
 // Based on key_type = double, value_type = int64_t
@@ -742,12 +707,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int
@@ -762,12 +726,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = short
@@ -782,12 +745,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -802,12 +764,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -822,12 +783,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -842,12 +802,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int
@@ -862,12 +821,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = short
@@ -882,12 +840,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -902,12 +859,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -922,12 +878,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int64_t
@@ -940,12 +895,11 @@ struct default_segmented_radix_sort_config<
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
     : segmented_radix_sort_config<7,
                                   2,
-                                  256,
-                                  8,
-                                  1,
+                                  kernel_config<256, 8>,
                                   typename std::conditional<1,
                                                             WarpSortConfig<4, 4, 256, 5, 8, 8, 256>,
-                                                            DisabledWarpSortConfig>::type>
+                                                            DisabledWarpSortConfig>::type,
+                                  1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -958,12 +912,11 @@ struct default_segmented_radix_sort_config<
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
     : segmented_radix_sort_config<6,
                                   4,
-                                  256,
-                                  8,
-                                  1,
+                                  kernel_config<256, 8>,
                                   typename std::conditional<1,
                                                             WarpSortConfig<4, 4, 256, 5, 8, 8, 256>,
-                                                            DisabledWarpSortConfig>::type>
+                                                            DisabledWarpSortConfig>::type,
+                                  1>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -977,12 +930,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          8,
-          1,
+          kernel_config<256, 8>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 4, 256, 5, 32, 8, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -997,12 +949,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -1016,12 +967,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -1036,12 +986,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -1056,12 +1005,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -1076,12 +1024,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -1096,12 +1043,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -1116,12 +1062,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -1136,12 +1081,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int
@@ -1156,12 +1100,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = short
@@ -1176,12 +1119,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -1196,12 +1138,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -1216,12 +1157,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -1236,12 +1176,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int
@@ -1256,12 +1195,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = short
@@ -1276,12 +1214,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -1296,12 +1233,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = empty_type
@@ -1316,12 +1252,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -1335,12 +1270,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          4,
-          1,
+          kernel_config<256, 4>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 2, 256, 5, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -1353,12 +1287,11 @@ struct default_segmented_radix_sort_config<
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
     : segmented_radix_sort_config<6,
                                   4,
-                                  256,
-                                  8,
-                                  1,
+                                  kernel_config<256, 8>,
                                   typename std::conditional<1,
                                                             WarpSortConfig<4, 4, 256, 5, 8, 8, 256>,
-                                                            DisabledWarpSortConfig>::type>
+                                                            DisabledWarpSortConfig>::type,
+                                  1>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -1372,12 +1305,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          8,
-          1,
+          kernel_config<256, 8>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 4, 256, 5, 32, 8, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -1392,12 +1324,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          4,
-          1,
+          kernel_config<256, 4>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 2, 256, 5, 16, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -1411,12 +1342,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int64_t
@@ -1431,12 +1361,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int
@@ -1451,12 +1380,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = short
@@ -1471,12 +1399,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -1491,12 +1418,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -1511,12 +1437,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -1531,12 +1456,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int
@@ -1551,12 +1475,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = short
@@ -1571,12 +1494,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -1591,12 +1513,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -1611,12 +1532,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int64_t
@@ -1630,12 +1550,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -1649,12 +1568,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -1668,12 +1586,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -1688,12 +1605,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -1707,12 +1623,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -1727,12 +1642,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -1747,12 +1661,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -1767,12 +1680,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -1787,12 +1699,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -1807,12 +1718,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -1827,12 +1737,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int
@@ -1847,12 +1756,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = short
@@ -1867,12 +1775,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -1887,12 +1794,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -1907,12 +1813,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -1927,12 +1832,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int
@@ -1947,12 +1851,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = short
@@ -1967,12 +1870,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -1987,12 +1889,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = empty_type
@@ -2007,12 +1908,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -2026,12 +1926,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -2045,12 +1944,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -2064,12 +1962,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -2084,12 +1981,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -2103,12 +1999,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int64_t
@@ -2123,12 +2018,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int
@@ -2143,12 +2037,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = short
@@ -2163,12 +2056,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -2183,12 +2075,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -2203,12 +2094,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -2223,12 +2113,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int
@@ -2243,12 +2132,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = short
@@ -2263,12 +2151,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -2283,12 +2170,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -2303,12 +2189,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           5,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int64_t
@@ -2322,12 +2207,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -2341,12 +2225,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -2360,12 +2243,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -2380,12 +2262,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -2399,12 +2280,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -2419,12 +2299,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -2439,12 +2318,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -2459,12 +2337,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -2479,12 +2356,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -2499,12 +2375,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -2519,12 +2394,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int
@@ -2539,12 +2413,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = short
@@ -2559,12 +2432,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -2579,12 +2451,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -2599,12 +2470,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -2619,12 +2489,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int
@@ -2639,12 +2508,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = short
@@ -2659,12 +2527,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -2679,12 +2546,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = empty_type
@@ -2699,12 +2565,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -2718,12 +2583,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -2737,12 +2601,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -2756,12 +2619,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -2776,12 +2638,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -2795,12 +2656,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int64_t
@@ -2815,12 +2675,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int
@@ -2835,12 +2694,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = short
@@ -2855,12 +2713,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -2875,12 +2732,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -2895,12 +2751,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -2915,12 +2770,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int
@@ -2935,12 +2789,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = short
@@ -2955,12 +2808,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -2975,12 +2827,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -2995,12 +2846,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int64_t
@@ -3013,12 +2863,11 @@ struct default_segmented_radix_sort_config<
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
     : segmented_radix_sort_config<6,
                                   4,
-                                  128,
-                                  8,
-                                  1,
+                                  kernel_config<128, 8>,
                                   typename std::conditional<1,
                                                             WarpSortConfig<4, 4, 128, 5, 8, 8, 128>,
-                                                            DisabledWarpSortConfig>::type>
+                                                            DisabledWarpSortConfig>::type,
+                                  1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -3032,12 +2881,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -3051,12 +2899,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -3071,12 +2918,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -3090,12 +2936,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -3110,12 +2955,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -3130,12 +2974,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -3150,12 +2993,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -3170,12 +3012,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -3190,12 +3031,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -3210,12 +3050,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int
@@ -3230,12 +3069,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = short
@@ -3250,12 +3088,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -3270,12 +3107,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -3290,12 +3126,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -3310,12 +3145,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int
@@ -3330,12 +3164,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = short
@@ -3350,12 +3183,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -3370,12 +3202,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = empty_type
@@ -3390,12 +3221,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           2,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -3409,12 +3239,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -3427,12 +3256,11 @@ struct default_segmented_radix_sort_config<
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
     : segmented_radix_sort_config<7,
                                   4,
-                                  128,
-                                  8,
-                                  1,
+                                  kernel_config<128, 8>,
                                   typename std::conditional<1,
                                                             WarpSortConfig<4, 4, 128, 5, 8, 8, 128>,
-                                                            DisabledWarpSortConfig>::type>
+                                                            DisabledWarpSortConfig>::type,
+                                  1>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -3445,12 +3273,11 @@ struct default_segmented_radix_sort_config<
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
     : segmented_radix_sort_config<6,
                                   4,
-                                  128,
-                                  8,
-                                  1,
+                                  kernel_config<128, 8>,
                                   typename std::conditional<1,
                                                             WarpSortConfig<4, 4, 128, 5, 8, 8, 128>,
-                                                            DisabledWarpSortConfig>::type>
+                                                            DisabledWarpSortConfig>::type,
+                                  1>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -3465,12 +3292,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           6,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -3484,12 +3310,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           4,
           3,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int64_t
@@ -3504,12 +3329,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int
@@ -3524,12 +3348,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = short
@@ -3544,12 +3367,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -3564,12 +3386,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -3584,12 +3405,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -3604,12 +3424,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int
@@ -3624,12 +3443,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = short
@@ -3644,12 +3462,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -3664,12 +3481,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -3684,12 +3500,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int64_t
@@ -3703,12 +3518,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -3722,12 +3536,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -3741,12 +3554,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -3761,12 +3573,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -3780,12 +3591,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -3800,12 +3610,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -3820,12 +3629,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -3840,12 +3648,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -3860,12 +3667,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -3880,12 +3686,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -3900,12 +3705,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int
@@ -3920,12 +3724,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = short
@@ -3940,12 +3743,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -3960,12 +3762,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -3980,12 +3781,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -4000,12 +3800,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int
@@ -4020,12 +3819,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = short
@@ -4040,12 +3838,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -4060,12 +3857,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = empty_type
@@ -4080,12 +3876,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -4099,12 +3894,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -4118,12 +3912,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -4137,12 +3930,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -4157,12 +3949,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -4176,12 +3967,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int64_t
@@ -4196,12 +3986,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int
@@ -4216,12 +4005,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = short
@@ -4236,12 +4024,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -4256,12 +4043,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -4276,12 +4062,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -4296,12 +4081,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int
@@ -4316,12 +4100,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = short
@@ -4336,12 +4119,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -4356,12 +4138,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -4376,12 +4157,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int64_t
@@ -4395,12 +4175,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -4414,12 +4193,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -4433,12 +4211,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -4453,12 +4230,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -4472,12 +4248,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -4492,12 +4267,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -4512,12 +4286,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -4532,12 +4305,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -4552,12 +4324,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -4572,12 +4343,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -4592,12 +4362,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int
@@ -4612,12 +4381,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<8, 8, 256, 5, 16, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = short
@@ -4632,12 +4400,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -4652,12 +4419,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           4,
-          256,
-          16,
-          1,
+          kernel_config<256, 16>,
           typename std::conditional<1,
                                     WarpSortConfig<16, 8, 256, 5, 32, 16, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -4672,12 +4438,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -4692,12 +4457,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int
@@ -4712,12 +4476,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = short
@@ -4732,12 +4495,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -4752,12 +4514,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = short, value_type = empty_type
@@ -4772,12 +4533,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -4791,12 +4551,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -4810,12 +4569,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -4829,12 +4587,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -4849,12 +4606,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -4868,12 +4624,11 @@ struct default_segmented_radix_sort_config<
     : segmented_radix_sort_config<
           7,
           6,
-          256,
-          17,
-          1,
+          kernel_config<256, 17>,
           typename std::conditional<1,
                                     WarpSortConfig<32, 4, 256, 3000, 32, 4, 256>,
-                                    DisabledWarpSortConfig>::type>
+                                    DisabledWarpSortConfig>::type,
+          1>
 {};
 
 } // end namespace detail

--- a/scripts/autotune/templates/segmented_radix_sort_config_template
+++ b/scripts/autotune/templates/segmented_radix_sort_config_template
@@ -5,7 +5,19 @@ ROCPRIM_DEVICE_DETAIL_CONFIG_DEVICE_SEGMENTED_RADIX_SORT_HPP_
 {%- endmacro %}
 
 {% macro kernel_configuration(measurement) -%}
-segmented_radix_sort_config<{{ measurement['cfg']['lrb'] }}, {{ measurement['cfg']['srb'] }}, {{ measurement['cfg']['bs'] }}, {{ measurement['cfg']['ipt'] }}, {{ measurement['cfg']['eupws'] }}, typename std::conditional<{{ measurement['cfg']['wsc']['pa'] }},WarpSortConfig<{{ measurement['cfg']['wsc']['lwss'] }},{{ measurement['cfg']['wsc']['ipts'] }},{{ measurement['cfg']['wsc']['bss'] }},{{ measurement['cfg']['wsc']['pt'] }},{{ measurement['cfg']['wsc']['lwsm'] }},{{ measurement['cfg']['wsc']['iptm'] }},{{ measurement['cfg']['wsc']['bsm'] }}>,DisabledWarpSortConfig>::type> { };
+segmented_radix_sort_config<
+    {{ measurement['cfg']['lrb'] }}, {{ measurement['cfg']['srb'] }},
+    kernel_config<{{ measurement['cfg']['bs'] }}, {{ measurement['cfg']['ipt'] }}>, 
+    typename std::conditional<
+        {{ measurement['cfg']['wsc']['pa'] }},
+        WarpSortConfig<
+            {{ measurement['cfg']['wsc']['lwss'] }}, {{ measurement['cfg']['wsc']['ipts'] }},
+            {{ measurement['cfg']['wsc']['bss'] }}, {{ measurement['cfg']['wsc']['pt'] }},
+            {{ measurement['cfg']['wsc']['lwsm'] }}, {{ measurement['cfg']['wsc']['iptm'] }},
+            {{ measurement['cfg']['wsc']['bsm'] }}>,
+        DisabledWarpSortConfig
+    >::type,
+    {{ measurement['cfg']['eupws'] }} > { };
 {%- endmacro %}
 
 {% macro general_case() -%}

--- a/test/rocprim/test_device_segmented_radix_sort.hpp
+++ b/test/rocprim/test_device_segmented_radix_sort.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -53,47 +53,45 @@ struct params
     using config                                     = Config;
 };
 
-using config_default = rocprim::segmented_radix_sort_config<4, //< long radix bits
-                                                            3, //< short radix bits
-                                                            256, //< sort block size,
-                                                            4 //< items per thread
-                                                            >;
+using config_default
+    = rocprim::segmented_radix_sort_config<4, //< long radix bits
+                                           3, //< short radix bits
+                                           rocprim::kernel_config<256, //< sort block size,
+                                                                  4>>; //< items per thread
 
 using config_semi_custom
     = rocprim::segmented_radix_sort_config<3, //< long radix bits
                                            2, //< short radix bits
-                                           128, //< sort block size
-                                           4, //< items per thread
-                                           false, //< enable unpartitioned sort
+                                           rocprim::kernel_config<128, //< sort block size
+                                                                  4>, //< items per thread
                                            rocprim::WarpSortConfig<16, //< logical warp size small
-                                                                   8 //< items per thread small
-                                                                   >>;
+                                                                   8>, //< items per thread small
+                                           false>; //< enable unpartitioned sort
 
 using config_semi_custom_warp_config
     = rocprim::segmented_radix_sort_config<3, //< long radix bits
                                            2, //< short radix bits
-                                           128, //< sort block size
-                                           4, //< items per thread
-                                           true, //< enable unpartitioned sort
+                                           rocprim::kernel_config<128, //< sort block size
+                                                                  4>, //< items per thread
                                            rocprim::WarpSortConfig<16, //< logical warp size small
                                                                    2, //< items per thread small
                                                                    512, //< block size small
-                                                                   0>>; //< partitioning threshold
+                                                                   0>, //< partitioning threshold
+                                           true>; //< enable unpartitioned sort
 
 using config_custom
     = rocprim::segmented_radix_sort_config<3, //< long radix bits
                                            2, //< short radix bits
-                                           128, //< sort block size
-                                           4, //< items per thread
-                                           true, //< enable unpartitioned sort
+                                           rocprim::kernel_config<128, //< sort block size
+                                                                  4>, //< items per thread
                                            rocprim::WarpSortConfig<16, //< logical warp size small
                                                                    2, //< items per thread small
                                                                    512, //< block size small
                                                                    0, //< partitioning threshold
                                                                    32, //< logical warp size medium
                                                                    4, //< items per thread medium
-                                                                   256 //< block size medium
-                                                                   >>;
+                                                                   256>, //< block size medium
+                                           true>; //< enable unpartitioned sort
 
 template<class Params>
 class RocprimDeviceSegmentedRadixSort : public ::testing::Test


### PR DESCRIPTION
https://github.com/ROCm/rocPRIM/pull/509 changes `rocprim::segmented_radix_sort_config` in a non-backwards-compatible way, this PR changes the config so it is compatible with the previous rocPRIM release.