### PR TITLE
Remove website URL from comments

### DIFF
--- a/scripts/copyright-date/check-copyright.sh
+++ b/scripts/copyright-date/check-copyright.sh
@@ -61,7 +61,6 @@ if $forkdiff; then
     source_commit="remotes/$remote/HEAD"
 
     # don't use fork-point for finding fork point (lol)
-    # see: https://stackoverflow.com/a/53981615
     diff_hash="$(git merge-base "$source_commit" "$branch")"
 fi
 


### PR DESCRIPTION
Referencing or using code from some websites is prohibited in this repository. This change removes an informational reference in the comments.