### PR TITLE
Update ROCm-CMake tag

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -190,7 +190,7 @@ if(NOT ROCM_FOUND)
   FetchContent_Declare(
     rocm-cmake
     GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git
-    GIT_TAG        rocm-6.1.2
+    GIT_TAG        rocm-6.0.2
     ${SOURCE_SUBDIR_ARG}
   )
   FetchContent_MakeAvailable(rocm-cmake)


### PR DESCRIPTION
The CMake dependencies GIT_TAG for rocm-cmake needs to be adjusted to be compatible with the ROCM package version 0.11.0 that's used elsewhere.

The current version of rocm-cmake (6.1.2) requires ROCM package version 0.12.0. The rocm-cmake 6.0.2 tag is the latest one that still allows us to use ROCM package version 0.11.0.