### PR TITLE
Fix rare memory access faults when using internal serial merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ Documentation for rocPRIM is available at
 * Fixed a bug for `rocprim::merge_path_search` where using `unsigned` offsets would output wrong results.
 * Fixed a bug for `rocprim::thread_load` and `rocprim::thread_store` where `float` and `double` were not casted to the correct type resulting in wrong results.
 * Fix tests failing when compiling with `-D_GLIBCXX_ASSERTIONS=ON`.
+* Fixed a bug for algorithms that use an internal serial merge routine that causes a memory access fault. This may result in a performance drop when using:
+  * block sort,
+  * device merge sort (block merge),
+  * device merge,
+  * device partial sort, and/or
+  * device sort (merge sort).
 
 ### Deprecations
 

--- a/rocprim/include/rocprim/block/detail/block_sort_merge.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_merge.hpp
@@ -388,6 +388,7 @@ private:
                 = {keys1_beg_local + keys1_beg, keys1_end, keys2_beg_local + keys1_end, keys2_end};
 
             serial_merge(keys_shared, thread_keys, range_local, compare_function);
+            ::rocprim::syncthreads();
         }
     }
 
@@ -434,6 +435,7 @@ private:
                          thread_values,
                          range_local,
                          compare_function);
+            ::rocprim::syncthreads();
         }
     }
 };

--- a/rocprim/include/rocprim/block/detail/block_sort_merge.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_merge.hpp
@@ -387,7 +387,7 @@ private:
             range_t<>          range_local
                 = {keys1_beg_local + keys1_beg, keys1_end, keys2_beg_local + keys1_end, keys2_end};
 
-            serial_merge<true>(keys_shared, thread_keys, range_local, compare_function);
+            serial_merge<false>(keys_shared, thread_keys, range_local, compare_function);
             ::rocprim::syncthreads();
         }
     }
@@ -429,12 +429,12 @@ private:
             range_t<>          range_local
                 = {keys1_beg_local + keys1_beg, keys1_end, keys2_beg_local + keys1_end, keys2_end};
 
-            serial_merge<true>(keys_shared,
-                               thread_keys,
-                               values_shared,
-                               thread_values,
-                               range_local,
-                               compare_function);
+            serial_merge<false>(keys_shared,
+                                thread_keys,
+                                values_shared,
+                                thread_values,
+                                range_local,
+                                compare_function);
             ::rocprim::syncthreads();
         }
     }

--- a/rocprim/include/rocprim/block/detail/block_sort_merge.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_merge.hpp
@@ -387,7 +387,7 @@ private:
             range_t<>          range_local
                 = {keys1_beg_local + keys1_beg, keys1_end, keys2_beg_local + keys1_end, keys2_end};
 
-            serial_merge(keys_shared, thread_keys, range_local, compare_function);
+            serial_merge<true>(keys_shared, thread_keys, range_local, compare_function);
             ::rocprim::syncthreads();
         }
     }
@@ -429,12 +429,12 @@ private:
             range_t<>          range_local
                 = {keys1_beg_local + keys1_beg, keys1_end, keys2_beg_local + keys1_end, keys2_end};
 
-            serial_merge(keys_shared,
-                         thread_keys,
-                         values_shared,
-                         thread_values,
-                         range_local,
-                         compare_function);
+            serial_merge<true>(keys_shared,
+                               thread_keys,
+                               values_shared,
+                               thread_values,
+                               range_local,
+                               compare_function);
             ::rocprim::syncthreads();
         }
     }

--- a/rocprim/include/rocprim/block/detail/block_sort_merge.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_merge.hpp
@@ -25,7 +25,6 @@
 #include "../../detail/merge_path.hpp"
 #include "../../detail/various.hpp"
 #include "../../warp/detail/warp_sort_stable.hpp"
-#include "../../warp/warp_sort.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -385,7 +384,7 @@ private:
                                                             diag0_local,
                                                             compare_function);
             const unsigned int keys2_beg_local = diag0_local - keys1_beg_local;
-            range_t            range_local
+            range_t<>          range_local
                 = {keys1_beg_local + keys1_beg, keys1_end, keys2_beg_local + keys1_end, keys2_end};
 
             serial_merge(keys_shared, thread_keys, range_local, compare_function);
@@ -426,7 +425,7 @@ private:
                                                             diag0_local,
                                                             compare_function);
             const unsigned int keys2_beg_local = diag0_local - keys1_beg_local;
-            range_t            range_local
+            range_t<>          range_local
                 = {keys1_beg_local + keys1_beg, keys1_end, keys2_beg_local + keys1_end, keys2_end};
 
             serial_merge(keys_shared,

--- a/rocprim/include/rocprim/block/detail/block_sort_merge.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_merge.hpp
@@ -384,8 +384,11 @@ private:
                                                             diag0_local,
                                                             compare_function);
             const unsigned int keys2_beg_local = diag0_local - keys1_beg_local;
-            range_t<>          range_local
-                = {keys1_beg_local + keys1_beg, keys1_end, keys2_beg_local + keys1_end, keys2_end};
+
+            range_t<> range_local{keys1_beg_local + keys1_beg,
+                                  keys1_end,
+                                  keys2_beg_local + keys1_end,
+                                  keys2_end};
 
             serial_merge<false>(keys_shared, thread_keys, range_local, compare_function);
             ::rocprim::syncthreads();
@@ -426,8 +429,11 @@ private:
                                                             diag0_local,
                                                             compare_function);
             const unsigned int keys2_beg_local = diag0_local - keys1_beg_local;
-            range_t<>          range_local
-                = {keys1_beg_local + keys1_beg, keys1_end, keys2_beg_local + keys1_end, keys2_end};
+
+            range_t<> range_local{keys1_beg_local + keys1_beg,
+                                  keys1_end,
+                                  keys2_beg_local + keys1_end,
+                                  keys2_end};
 
             serial_merge<false>(keys_shared,
                                 thread_keys,

--- a/rocprim/include/rocprim/detail/merge_path.hpp
+++ b/rocprim/include/rocprim/detail/merge_path.hpp
@@ -126,7 +126,7 @@ void serial_merge(KeyType*                keys_shared,
     }
 
     ROCPRIM_UNROLL
-    for(OffsetT i = 0; i < ItemsPerThread; ++i)
+    for(unsigned int i = 0; i < ItemsPerThread; ++i)
     {
         // If we don't have any in b, we always take from a. Then, if we don't
         // have any in a, we take from b. Otherwise we take the smallest item.
@@ -181,7 +181,7 @@ void serial_merge(KeyType* keys_shared,
         keys_shared,
         range,
         compare_function,
-        [&](const OffsetT& i, const KeyType& key, const OffsetT& index)
+        [&](const unsigned int& i, const KeyType& key, const OffsetT& index)
         {
             outputs[i] = key;
             indices[i] = index;
@@ -203,7 +203,7 @@ void serial_merge(KeyType* keys_shared,
         keys_shared,
         range,
         compare_function,
-        [&](const OffsetT& i, const KeyType& key, const OffsetT&) { outputs[i] = key; });
+        [&](const unsigned int& i, const KeyType& key, const OffsetT&) { outputs[i] = key; });
 }
 
 template<bool AllowUnsafe = false,
@@ -224,7 +224,7 @@ void serial_merge(KeyType* keys_shared,
         keys_shared,
         range,
         compare_function,
-        [&](const OffsetT& i, const KeyType& key, const OffsetT& index)
+        [&](const unsigned int& i, const KeyType& key, const OffsetT& index)
         {
             outputs[i] = key;
             values[i]  = values_shared[index];

--- a/rocprim/include/rocprim/detail/merge_path.hpp
+++ b/rocprim/include/rocprim/detail/merge_path.hpp
@@ -34,18 +34,21 @@ namespace detail
 template<class OffsetT = unsigned int>
 struct range_t
 {
-    OffsetT                begin1;
-    OffsetT                end1;
-    OffsetT                begin2;
-    OffsetT                end2;
+    OffsetT begin1;
+    OffsetT end1;
+    OffsetT begin2;
+    OffsetT end2;
 
+    /// \brief Number of elements in first range.
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    constexpr unsigned int count1() const
+    constexpr OffsetT count1() const
     {
         return end1 - begin1;
     }
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE constexpr unsigned int count2() const
+    /// \brief Number of elements in second range.
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    constexpr OffsetT count2() const
     {
         return end2 - begin2;
     }

--- a/rocprim/include/rocprim/detail/merge_path.hpp
+++ b/rocprim/include/rocprim/detail/merge_path.hpp
@@ -87,12 +87,17 @@ ROCPRIM_HOST_DEVICE ROCPRIM_INLINE OffsetT merge_path(KeysInputIterator1 keys_in
     return begin;
 }
 
-template<unsigned int ItemsPerThread, bool AllowUnsafe, class KeyType, class BinaryFunction, class OutputFunction, class OffsetT>
-ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
-void serial_merge(KeyType*       keys_shared,
-                  range_t<OffsetT> range,
-                  BinaryFunction compare_function,
-                  OutputFunction output_function)
+template<unsigned int ItemsPerThread,
+         bool         AllowUnsafe,
+         class KeyType,
+         class BinaryFunction,
+         class OutputFunction,
+         class OffsetT>
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void serial_merge(KeyType*                keys_shared,
+                  const range_t<OffsetT>& range,
+                  BinaryFunction          compare_function,
+                  OutputFunction          output_function)
 {
     // Pre condition, we're including some edge cases too.
     assert(range.begin1 <= range.end1);
@@ -169,17 +174,18 @@ ROCPRIM_DEVICE ROCPRIM_INLINE
 void serial_merge(KeyType* keys_shared,
                   KeyType (&outputs)[ItemsPerThread],
                   unsigned int (&indices)[ItemsPerThread],
-                  range_t<OffsetT> range,
-                  BinaryFunction   compare_function)
+                  const range_t<OffsetT>& range,
+                  BinaryFunction          compare_function)
 {
-    serial_merge<ItemsPerThread, AllowUnsafe>(keys_shared,
-                                              range,
-                                              compare_function,
-                                              [&](OffsetT i, KeyType key, OffsetT index)
-                                              {
-                                                  outputs[i] = key;
-                                                  indices[i] = index;
-                                              });
+    serial_merge<ItemsPerThread, AllowUnsafe>(
+        keys_shared,
+        range,
+        compare_function,
+        [&](const OffsetT& i, const KeyType& key, const OffsetT& index)
+        {
+            outputs[i] = key;
+            indices[i] = index;
+        });
 }
 
 template<bool AllowUnsafe = false,
@@ -190,14 +196,14 @@ template<bool AllowUnsafe = false,
 ROCPRIM_DEVICE ROCPRIM_INLINE
 void serial_merge(KeyType* keys_shared,
                   KeyType (&outputs)[ItemsPerThread],
-                  range_t<OffsetT> range,
-                  BinaryFunction   compare_function)
+                  const range_t<OffsetT>& range,
+                  BinaryFunction          compare_function)
 {
-    serial_merge<ItemsPerThread, AllowUnsafe>(keys_shared,
-                                              range,
-                                              compare_function,
-                                              [&](OffsetT i, KeyType key, OffsetT)
-                                              { outputs[i] = key; });
+    serial_merge<ItemsPerThread, AllowUnsafe>(
+        keys_shared,
+        range,
+        compare_function,
+        [&](const OffsetT& i, const KeyType& key, const OffsetT&) { outputs[i] = key; });
 }
 
 template<bool AllowUnsafe = false,
@@ -211,17 +217,18 @@ void serial_merge(KeyType* keys_shared,
                   KeyType (&outputs)[ItemsPerThread],
                   ValueType* values_shared,
                   ValueType (&values)[ItemsPerThread],
-                  range_t<OffsetT> range,
-                  BinaryFunction   compare_function)
+                  const range_t<OffsetT>& range,
+                  BinaryFunction          compare_function)
 {
-    serial_merge<ItemsPerThread, AllowUnsafe>(keys_shared,
-                                              range,
-                                              compare_function,
-                                              [&](OffsetT i, KeyType key, OffsetT index)
-                                              {
-                                                  outputs[i] = key;
-                                                  values[i]  = values_shared[index];
-                                              });
+    serial_merge<ItemsPerThread, AllowUnsafe>(
+        keys_shared,
+        range,
+        compare_function,
+        [&](const OffsetT& i, const KeyType& key, const OffsetT& index)
+        {
+            outputs[i] = key;
+            values[i]  = values_shared[index];
+        });
 }
 
 } // end namespace detail

--- a/rocprim/include/rocprim/detail/merge_path.hpp
+++ b/rocprim/include/rocprim/detail/merge_path.hpp
@@ -84,7 +84,7 @@ ROCPRIM_HOST_DEVICE ROCPRIM_INLINE OffsetT merge_path(KeysInputIterator1 keys_in
     return begin;
 }
 
-template<unsigned int ItemsPerThread, class KeyType, class BinaryFunction, class OutputFunction, class OffsetT>
+template<unsigned int ItemsPerThread, bool AllowUnsafe, class KeyType, class BinaryFunction, class OutputFunction, class OffsetT>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
 void serial_merge(KeyType*       keys_shared,
                   range_t<OffsetT> range,
@@ -95,21 +95,26 @@ void serial_merge(KeyType*       keys_shared,
     assert(range.begin1 <= range.end1);
     assert(range.begin2 <= range.end2);
 
+    // More descriptive names for ranges:
+    auto       idx_a = range.begin1;
+    auto       idx_b = range.begin2;
+    const auto end_a = range.end1;
+    const auto end_b = range.end2;
+
     // Pre-loaded keys so we don't have to re-fetch multiple times from memory.
     // These will be updated every iteration.
     KeyType key_a;
     KeyType key_b;
-    auto    num_a = range.end1 - range.begin1;
-    auto    num_b = range.end2 - range.begin2;
 
     // Only load valid keys, otherwise might be out of bounds!
-    if(num_a > 0)
+    // If we allow unsafe, this check is not done.
+    if(AllowUnsafe || idx_a < end_a)
     {
-        key_a = keys_shared[range.begin1];
+        key_a = keys_shared[idx_a];
     }
-    if(num_b > 0)
+    if(AllowUnsafe || idx_b < end_b)
     {
-        key_b = keys_shared[range.begin2];
+        key_b = keys_shared[idx_b];
     }
 
     ROCPRIM_UNROLL
@@ -117,47 +122,34 @@ void serial_merge(KeyType*       keys_shared,
     {
         // If we don't have any in b, we always take from a. Then, if we don't
         // have any in a, we take from b. Otherwise we take the smallest item.
-        //
-        // We're using the number of items left as a shortcut for comparing
-        // items.
-        const bool take_a = (num_b == 0) || ((num_a > 0) && !compare_function(key_b, key_a));
+        const bool take_a
+            = (idx_b >= end_b) || ((idx_a < end_a) && !compare_function(key_b, key_a));
 
         // Retrieve info about the smallest key.
-        const auto idx = take_a ? range.begin1 : range.begin2;
-        const auto num = take_a ? num_a : num_b;
+        const auto idx = take_a ? idx_a : idx_b;
+        const auto end = take_a ? end_a : end_b;
         const auto key = take_a ? key_a : key_b;
 
         // Output results.
         output_function(i, key, idx);
 
-        // Get the next key from the array that we consumed from. We need two
-        // seperate checks:
-        // 1) We need at least two items to read the next item, as we're already
-        //    pre-loaded one before we started looping.
-        // 2) We need at least one item to read from the input. Otherwise we
-        //    don't do anything!
-        const auto next_idx = num > 1 ? idx + 1 : idx;
-        const auto next_num = num > 0 ? num - 1 : num;
-
-        // We don't access out of range!
-        assert(next_idx < range.end2);
+        // Get the next idx, if we allow unsafe we may access out-of-bounds elements.
+        const auto next_idx = idx + 1;
 
         // Load the next item. The compiler *should* be smart enough to optimize
         // away the case where we don't have any items to read.
-        const auto next_key = keys_shared[next_idx];
+        const auto next_key = keys_shared[AllowUnsafe ? next_idx : min(next_idx, end - 1)];
 
         // Store the info about the next key.
         if(take_a)
         {
-            range.begin1 = next_idx;
-            key_a        = next_key;
-            num_a        = next_num;
+            idx_a = next_idx;
+            key_a = next_key;
         }
         else
         {
-            range.begin2 = next_idx;
-            key_b        = next_key;
-            num_b        = next_num;
+            idx_b = next_idx;
+            key_b = next_key;
         }
     }
 
@@ -165,7 +157,11 @@ void serial_merge(KeyType*       keys_shared,
     // warp granularity!
 }
 
-template<class KeyType, unsigned int ItemsPerThread, class BinaryFunction, class OffsetT>
+template<bool AllowUnsafe = false,
+         class KeyType,
+         unsigned int ItemsPerThread,
+         class BinaryFunction,
+         class OffsetT>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 void serial_merge(KeyType* keys_shared,
                   KeyType (&outputs)[ItemsPerThread],
@@ -173,30 +169,36 @@ void serial_merge(KeyType* keys_shared,
                   range_t<OffsetT> range,
                   BinaryFunction   compare_function)
 {
-    serial_merge<ItemsPerThread>(keys_shared,
-                                 range,
-                                 compare_function,
-                                 [&](OffsetT i, KeyType key, OffsetT index)
-                                 {
-                                     outputs[i] = key;
-                                     indices[i] = index;
-                                 });
+    serial_merge<ItemsPerThread, AllowUnsafe>(keys_shared,
+                                              range,
+                                              compare_function,
+                                              [&](OffsetT i, KeyType key, OffsetT index)
+                                              {
+                                                  outputs[i] = key;
+                                                  indices[i] = index;
+                                              });
 }
 
-template<class KeyType, unsigned int ItemsPerThread, class BinaryFunction, class OffsetT>
+template<bool AllowUnsafe = false,
+         class KeyType,
+         unsigned int ItemsPerThread,
+         class BinaryFunction,
+         class OffsetT>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 void serial_merge(KeyType* keys_shared,
                   KeyType (&outputs)[ItemsPerThread],
                   range_t<OffsetT> range,
                   BinaryFunction   compare_function)
 {
-    serial_merge<ItemsPerThread>(keys_shared,
-                                 range,
-                                 compare_function,
-                                 [&](OffsetT i, KeyType key, OffsetT) { outputs[i] = key; });
+    serial_merge<ItemsPerThread, AllowUnsafe>(keys_shared,
+                                              range,
+                                              compare_function,
+                                              [&](OffsetT i, KeyType key, OffsetT)
+                                              { outputs[i] = key; });
 }
 
-template<class KeyType,
+template<bool AllowUnsafe = false,
+         class KeyType,
          class ValueType,
          unsigned int ItemsPerThread,
          class BinaryFunction,
@@ -209,14 +211,14 @@ void serial_merge(KeyType* keys_shared,
                   range_t<OffsetT> range,
                   BinaryFunction   compare_function)
 {
-    serial_merge<ItemsPerThread>(keys_shared,
-                                 range,
-                                 compare_function,
-                                 [&](OffsetT i, KeyType key, OffsetT index)
-                                 {
-                                     outputs[i] = key;
-                                     values[i]  = values_shared[index];
-                                 });
+    serial_merge<ItemsPerThread, AllowUnsafe>(keys_shared,
+                                              range,
+                                              compare_function,
+                                              [&](OffsetT i, KeyType key, OffsetT index)
+                                              {
+                                                  outputs[i] = key;
+                                                  values[i]  = values_shared[index];
+                                              });
 }
 
 } // end namespace detail

--- a/rocprim/include/rocprim/detail/merge_path.hpp
+++ b/rocprim/include/rocprim/detail/merge_path.hpp
@@ -104,9 +104,13 @@ void serial_merge(KeyType*       keys_shared,
 
     // Only load valid keys, otherwise might be out of bounds!
     if(num_a > 0)
+    {
         key_a = keys_shared[range.begin1];
+    }
     if(num_b > 0)
+    {
         key_b = keys_shared[range.begin2];
+    }
 
     ROCPRIM_UNROLL
     for(OffsetT i = 0; i < ItemsPerThread; ++i)
@@ -156,6 +160,9 @@ void serial_merge(KeyType*       keys_shared,
             num_b        = next_num;
         }
     }
+
+    // We don't finish with a block sync since this may be used on thread or
+    // warp granularity!
 }
 
 template<class KeyType, unsigned int ItemsPerThread, class BinaryFunction, class OffsetT>

--- a/rocprim/include/rocprim/device/detail/device_merge.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge.hpp
@@ -142,8 +142,7 @@ void merge_keys(unsigned int       flat_id,
         keys_shared, range.count1(), range.count2()
     );
 
-    range_t<> range_local
-        = range_t<>{0, range.count1(), range.count1(), (range.count1() + range.count2())};
+    range_t<> range_local{0, range.count1(), range.count1(), (range.count1() + range.count2())};
 
     unsigned int diag = ItemsPerThread * flat_id;
     unsigned int partition =
@@ -156,10 +155,10 @@ void merge_keys(unsigned int       flat_id,
             compare_function
         );
 
-    range_t<> range_partition = range_t<>{range_local.begin1 + partition,
-                                          range_local.end1,
-                                          range_local.begin2 + diag - partition,
-                                          range_local.end2};
+    range_t<> range_partition{range_local.begin1 + partition,
+                              range_local.end1,
+                              range_local.begin2 + diag - partition,
+                              range_local.end2};
 
     serial_merge<false>(keys_shared, key_inputs, index, range_partition, compare_function);
 }

--- a/rocprim/include/rocprim/device/detail/device_merge.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge.hpp
@@ -161,7 +161,7 @@ void merge_keys(unsigned int       flat_id,
                                           range_local.begin2 + diag - partition,
                                           range_local.end2};
 
-    serial_merge(keys_shared, key_inputs, index, range_partition, compare_function);
+    serial_merge<true>(keys_shared, key_inputs, index, range_partition, compare_function);
 }
 
 template<

--- a/rocprim/include/rocprim/device/detail/device_merge.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge.hpp
@@ -40,17 +40,17 @@ namespace detail
 {
 
 ROCPRIM_DEVICE ROCPRIM_INLINE
-range_t compute_range(const unsigned int id,
-                      const unsigned int size1,
-                      const unsigned int size2,
-                      const unsigned int spacing,
-                      const unsigned int p1,
-                      const unsigned int p2)
+range_t<> compute_range(const unsigned int id,
+                        const unsigned int size1,
+                        const unsigned int size2,
+                        const unsigned int spacing,
+                        const unsigned int p1,
+                        const unsigned int p2)
 {
     unsigned int diag1 = id * spacing;
     unsigned int diag2 = min(size1 + size2, diag1 + spacing);
 
-    return range_t{p1, p2, diag1 - p1, diag2 - p2};
+    return range_t<>{p1, p2, diag1 - p1, diag2 - p2};
 }
 
 template<
@@ -121,22 +121,20 @@ void load(unsigned int flat_id,
     ::rocprim::syncthreads();
 }
 
-template<
-    unsigned int BlockSize,
-    class KeysInputIterator1,
-    class KeysInputIterator2,
-    class KeyType,
-    unsigned int ItemsPerThread,
-    class BinaryFunction
->
+template<unsigned int BlockSize,
+         class KeysInputIterator1,
+         class KeysInputIterator2,
+         class KeyType,
+         unsigned int ItemsPerThread,
+         class BinaryFunction>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-void merge_keys(unsigned int flat_id,
+void merge_keys(unsigned int       flat_id,
                 KeysInputIterator1 keys_input1,
                 KeysInputIterator2 keys_input2,
                 KeyType (&key_inputs)[ItemsPerThread],
                 unsigned int (&index)[ItemsPerThread],
-                KeyType * keys_shared,
-                range_t range,
+                KeyType*       keys_shared,
+                range_t<>      range,
                 BinaryFunction compare_function)
 {
     load<BlockSize, ItemsPerThread>(
@@ -144,11 +142,8 @@ void merge_keys(unsigned int flat_id,
         keys_shared, range.count1(), range.count2()
     );
 
-    range_t range_local =
-        range_t {
-            0, range.count1(), range.count1(),
-            (range.count1() + range.count2())
-        };
+    range_t<> range_local
+        = range_t<>{0, range.count1(), range.count1(), (range.count1() + range.count2())};
 
     unsigned int diag = ItemsPerThread * flat_id;
     unsigned int partition =
@@ -161,18 +156,12 @@ void merge_keys(unsigned int flat_id,
             compare_function
         );
 
-    range_t range_partition =
-        range_t {
-            range_local.begin1 + partition,
-            range_local.end1,
-            range_local.begin2 + diag - partition,
-            range_local.end2
-        };
+    range_t<> range_partition = range_t<>{range_local.begin1 + partition,
+                                          range_local.end1,
+                                          range_local.begin2 + diag - partition,
+                                          range_local.end2};
 
-    serial_merge(
-        keys_shared, key_inputs, index, range_partition,
-        compare_function
-    );
+    serial_merge(keys_shared, key_inputs, index, range_partition, compare_function);
 }
 
 template<
@@ -316,11 +305,8 @@ void merge_kernel_impl(IndexIterator indices,
     const unsigned int p1 = indices[rocprim::min(flat_block_id, partitions)];
     const unsigned int p2 = indices[rocprim::min(flat_block_id + 1, partitions)];
 
-    range_t range =
-        compute_range(
-            flat_block_id, input1_size, input2_size, items_per_block,
-            p1, p2
-        );
+    range_t<> range
+        = compute_range(flat_block_id, input1_size, input2_size, items_per_block, p1, p2);
 
     merge_keys<BlockSize>(
         flat_id, keys_input1, keys_input2, input, index,

--- a/rocprim/include/rocprim/device/detail/device_merge.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge.hpp
@@ -161,7 +161,7 @@ void merge_keys(unsigned int       flat_id,
                                           range_local.begin2 + diag - partition,
                                           range_local.end2};
 
-    serial_merge<true>(keys_shared, key_inputs, index, range_partition, compare_function);
+    serial_merge<false>(keys_shared, key_inputs, index, range_partition, compare_function);
 }
 
 template<

--- a/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
@@ -192,10 +192,10 @@ namespace detail
         const unsigned int keys1_end_local = num_keys1;
         const unsigned int keys2_beg_local = diag0_local - keys1_beg_local;
         const unsigned int keys2_end_local = num_keys2;
-        range_t range_local = {keys1_beg_local,
-                               keys1_end_local,
-                               keys2_beg_local + keys1_end_local,
-                               keys2_end_local + keys1_end_local};
+        range_t<>          range_local     = {keys1_beg_local,
+                                              keys1_end_local,
+                                              keys2_beg_local + keys1_end_local,
+                                              keys2_end_local + keys1_end_local};
 
         unsigned int indices[ItemsPerThread];
 
@@ -330,10 +330,10 @@ namespace detail
         const unsigned int keys1_end_local = num_keys1;
         const unsigned int keys2_beg_local = diag0_local - keys1_beg_local;
         const unsigned int keys2_end_local = num_keys2;
-        range_t range_local = {keys1_beg_local,
-                               keys1_end_local,
-                               keys2_beg_local + keys1_end_local,
-                               keys2_end_local + keys1_end_local};
+        range_t<>          range_local     = {keys1_beg_local,
+                                              keys1_end_local,
+                                              keys2_beg_local + keys1_end_local,
+                                              keys2_end_local + keys1_end_local};
 
         unsigned int indices[ItemsPerThread];
 

--- a/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
@@ -192,10 +192,11 @@ namespace detail
         const unsigned int keys1_end_local = num_keys1;
         const unsigned int keys2_beg_local = diag0_local - keys1_beg_local;
         const unsigned int keys2_end_local = num_keys2;
-        range_t<>          range_local     = {keys1_beg_local,
-                                              keys1_end_local,
-                                              keys2_beg_local + keys1_end_local,
-                                              keys2_end_local + keys1_end_local};
+
+        range_t<> range_local{keys1_beg_local,
+                              keys1_end_local,
+                              keys2_beg_local + keys1_end_local,
+                              keys2_end_local + keys1_end_local};
 
         unsigned int indices[ItemsPerThread];
 
@@ -326,10 +327,11 @@ namespace detail
         const unsigned int keys1_end_local = num_keys1;
         const unsigned int keys2_beg_local = diag0_local - keys1_beg_local;
         const unsigned int keys2_end_local = num_keys2;
-        range_t<>          range_local     = {keys1_beg_local,
-                                              keys1_end_local,
-                                              keys2_beg_local + keys1_end_local,
-                                              keys2_end_local + keys1_end_local};
+
+        range_t<> range_local{keys1_beg_local,
+                              keys1_end_local,
+                              keys2_beg_local + keys1_end_local,
+                              keys2_end_local + keys1_end_local};
 
         unsigned int indices[ItemsPerThread];
 

--- a/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
@@ -199,11 +199,7 @@ namespace detail
 
         unsigned int indices[ItemsPerThread];
 
-        serial_merge(keys_shared,
-                     keys,
-                     indices,
-                     range_local,
-                     compare_function);
+        serial_merge<true>(keys_shared, keys, indices, range_local, compare_function);
 
         if ROCPRIM_IF_CONSTEXPR(with_values){
             reg_to_shared<BlockSize, ItemsPerThread>(values_shared, values);
@@ -337,11 +333,7 @@ namespace detail
 
         unsigned int indices[ItemsPerThread];
 
-        serial_merge(keys_shared,
-                     keys,
-                     indices,
-                     range_local,
-                     compare_function);
+        serial_merge<true>(keys_shared, keys, indices, range_local, compare_function);
 
         if ROCPRIM_IF_CONSTEXPR(with_values)
         {

--- a/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
@@ -199,7 +199,7 @@ namespace detail
 
         unsigned int indices[ItemsPerThread];
 
-        serial_merge<true>(keys_shared, keys, indices, range_local, compare_function);
+        serial_merge<false>(keys_shared, keys, indices, range_local, compare_function);
 
         if ROCPRIM_IF_CONSTEXPR(with_values){
             reg_to_shared<BlockSize, ItemsPerThread>(values_shared, values);
@@ -333,7 +333,7 @@ namespace detail
 
         unsigned int indices[ItemsPerThread];
 
-        serial_merge<true>(keys_shared, keys, indices, range_local, compare_function);
+        serial_merge<false>(keys_shared, keys, indices, range_local, compare_function);
 
         if ROCPRIM_IF_CONSTEXPR(with_values)
         {

--- a/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
+++ b/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
@@ -201,6 +201,7 @@ namespace detail
         unsigned int indices[ItemsPerThread];
 
         serial_merge<false>(keys_shared, keys, indices, range_local, compare_function);
+        rocprim::syncthreads();
 
         if ROCPRIM_IF_CONSTEXPR(with_values){
             reg_to_shared<BlockSize, ItemsPerThread>(values_shared, values);
@@ -336,6 +337,7 @@ namespace detail
         unsigned int indices[ItemsPerThread];
 
         serial_merge<false>(keys_shared, keys, indices, range_local, compare_function);
+        rocprim::syncthreads();
 
         if ROCPRIM_IF_CONSTEXPR(with_values)
         {

--- a/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
@@ -24,6 +24,7 @@
 #include <type_traits>
 
 #include "../../config.hpp"
+#include "../../detail/merge_path.hpp"
 #include "../../detail/various.hpp"
 
 #include "../../functional.hpp"
@@ -161,7 +162,7 @@ private:
                 keys2_end,
             };
 
-            serial_merge(shared_keys, thread_keys, range, compare_function);
+            serial_merge<true>(shared_keys, thread_keys, range, compare_function);
 
             wave_barrier();
         }
@@ -222,12 +223,12 @@ private:
                 keys2_end,
             };
 
-            serial_merge(shared_keys,
-                         thread_keys,
-                         shared_values,
-                         thread_values,
-                         range,
-                         compare_function);
+            serial_merge<true>(shared_keys,
+                               thread_keys,
+                               shared_values,
+                               thread_values,
+                               range,
+                               compare_function);
 
             wave_barrier();
         }

--- a/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
@@ -162,7 +162,7 @@ private:
                 keys2_end,
             };
 
-            serial_merge<true>(shared_keys, thread_keys, range, compare_function);
+            serial_merge<false>(shared_keys, thread_keys, range, compare_function);
 
             wave_barrier();
         }
@@ -223,12 +223,12 @@ private:
                 keys2_end,
             };
 
-            serial_merge<true>(shared_keys,
-                               thread_keys,
-                               shared_values,
-                               thread_values,
-                               range,
-                               compare_function);
+            serial_merge<false>(shared_keys,
+                                thread_keys,
+                                shared_values,
+                                thread_values,
+                                range,
+                                compare_function);
 
             wave_barrier();
         }

--- a/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
@@ -155,7 +155,7 @@ private:
             const auto keys1_merge_begin = keys1_begin + partition;
             const auto keys2_merge_begin = keys2_begin + diag - partition;
 
-            const range_t<> range = {
+            const range_t<> range{
                 keys1_merge_begin,
                 keys1_end,
                 keys2_merge_begin,
@@ -216,7 +216,7 @@ private:
             const auto keys1_merge_begin = keys1_begin + partition;
             const auto keys2_merge_begin = keys2_begin + diag - partition;
 
-            const range_t<> range = {
+            const range_t<> range{
                 keys1_merge_begin,
                 keys1_end,
                 keys2_merge_begin,

--- a/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
@@ -154,7 +154,7 @@ private:
             const auto keys1_merge_begin = keys1_begin + partition;
             const auto keys2_merge_begin = keys2_begin + diag - partition;
 
-            const range_t range = {
+            const range_t<> range = {
                 keys1_merge_begin,
                 keys1_end,
                 keys2_merge_begin,
@@ -215,7 +215,7 @@ private:
             const auto keys1_merge_begin = keys1_begin + partition;
             const auto keys2_merge_begin = keys2_begin + diag - partition;
 
-            const range_t range = {
+            const range_t<> range = {
                 keys1_merge_begin,
                 keys1_end,
                 keys2_merge_begin,

--- a/test/rocprim/CMakeLists.txt
+++ b/test/rocprim/CMakeLists.txt
@@ -231,8 +231,7 @@ endfunction()
 # Tests
 # ****************************************************************************
 
-# add_subdirectory("internal")
-
+# Internal test to check internal behaviour
 add_rocprim_test("rocprim.internal_merge_path" "internal/test_internal_merge_path.cpp")
 
 # HIP basic test, which also checks if there are no linkage problems when there are multiple sources

--- a/test/rocprim/CMakeLists.txt
+++ b/test/rocprim/CMakeLists.txt
@@ -231,6 +231,10 @@ endfunction()
 # Tests
 # ****************************************************************************
 
+# add_subdirectory("internal")
+
+add_rocprim_test("rocprim.internal_merge_path" "internal/test_internal_merge_path.cpp")
+
 # HIP basic test, which also checks if there are no linkage problems when there are multiple sources
 add_rocprim_test("rocprim.basic_test" "test_basic.cpp;detail/get_rocprim_version.cpp")
 

--- a/test/rocprim/internal/CMakeLists.txt
+++ b/test/rocprim/internal/CMakeLists.txt
@@ -1,0 +1,23 @@
+# MIT License
+#
+# Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+add_rocprim_test("rocprim.internal.merge_path" test_internal_merge_path.hpp)

--- a/test/rocprim/internal/test_internal_merge_path.cpp
+++ b/test/rocprim/internal/test_internal_merge_path.cpp
@@ -3,10 +3,8 @@
 #include "../test_utils_assertions.hpp"
 #include "../test_utils_data_generation.hpp"
 
+#include <rocprim/block/block_store_func.hpp>
 #include <rocprim/detail/merge_path.hpp>
-#include <rocprim/rocprim.hpp>
-
-#include <hip/driver_types.h>
 
 template<int IPT, class T, class Op>
 __global__

--- a/test/rocprim/internal/test_internal_merge_path.cpp
+++ b/test/rocprim/internal/test_internal_merge_path.cpp
@@ -10,7 +10,7 @@
 
 template<int IPT, class T, class Op>
 __global__
-void merge_kernel(T* shared, rocprim::detail::range_t range, Op compare_function)
+void merge_kernel(T* shared, rocprim::detail::range_t<> range, Op compare_function)
 {
     T outputs[IPT];
 
@@ -34,7 +34,7 @@ void serial_merge(std::vector<T>& input,
     HIP_CHECK(hipMemcpy(device_data, input.data(), num_bytes, hipMemcpyHostToDevice));
 
     merge_kernel<IPT>
-        <<<1, 1>>>(device_data, rocprim::detail::range_t{0, mid, mid, N}, compare_function);
+        <<<1, 1>>>(device_data, rocprim::detail::range_t<>{0, mid, mid, N}, compare_function);
     HIP_CHECK(hipGetLastError());
 
     HIP_CHECK(hipMemcpy(output.data(), device_data, num_bytes, hipMemcpyDeviceToHost));

--- a/test/rocprim/internal/test_internal_merge_path.cpp
+++ b/test/rocprim/internal/test_internal_merge_path.cpp
@@ -1,0 +1,66 @@
+
+#include "../../common_test_header.hpp"
+#include "../test_utils_assertions.hpp"
+#include "../test_utils_data_generation.hpp"
+
+#include <rocprim/detail/merge_path.hpp>
+#include <rocprim/rocprim.hpp>
+
+#include <hip/driver_types.h>
+
+template<int IPT, class T, class Op>
+__global__
+void merge_kernel(T* shared, rocprim::detail::range_t range, Op compare_function)
+{
+    T outputs[IPT];
+
+    rocprim::detail::serial_merge(shared, outputs, range, compare_function);
+
+    rocprim::block_store_direct_blocked(0, shared, outputs, range.end2);
+}
+
+template<int IPT, int N, class T, class OpT>
+void serial_merge(std::vector<T>& input,
+                  std::vector<T>& output,
+                  unsigned int    mid,
+                  OpT             compare_function)
+{
+    static_assert(IPT >= N, "Kernel must be launched such that all items can be processed!");
+
+    size_t num_bytes = sizeof(T) * N;
+    T*     device_data;
+
+    HIP_CHECK(hipMalloc(&device_data, num_bytes));
+    HIP_CHECK(hipMemcpy(device_data, input.data(), num_bytes, hipMemcpyHostToDevice));
+
+    merge_kernel<IPT>
+        <<<1, 1>>>(device_data, rocprim::detail::range_t{0, mid, mid, N}, compare_function);
+    HIP_CHECK(hipGetLastError());
+
+    HIP_CHECK(hipMemcpy(output.data(), device_data, num_bytes, hipMemcpyDeviceToHost));
+}
+
+TEST(RocprimInternalMergePathTests, Basic)
+{
+    using T   = int;
+    using OpT = rocprim::less<T>;
+
+    constexpr int n   = 512;
+    constexpr int m   = n / 3;
+    constexpr int ipt = 2 * n;
+
+    std::vector<T> x = test_utils::get_random_data<T>(n,
+                                                      std::numeric_limits<T>::min(),
+                                                      std::numeric_limits<T>::max(),
+                                                      0);
+    std::vector<T> y(n);
+
+    std::sort(x.begin(), x.begin() + m);
+    std::sort(x.begin() + m, x.end());
+
+    serial_merge<ipt, n>(x, y, m, OpT{});
+
+    std::sort(x.begin(), x.end());
+
+    test_utils::assert_eq(x, y);
+}


### PR DESCRIPTION
This PR fixes a rare bug with serial merge where the data pre-loading looks too far ahead which may happen when merging less items than the number of items per thread. In extreme cases this causes a memory access fault where a requested page is not available. This change modifies serial merge to have strict checking when values are allowed to be pre-loaded. The function has a template argument to restore the old unsafe behaviour.

It affects any algorithm that uses serial merge:
- block sort,
- device merge sort (block merge),
- device merge,
- device partial sort,
- device sort (merge sort).

Performance regression should be between 0-5%, tested on gfx906 ([results_gfx906.zip](https://github.com/user-attachments/files/16694351/results_gfx906.zip)), gfx908 ([results_gfx908.zip](https://github.com/user-attachments/files/16694354/results_gfx908.zip)), and gfx1030 ([results_gfx1030.zip](https://github.com/user-attachments/files/16694358/results_gfx1030.zip)).
