### PR TITLE
docs: fix broken contributing link (#552)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ The rocPRIM documentation is structured as follows:
     * :ref:`iterators` 
     * :ref:`intrinsics` 
 
-To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/index.html>`_.
+To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 
 You can find licensing information on the `Licensing <https://rocm.docs.amd.com/en/latest/about/license.html>`_ page.
 


### PR DESCRIPTION
Summary of proposed changes:

Cherry-pick fixed broken link from `develop`
