### PR TITLE
Fix data generation in benchmarks

### DIFF
--- a/benchmark/benchmark_block_radix_rank.cpp
+++ b/benchmark/benchmark_block_radix_rank.cpp
@@ -103,18 +103,10 @@ void run_benchmark(benchmark::State& state, size_t N, const managed_seed& seed, 
     const unsigned int     grid_size       = ((N + items_per_block - 1) / items_per_block);
     const unsigned int     size            = items_per_block * grid_size;
 
-    std::vector<T> input;
-    if ROCPRIM_IF_CONSTEXPR(std::is_floating_point<T>::value)
-    {
-        input = get_random_data<T>(size, static_cast<T>(-1000), static_cast<T>(1000), seed.get_0());
-    }
-    else
-    {
-        input = get_random_data<T>(size,
-                                   std::numeric_limits<T>::min(),
-                                   std::numeric_limits<T>::max(),
-                                   seed.get_0());
-    }
+    std::vector<T> input = get_random_data<T>(size,
+                                              generate_limits<T>::min(),
+                                              generate_limits<T>::max(),
+                                              seed.get_0());
 
     T*            d_input;
     unsigned int* d_output;

--- a/benchmark/benchmark_block_radix_sort.cpp
+++ b/benchmark/benchmark_block_radix_sort.cpp
@@ -136,19 +136,12 @@ void run_benchmark(benchmark::State&   state,
     constexpr auto items_per_block = BlockSize * ItemsPerThread;
     const auto size = items_per_block * ((N + items_per_block - 1)/items_per_block);
 
-    std::vector<T> input;
-    if(std::is_floating_point<T>::value)
-    {
-        input = get_random_data<T>(size, static_cast<T>(-1000), static_cast<T>(1000), seed.get_0());
-    }
-    else
-    {
-        input = get_random_data<T>(size,
-                                   std::numeric_limits<T>::min(),
-                                   std::numeric_limits<T>::max(),
-                                   seed.get_0());
-    }
-    T * d_input;
+    std::vector<T> input = get_random_data<T>(size,
+                                              generate_limits<T>::min(),
+                                              generate_limits<T>::max(),
+                                              seed.get_0());
+
+    T*  d_input;
     T * d_output;
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_input), size * sizeof(T)));
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_output), size * sizeof(T)));

--- a/benchmark/benchmark_block_sort.parallel.hpp
+++ b/benchmark/benchmark_block_sort.parallel.hpp
@@ -234,21 +234,11 @@ public:
     {
         const auto size = items_per_block * ((N + items_per_block - 1) / items_per_block);
 
-        std::vector<KeyType> input;
-        if(std::is_floating_point<KeyType>::value)
-        {
-            input = get_random_data<KeyType>(size,
-                                             static_cast<KeyType>(-1000),
-                                             static_cast<KeyType>(1000),
-                                             seed.get_0());
-        }
-        else
-        {
-            input = get_random_data<KeyType>(size,
-                                             std::numeric_limits<KeyType>::min(),
-                                             std::numeric_limits<KeyType>::max(),
-                                             seed.get_0());
-        }
+        std::vector<KeyType> input = get_random_data<KeyType>(size,
+                                                              generate_limits<KeyType>::min(),
+                                                              generate_limits<KeyType>::max(),
+                                                              seed.get_0());
+
         KeyType* d_input;
         KeyType* d_output;
         HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_input), size * sizeof(KeyType)));

--- a/benchmark/benchmark_device_memory.cpp
+++ b/benchmark/benchmark_device_memory.cpp
@@ -335,19 +335,12 @@ void run_benchmark(benchmark::State&   state,
                    const managed_seed& seed,
                    const hipStream_t   stream)
 {
-    const size_t grid_size = size / (BlockSize * ItemsPerThread);
-    std::vector<T> input;
-    if(std::is_floating_point<T>::value)
-    {
-        input = get_random_data<T>(size, static_cast<T>(-1000), static_cast<T>(1000), seed.get_0());
-    }
-    else
-    {
-        input = get_random_data<T>(size,
-                                   std::numeric_limits<T>::min(),
-                                   std::numeric_limits<T>::max(),
-                                   seed.get_0());
-    }
+    const size_t   grid_size = size / (BlockSize * ItemsPerThread);
+    std::vector<T> input     = get_random_data<T>(size,
+                                              generate_limits<T>::min(),
+                                              generate_limits<T>::max(),
+                                              seed.get_0());
+
     T * d_input;
     T * d_output;
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_input), size * sizeof(T)));

--- a/benchmark/benchmark_device_merge_sort.hpp
+++ b/benchmark/benchmark_device_merge_sort.hpp
@@ -67,21 +67,11 @@ struct device_merge_sort_benchmark : public config_autotune_interface
         using key_type = Key;
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         key_type* d_keys_input;
         key_type* d_keys_output;
@@ -177,21 +167,11 @@ struct device_merge_sort_benchmark : public config_autotune_interface
         using value_type = Value;
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         std::vector<value_type> values_input(size);
         std::iota(values_input.begin(), values_input.end(), 0);

--- a/benchmark/benchmark_device_merge_sort_block_merge.parallel.hpp
+++ b/benchmark/benchmark_device_merge_sort_block_merge.parallel.hpp
@@ -88,21 +88,11 @@ struct device_merge_sort_block_merge_benchmark : public config_autotune_interfac
         using key_type = Key;
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         key_type* d_keys_input;
         key_type* d_keys;
@@ -231,21 +221,12 @@ struct device_merge_sort_block_merge_benchmark : public config_autotune_interfac
         using value_type = Value;
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
+
         std::vector<value_type> values_input(size);
         std::iota(values_input.begin(), values_input.end(), 0);
 

--- a/benchmark/benchmark_device_merge_sort_block_sort.parallel.hpp
+++ b/benchmark/benchmark_device_merge_sort_block_sort.parallel.hpp
@@ -97,21 +97,11 @@ struct device_merge_sort_block_sort_benchmark : public config_autotune_interface
         using key_type = Key;
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         key_type* d_keys_input;
         key_type* d_keys_output;
@@ -195,21 +185,11 @@ struct device_merge_sort_block_sort_benchmark : public config_autotune_interface
         using value_type = Value;
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         std::vector<value_type> values_input(size);
         std::iota(values_input.begin(), values_input.end(), 0);

--- a/benchmark/benchmark_device_nth_element.hpp
+++ b/benchmark/benchmark_device_nth_element.hpp
@@ -75,21 +75,11 @@ struct device_nth_element_benchmark : public config_autotune_interface
         }
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         key_type* d_keys_input;
         key_type* d_keys_output;

--- a/benchmark/benchmark_device_partial_sort.hpp
+++ b/benchmark/benchmark_device_partial_sort.hpp
@@ -75,21 +75,11 @@ struct device_partial_sort_benchmark : public config_autotune_interface
         }
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         key_type* d_keys_input;
         key_type* d_keys_new_data;

--- a/benchmark/benchmark_device_partial_sort_copy.hpp
+++ b/benchmark/benchmark_device_partial_sort_copy.hpp
@@ -75,21 +75,11 @@ struct device_partial_sort_copy_benchmark : public config_autotune_interface
         }
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         key_type* d_keys_input;
         key_type* d_keys_output;

--- a/benchmark/benchmark_device_partition.parallel.hpp
+++ b/benchmark/benchmark_device_partition.parallel.hpp
@@ -135,21 +135,10 @@ struct device_partition_flag_benchmark : public config_autotune_interface
              const managed_seed& seed,
              const hipStream_t   stream) const override
     {
-        std::vector<DataType> input;
-        if(std::is_floating_point<DataType>::value)
-        {
-            input = get_random_data<DataType>(size,
-                                              static_cast<DataType>(-1000),
-                                              static_cast<DataType>(1000),
-                                              seed.get_0());
-        }
-        else
-        {
-            input = get_random_data<DataType>(size,
-                                              std::numeric_limits<DataType>::min(),
-                                              std::numeric_limits<DataType>::max(),
-                                              seed.get_0());
-        }
+        std::vector<DataType> input = get_random_data<DataType>(size,
+                                                                generate_limits<DataType>::min(),
+                                                                generate_limits<DataType>::max(),
+                                                                seed.get_0());
 
         std::vector<FlagType> flags_0;
         std::vector<FlagType> flags_1;
@@ -309,7 +298,7 @@ struct device_partition_predicate_benchmark : public config_autotune_interface
         {
             const auto dispatch_predicate = [&](float probability)
             {
-                auto predicate = [probability] __device__(const DataType& value) -> bool
+                auto predicate = [probability](const DataType& value) -> bool
                 { return value < static_cast<DataType>(127 * probability); };
                 HIP_CHECK(rocprim::partition<Config>(d_temp_storage,
                                                      temp_storage_size_bytes,
@@ -401,21 +390,10 @@ struct device_partition_two_way_flag_benchmark : public config_autotune_interfac
              const managed_seed& seed,
              const hipStream_t   stream) const override
     {
-        std::vector<DataType> input;
-        if(std::is_floating_point<DataType>::value)
-        {
-            input = get_random_data<DataType>(size,
-                                              static_cast<DataType>(-1000),
-                                              static_cast<DataType>(1000),
-                                              seed.get_0());
-        }
-        else
-        {
-            input = get_random_data<DataType>(size,
-                                              std::numeric_limits<DataType>::min(),
-                                              std::numeric_limits<DataType>::max(),
-                                              seed.get_0());
-        }
+        std::vector<DataType> input = get_random_data<DataType>(size,
+                                                                generate_limits<DataType>::min(),
+                                                                generate_limits<DataType>::max(),
+                                                                seed.get_0());
 
         std::vector<FlagType> flags_0;
         std::vector<FlagType> flags_1;
@@ -583,7 +561,7 @@ struct device_partition_two_way_predicate_benchmark : public config_autotune_int
         {
             const auto dispatch_predicate = [&](float probability)
             {
-                auto predicate = [probability] __device__(const DataType& value) -> bool
+                auto predicate = [probability](const DataType& value) -> bool
                 { return value < static_cast<DataType>(127 * probability); };
                 HIP_CHECK(rocprim::partition_two_way<Config>(d_temp_storage,
                                                              temp_storage_size_bytes,
@@ -701,10 +679,10 @@ struct device_partition_three_way_benchmark : public config_autotune_interface
             const auto dispatch_predicate = [&](std::pair<float, float> probability)
             {
                 const float probability_one = probability.first;
-                auto        predicate_one   = [probability_one] __device__(const DataType& value)
+                auto        predicate_one   = [probability_one](const DataType& value)
                 { return value < DataType(127 * probability_one); };
                 const float probability_two = probability.second;
-                auto        predicate_two   = [probability_two] __device__(const DataType& value)
+                auto        predicate_two   = [probability_two](const DataType& value)
                 { return value < DataType(127 * probability_two); };
 
                 HIP_CHECK(rocprim::partition_three_way<Config>(d_temp_storage,

--- a/benchmark/benchmark_device_radix_sort.hpp
+++ b/benchmark/benchmark_device_radix_sort.hpp
@@ -57,28 +57,6 @@ struct device_radix_sort_benchmark : public config_autotune_interface
     static constexpr unsigned int batch_size  = 10;
     static constexpr unsigned int warmup_size = 5;
 
-    static std::vector<Key> generate_keys(size_t size, unsigned int seed)
-    {
-        using key_type = Key;
-
-        if(std::is_floating_point<key_type>::value)
-        {
-            return get_random_data<key_type>(size,
-                                             static_cast<key_type>(-1000),
-                                             static_cast<key_type>(1000),
-                                             seed,
-                                             size);
-        }
-        else
-        {
-            return get_random_data<key_type>(size,
-                                             std::numeric_limits<key_type>::min(),
-                                             std::numeric_limits<key_type>::max(),
-                                             seed,
-                                             size);
-        }
-    }
-
     // keys benchmark
     template<typename val = Value>
     auto do_run(benchmark::State&   state,
@@ -87,9 +65,13 @@ struct device_radix_sort_benchmark : public config_autotune_interface
                 hipStream_t         stream) const
         -> std::enable_if_t<std::is_same<val, ::rocprim::empty_type>::value, void>
     {
-        auto keys_input = generate_keys(size, seed.get_0());
-
         using key_type = Key;
+
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         key_type* d_keys_input;
         key_type* d_keys_output;
@@ -180,10 +162,14 @@ struct device_radix_sort_benchmark : public config_autotune_interface
                 hipStream_t         stream) const
         -> std::enable_if_t<!std::is_same<val, ::rocprim::empty_type>::value, void>
     {
-        auto keys_input = generate_keys(size, seed.get_0());
-
         using key_type   = Key;
         using value_type = Value;
+
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         std::vector<value_type> values_input(size);
         for(size_t i = 0; i < size; i++)

--- a/benchmark/benchmark_device_radix_sort_block_sort.parallel.hpp
+++ b/benchmark/benchmark_device_radix_sort_block_sort.parallel.hpp
@@ -82,21 +82,11 @@ struct device_radix_sort_block_sort_benchmark : public config_autotune_interface
         using key_type = Key;
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         key_type* d_keys_input;
         key_type* d_keys_output;
@@ -184,21 +174,11 @@ struct device_radix_sort_block_sort_benchmark : public config_autotune_interface
         using value_type = Value;
 
         // Generate data
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         std::vector<value_type> values_input(size);
         for(size_t i = 0; i < size; i++)

--- a/benchmark/benchmark_device_segmented_radix_sort_keys.cpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_keys.cpp
@@ -94,21 +94,11 @@ void run_sort_keys_benchmark(benchmark::State&   state,
     const size_t size           = offset;
     const size_t segments_count = offsets.size() - 1;
 
-    std::vector<key_type> keys_input;
-    if(std::is_floating_point<key_type>::value)
-    {
-        keys_input = get_random_data<key_type>(size,
-                                               static_cast<key_type>(-1000),
-                                               static_cast<key_type>(1000),
-                                               seed.get_0());
-    }
-    else
-    {
-        keys_input = get_random_data<key_type>(size,
-                                               std::numeric_limits<key_type>::min(),
-                                               std::numeric_limits<key_type>::max(),
-                                               seed.get_0());
-    }
+    std::vector<key_type> keys_input = get_random_data<key_type>(size,
+                                                                 generate_limits<key_type>::min(),
+                                                                 generate_limits<key_type>::max(),
+                                                                 seed.get_0());
+
     size_t batch_size = 1;
     if(size < target_size)
     {

--- a/benchmark/benchmark_device_segmented_radix_sort_keys.parallel.hpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_keys.parallel.hpp
@@ -122,21 +122,12 @@ struct device_segmented_radix_sort_benchmark : public config_autotune_interface
         const size_t size           = offset;
         const size_t segments_count = offsets.size() - 1;
 
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
+
         size_t batch_size = 1;
         if(size < target_size)
         {

--- a/benchmark/benchmark_device_segmented_radix_sort_pairs.cpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_pairs.cpp
@@ -96,21 +96,11 @@ void run_sort_pairs_benchmark(benchmark::State&   state,
     const size_t size           = offset;
     const size_t segments_count = offsets.size() - 1;
 
-    std::vector<key_type> keys_input;
-    if(std::is_floating_point<key_type>::value)
-    {
-        keys_input = get_random_data<key_type>(size,
-                                               static_cast<key_type>(-1000),
-                                               static_cast<key_type>(1000),
-                                               seed.get_0());
-    }
-    else
-    {
-        keys_input = get_random_data<key_type>(size,
-                                               std::numeric_limits<key_type>::min(),
-                                               std::numeric_limits<key_type>::max(),
-                                               seed.get_0());
-    }
+    std::vector<key_type> keys_input = get_random_data<key_type>(size,
+                                                                 generate_limits<key_type>::min(),
+                                                                 generate_limits<key_type>::max(),
+                                                                 seed.get_0());
+
     size_t batch_size = 1;
     if(size < target_size)
     {

--- a/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.hpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.hpp
@@ -124,37 +124,17 @@ struct device_segmented_radix_sort_benchmark : public config_autotune_interface
         const size_t size           = offset;
         const size_t segments_count = offsets.size() - 1;
 
-        std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   static_cast<key_type>(-1000),
-                                                   static_cast<key_type>(1000),
-                                                   seed.get_0());
-        }
-        else
-        {
-            keys_input = get_random_data<key_type>(size,
-                                                   std::numeric_limits<key_type>::min(),
-                                                   std::numeric_limits<key_type>::max(),
-                                                   seed.get_0());
-        }
+        std::vector<key_type> keys_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
-        std::vector<value_type> values_input;
-        if(std::is_floating_point<value_type>::value)
-        {
-            values_input = get_random_data<value_type>(size,
-                                                       static_cast<value_type>(-1000),
-                                                       static_cast<value_type>(1000),
-                                                       seed.get_1());
-        }
-        else
-        {
-            values_input = get_random_data<value_type>(size,
-                                                       std::numeric_limits<value_type>::min(),
-                                                       std::numeric_limits<value_type>::max(),
-                                                       seed.get_1());
-        }
+        std::vector<value_type> values_input
+            = get_random_data<key_type>(size,
+                                        generate_limits<key_type>::min(),
+                                        generate_limits<key_type>::max(),
+                                        seed.get_0());
 
         size_t batch_size = 1;
         if(size < target_size)

--- a/benchmark/benchmark_device_select.parallel.hpp
+++ b/benchmark/benchmark_device_select.parallel.hpp
@@ -98,18 +98,10 @@ struct device_select_flag_benchmark : public config_autotune_interface
              const managed_seed& seed,
              hipStream_t         stream) const override
     {
-        std::vector<DataType> input;
-        if(std::is_floating_point<DataType>::value)
-        {
-            input = get_random_data<DataType>(size, DataType(-1000), DataType(1000), seed.get_0());
-        }
-        else
-        {
-            input = get_random_data<DataType>(size,
-                                              std::numeric_limits<DataType>::min(),
-                                              std::numeric_limits<DataType>::max(),
-                                              seed.get_0());
-        }
+        std::vector<DataType> input = get_random_data<DataType>(size,
+                                                                generate_limits<DataType>::min(),
+                                                                generate_limits<DataType>::max(),
+                                                                seed.get_0());
 
         std::vector<FlagType> flags_0;
         std::vector<FlagType> flags_1;
@@ -269,7 +261,7 @@ struct device_select_predicate_benchmark : public config_autotune_interface
         {
             const auto dispatch_predicate = [&](float probability)
             {
-                auto predicate = [probability] __device__(const DataType& value) -> bool
+                auto predicate = [probability](const DataType& value) -> bool
                 { return value < static_cast<DataType>(127 * probability); };
                 HIP_CHECK(rocprim::select<Config>(d_temp_storage,
                                                   temp_storage_size_bytes,

--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -329,6 +329,50 @@ struct custom_type_decomposer
     }
 };
 
+template<class T, class enable = void>
+struct generate_limits;
+
+template<class T>
+struct generate_limits<T, std::enable_if_t<rocprim::is_integral<T>::value>>
+{
+    static inline T min()
+    {
+        return std::numeric_limits<T>::min();
+    }
+    static inline T max()
+    {
+        return std::numeric_limits<T>::max();
+    }
+};
+
+template<class T>
+struct generate_limits<T, std::enable_if_t<is_custom_type<T>::value>>
+{
+    using F = typename T::first_type;
+    using S = typename T::second_type;
+    static inline T min()
+    {
+        return T(generate_limits<F>::min(), generate_limits<S>::min());
+    }
+    static inline T max()
+    {
+        return T(generate_limits<F>::max(), generate_limits<S>::max());
+    }
+};
+
+template<class T>
+struct generate_limits<T, std::enable_if_t<rocprim::is_floating_point<T>::value>>
+{
+    static inline T min()
+    {
+        return T(-1000);
+    }
+    static inline T max()
+    {
+        return T(1000);
+    }
+};
+
 template<class OutputIterator, class Generator>
 inline auto generate_random_data_n(OutputIterator             it,
                                    size_t                     size,


### PR DESCRIPTION
Add new generate_limit tool to fix numeric_limits not working on custom types and rocprim::half. Currently numeric_limits returns zero for these types, which generates data with all zeroes.