### PR TITLE
Fixed radix sort with custom float type

### DIFF
--- a/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
@@ -581,7 +581,7 @@ private:
                                          storage_type& storage,
                                          unsigned int  begin_bit,
                                          unsigned int  end_bit)
-        -> std::enable_if_t<is_floating_point<K>::value>
+        -> std::enable_if_t<!is_integral<K>::value>
     {
         (void)begin_bit;
         (void)end_bit;
@@ -597,7 +597,7 @@ private:
                                          storage_type& storage,
                                          unsigned int  begin_bit,
                                          unsigned int  end_bit)
-        -> std::enable_if_t<!is_floating_point<K>::value>
+        -> std::enable_if_t<is_integral<K>::value>
     {
         if(begin_bit == 0 && end_bit == 8 * sizeof(key_type))
         {

--- a/rocprim/include/rocprim/device/specialization/device_radix_merge_sort.hpp
+++ b/rocprim/include/rocprim/device/specialization/device_radix_merge_sort.hpp
@@ -48,9 +48,8 @@ auto invoke_merge_sort_block_merge(
     bool                                                       debug_synchronous,
     typename std::iterator_traits<KeysIterator>::value_type*   keys_buffer,
     typename std::iterator_traits<ValuesIterator>::value_type* values_buffer)
-    -> std::enable_if_t<
-        !is_floating_point<typename std::iterator_traits<KeysIterator>::value_type>::value,
-        hipError_t>
+    -> std::enable_if_t<is_integral<typename std::iterator_traits<KeysIterator>::value_type>::value,
+                        hipError_t>
 {
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
     (void)decomposer;
@@ -101,7 +100,7 @@ auto invoke_merge_sort_block_merge(
     typename std::iterator_traits<KeysIterator>::value_type*   keys_buffer,
     typename std::iterator_traits<ValuesIterator>::value_type* values_buffer)
     -> std::enable_if_t<
-        is_floating_point<typename std::iterator_traits<KeysIterator>::value_type>::value,
+        !is_integral<typename std::iterator_traits<KeysIterator>::value_type>::value,
         hipError_t>
 {
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;

--- a/test/rocprim/test_device_radix_sort.hpp
+++ b/test/rocprim/test_device_radix_sort.hpp
@@ -95,7 +95,8 @@ auto generate_key_input(KeyIter keys_input, size_t size, engine_type& rng_engine
 // Working around custom_float_test_type, which is both a float and a custom_test_type
 template<class T>
 constexpr bool is_custom_not_float_test_type
-    = test_utils::is_custom_test_type<T>::value && !rocprim::is_floating_point<T>::value;
+    = test_utils::is_custom_test_type<T>::value
+      && !std::is_same<test_utils::custom_float_type, T>::value;
 
 template<class Config, bool Descending, class Key>
 auto invoke_sort_keys(void*        d_temporary_storage,

--- a/test/rocprim/test_utils_custom_float_type.hpp
+++ b/test/rocprim/test_utils_custom_float_type.hpp
@@ -110,10 +110,6 @@ struct inner_type<custom_float_type>
 namespace rocprim
 {
 
-template<>
-struct is_floating_point<test_utils::custom_float_type> : std::true_type
-{};
-
 namespace detail
 {
 
@@ -130,6 +126,10 @@ template<>
 struct radix_key_codec_base<test_utils::custom_float_type>
     : radix_key_codec_floating<test_utils::custom_float_type, unsigned int>
 {};
+
+static_assert(!is_floating_point<test_utils::custom_float_type>::value,
+              "custom_float_type must not be rocprim::is_floating_point, "
+              "since that is how downstream libraries use it.");
 
 } // namespace detail
 } // namespace rocprim


### PR DESCRIPTION
### Analysis

- The build failure was caused by the modification of `radix_merge_compare` in #541
- The assumption was that only fundamental (floating-point and integral) types are radix sorted with the `identity_decomposer`, and custom types are always sorted with a custom decomposer.
- Also, the library is explicit about the input contract: for floating-point types, the `begin_bit` and `end_bit` must match `0` and the size of the type accordingly. But these are runtime passed parameters.
- For this reason: the previous implementation needed to provide a "placeholder" specialization that would have been called when `begin_bit` and `end_bit` did not conform, which was expected to be never called. The new logic has the dispatch between integral and floating-point types at a different overload set (`invoke_merge_sort_block_merge`), therefore the placeholder was no longer needed.
- However, Tensorflow uses radix sort with user-defined float types (`tf::bfloat16` and `Eigen::half`). Unfortunately we don't provide an alternative nor a documented way of doing so, therefore TF must 'hack' its way in, via adding specializations to the `rocprim::detail` namespace. But since they don't specialize `rocprim::is_floating_point` for these types, their call dispatches to the integral code path, which assumes integral operators. That fails to compile.
- We are aware that TF uses rocPRIM like this, and we added specific tests to prevent breakage (see `custom_float_type`). However, since these tests were added, the type traits around `custom_float_type` has been changed (namely a `rocprim::is_floating_point` specialization was added), therefore this test no longer reflected the use case of TF, and could not prevent this breakage.

### Changes

- The problem is fixed in a minimal-change way. The dispatch between fundamental float and fundamental integral was based on `is_floating_point` and `!is_floating_point` expressions, and this was changed to `!is_integral` and `is_integral`. When called with a custom type, that is neither `is_floating_point` nor `is_integral`, the dispatch will point to the floating point code path.
- The `custom_float_type` test is patched to reflect the TF situation accurately. A `static_assert` was added to ensure that `is_floating_point<custom_float_type>` won't be added again.

### Notes

- We should design a supported way of using these functions with custom float types. As per our analysis with @Maetveis, unfortunately the newly implemented decomposer support cannot fulfill this need.