### PR TITLE
Memory leak fix for multiple rocPRIM unit  tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Documentation for rocPRIM is available at
   * device merge,
   * device partial sort, and/or
   * device sort (merge sort).
+* Fixed memory leaks in unit tests that were due to missing hipFree calls and incorrect use of hipGraphs
 
 ### Deprecations
 

--- a/test/hipgraph/test_hipgraph_algs.cpp
+++ b/test/hipgraph/test_hipgraph_algs.cpp
@@ -208,7 +208,7 @@ TEST(TestHipGraphAlgs, SortAndSearch)
         
         // Launch the graph
         // test_utils::launchGraphHelper(graph_instance, stream, true);
-        gHelper.launchGraph(stream); 
+        gHelper.launchGraph(stream, true); 
 
         // Copy output back to host
         HIP_CHECK(hipMemcpy(device_output.data(), d_search_output, search_needle_size * sizeof(key_type), hipMemcpyDeviceToHost));

--- a/test/hipgraph/test_hipgraph_algs.cpp
+++ b/test/hipgraph/test_hipgraph_algs.cpp
@@ -149,7 +149,9 @@ TEST(TestHipGraphAlgs, SortAndSearch)
     HIP_CHECK(hipDeviceSynchronize());
 
     // Begin graph capture
-    hipGraph_t graph = test_utils::createGraphHelper(stream);
+    // hipGraph_t graph = test_utils::createGraphHelper(stream);
+    test_utils::GraphHelper gHelper;
+    gHelper.startStreamCapture(stream);
 
     // Launch merge_sort
     HIP_CHECK(
@@ -181,7 +183,9 @@ TEST(TestHipGraphAlgs, SortAndSearch)
 
     // End graph capture, but do not execute the graph yet.
     hipGraphExec_t graph_instance;
-    graph_instance = test_utils::endCaptureGraphHelper(graph, stream);
+    // graph_instance = test_utils::endCaptureGraphHelper(graph, stream);
+    gHelper.endStreamCapture(stream);
+    gHelper.createGraph();
 
     std::vector<key_type> sort_input;
     std::vector<key_type> search_needles(search_needle_size);
@@ -203,7 +207,8 @@ TEST(TestHipGraphAlgs, SortAndSearch)
         HIP_CHECK(hipMemcpy(d_search_needles, search_needles.data(), search_needle_size * sizeof(key_type), hipMemcpyHostToDevice));
         
         // Launch the graph
-        test_utils::launchGraphHelper(graph_instance, stream, true);
+        // test_utils::launchGraphHelper(graph_instance, stream, true);
+        gHelper.launchGraph(stream); 
 
         // Copy output back to host
         HIP_CHECK(hipMemcpy(device_output.data(), d_search_output, search_needle_size * sizeof(key_type), hipMemcpyDeviceToHost));
@@ -219,7 +224,8 @@ TEST(TestHipGraphAlgs, SortAndSearch)
     HIP_CHECK(hipFree(d_search_needles));
     HIP_CHECK(hipFree(d_temp_storage));
 
-    test_utils::cleanupGraphHelper(graph, graph_instance);
+    // test_utils::cleanupGraphHelper(graph, graph_instance);
+    gHelper.cleanupGraphHelper();
     HIP_CHECK(hipStreamDestroy(stream));
 }
                                   

--- a/test/hipgraph/test_hipgraph_algs.cpp
+++ b/test/hipgraph/test_hipgraph_algs.cpp
@@ -149,7 +149,6 @@ TEST(TestHipGraphAlgs, SortAndSearch)
     HIP_CHECK(hipDeviceSynchronize());
 
     // Begin graph capture
-    // hipGraph_t graph = test_utils::createGraphHelper(stream);
     test_utils::GraphHelper gHelper;
     gHelper.startStreamCapture(stream);
 
@@ -182,8 +181,6 @@ TEST(TestHipGraphAlgs, SortAndSearch)
               );
 
     // End graph capture, but do not execute the graph yet.
-    hipGraphExec_t graph_instance;
-    // graph_instance = test_utils::endCaptureGraphHelper(graph, stream);
     gHelper.endStreamCapture(stream);
     gHelper.createGraph();
 
@@ -207,7 +204,6 @@ TEST(TestHipGraphAlgs, SortAndSearch)
         HIP_CHECK(hipMemcpy(d_search_needles, search_needles.data(), search_needle_size * sizeof(key_type), hipMemcpyHostToDevice));
         
         // Launch the graph
-        // test_utils::launchGraphHelper(graph_instance, stream, true);
         gHelper.launchGraph(stream, true); 
 
         // Copy output back to host
@@ -223,8 +219,6 @@ TEST(TestHipGraphAlgs, SortAndSearch)
     HIP_CHECK(hipFree(d_search_output));
     HIP_CHECK(hipFree(d_search_needles));
     HIP_CHECK(hipFree(d_temp_storage));
-
-    // test_utils::cleanupGraphHelper(graph, graph_instance);
     gHelper.cleanupGraphHelper();
     HIP_CHECK(hipStreamDestroy(stream));
 }

--- a/test/rocprim/test_block_scan.kernels.hpp
+++ b/test/rocprim/test_block_scan.kernels.hpp
@@ -989,6 +989,8 @@ auto test_block_scan_input_arrays()
         // Validating results
         ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
         ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_reductions, expected_reductions));
+        HIP_CHECK(hipFree(device_output));
+        HIP_CHECK(hipFree(device_output_reductions));
     }
 
 }

--- a/test/rocprim/test_config_dispatch.cpp
+++ b/test/rocprim/test_config_dispatch.cpp
@@ -60,6 +60,8 @@ TEST(RocprimConfigDispatchTests, HostMatchesDevice)
 
     ASSERT_NE(host_arch, target_arch::invalid);
     ASSERT_EQ(host_arch, device_arch);
+
+    HIP_CHECK(hipFree(device_arch_ptr))
 }
 
 TEST(RocprimConfigDispatchTests, ParseCommonArches)

--- a/test/rocprim/test_device_adjacent_difference.cpp
+++ b/test/rocprim/test_device_adjacent_difference.cpp
@@ -369,7 +369,7 @@ TYPED_TEST(RocprimDeviceAdjacentDifferenceTests, AdjacentDifference)
 
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size));
 
-            hipGraph_t     graph;
+            test_utils::GraphHelper gHelper;
             hipGraphExec_t graph_instance;
 
             // We might call the API multiple times, with almost the same parameter
@@ -380,7 +380,7 @@ TYPED_TEST(RocprimDeviceAdjacentDifferenceTests, AdjacentDifference)
             {
                 if(TestFixture::use_graphs)
                 {
-                    graph = test_utils::createGraphHelper(stream);
+                    gHelper.startStreamCapture(stream);
                 }
 
                 // Run
@@ -398,7 +398,7 @@ TYPED_TEST(RocprimDeviceAdjacentDifferenceTests, AdjacentDifference)
 
                 if(TestFixture::use_graphs)
                 {
-                    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                    gHelper.createAndLaunchGraph(stream);
                 }
 
                 // input_type for in-place, output_type for out of place
@@ -425,7 +425,7 @@ TYPED_TEST(RocprimDeviceAdjacentDifferenceTests, AdjacentDifference)
 
                 if(TestFixture::use_graphs)
                 {
-                    test_utils::cleanupGraphHelper(graph, graph_instance);
+                    gHelper.cleanupGraphHelper();
                 }
             };
 
@@ -676,10 +676,10 @@ TYPED_TEST(RocprimDeviceAdjacentDifferenceLargeTests, LargeIndices)
 
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Capture the memset in the graph so that relaunching will have expected result
@@ -701,7 +701,7 @@ TYPED_TEST(RocprimDeviceAdjacentDifferenceLargeTests, LargeIndices)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             // Copy output to host
@@ -722,7 +722,7 @@ TYPED_TEST(RocprimDeviceAdjacentDifferenceLargeTests, LargeIndices)
 
             if(TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }

--- a/test/rocprim/test_device_adjacent_difference.cpp
+++ b/test/rocprim/test_device_adjacent_difference.cpp
@@ -370,7 +370,6 @@ TYPED_TEST(RocprimDeviceAdjacentDifferenceTests, AdjacentDifference)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size));
 
             test_utils::GraphHelper gHelper;
-            hipGraphExec_t graph_instance;
 
             // We might call the API multiple times, with almost the same parameter
             // (in-place and out-of-place)
@@ -698,7 +697,6 @@ TYPED_TEST(RocprimDeviceAdjacentDifferenceLargeTests, LargeIndices)
                                                    stream,
                                                    debug_synchronous));
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);

--- a/test/rocprim/test_device_binary_search.cpp
+++ b/test/rocprim/test_device_binary_search.cpp
@@ -174,12 +174,9 @@ TYPED_TEST(RocprimDeviceBinarySearch, LowerBound)
 
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            // hipGraph_t graph;
-            
-            test_utils::GraphHelper gHelper;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::params::use_graphs)
             {
-                // graph = test_utils::createGraphHelper(stream);
                 gHelper.startStreamCapture(stream);
             }
 
@@ -194,10 +191,8 @@ TYPED_TEST(RocprimDeviceBinarySearch, LowerBound)
                                                    stream,
                                                    debug_synchronous));
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                // graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
                 gHelper.createAndLaunchGraph(stream);
             }
 
@@ -217,7 +212,6 @@ TYPED_TEST(RocprimDeviceBinarySearch, LowerBound)
 
             if(TestFixture::params::use_graphs)
             {
-                // test_utils::cleanupGraphHelper(graph, graph_instance);
                 gHelper.cleanupGraphHelper();
             }
 
@@ -325,11 +319,9 @@ TYPED_TEST(RocprimDeviceBinarySearch, UpperBound)
 
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            // hipGraph_t graph;
-            test_utils::GraphHelper gHelper;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::params::use_graphs)
             {
-                // graph = test_utils::createGraphHelper(stream);
                 gHelper.startStreamCapture(stream);
             }
 
@@ -344,10 +336,8 @@ TYPED_TEST(RocprimDeviceBinarySearch, UpperBound)
                                                    stream,
                                                    debug_synchronous));
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                // graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
                 gHelper.createAndLaunchGraph(stream);
             }
 
@@ -367,7 +357,6 @@ TYPED_TEST(RocprimDeviceBinarySearch, UpperBound)
 
             if(TestFixture::params::use_graphs)
             {
-                // test_utils::cleanupGraphHelper(graph, graph_instance);
                 gHelper.cleanupGraphHelper();
             }
 
@@ -476,11 +465,9 @@ TYPED_TEST(RocprimDeviceBinarySearch, BinarySearch)
 
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            // hipGraph_t graph;
-            test_utils::GraphHelper gHelper;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::params::use_graphs)
             {
-                // graph = test_utils::createGraphHelper(stream);
                 gHelper.startStreamCapture(stream);
             }
 
@@ -495,10 +482,8 @@ TYPED_TEST(RocprimDeviceBinarySearch, BinarySearch)
                                                      stream,
                                                      debug_synchronous));
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                // graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
                 gHelper.createAndLaunchGraph(stream);
             }
 
@@ -518,7 +503,6 @@ TYPED_TEST(RocprimDeviceBinarySearch, BinarySearch)
 
             if(TestFixture::params::use_graphs)
             {
-                // test_utils::cleanupGraphHelper(graph, graph_instance);
                 gHelper.cleanupGraphHelper();
             }
 

--- a/test/rocprim/test_device_binary_search.cpp
+++ b/test/rocprim/test_device_binary_search.cpp
@@ -174,10 +174,13 @@ TYPED_TEST(RocprimDeviceBinarySearch, LowerBound)
 
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            // hipGraph_t graph;
+            
+            test_utils::GraphHelper gHelper;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                // graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             HIP_CHECK(rocprim::lower_bound<config>(d_temporary_storage,
@@ -194,7 +197,8 @@ TYPED_TEST(RocprimDeviceBinarySearch, LowerBound)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                // graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             std::vector<output_type> output(needles_size);
@@ -213,7 +217,8 @@ TYPED_TEST(RocprimDeviceBinarySearch, LowerBound)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                // test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
@@ -320,10 +325,12 @@ TYPED_TEST(RocprimDeviceBinarySearch, UpperBound)
 
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            // hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                // graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             HIP_CHECK(rocprim::upper_bound<config>(d_temporary_storage,
@@ -340,7 +347,8 @@ TYPED_TEST(RocprimDeviceBinarySearch, UpperBound)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                // graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             std::vector<output_type> output(needles_size);
@@ -359,7 +367,8 @@ TYPED_TEST(RocprimDeviceBinarySearch, UpperBound)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                // test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
@@ -467,10 +476,12 @@ TYPED_TEST(RocprimDeviceBinarySearch, BinarySearch)
 
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            // hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                // graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             HIP_CHECK(rocprim::binary_search<config>(d_temporary_storage,
@@ -487,7 +498,8 @@ TYPED_TEST(RocprimDeviceBinarySearch, BinarySearch)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                // graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             std::vector<output_type> output(needles_size);
@@ -506,7 +518,8 @@ TYPED_TEST(RocprimDeviceBinarySearch, BinarySearch)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                // test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));

--- a/test/rocprim/test_device_histogram.cpp
+++ b/test/rocprim/test_device_histogram.cpp
@@ -307,10 +307,10 @@ TYPED_TEST(RocprimDeviceHistogramEven, Even)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             if(rows == 1)
@@ -341,7 +341,7 @@ TYPED_TEST(RocprimDeviceHistogramEven, Even)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             std::vector<counter_type> histogram(bins);
@@ -364,7 +364,7 @@ TYPED_TEST(RocprimDeviceHistogramEven, Even)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -585,10 +585,10 @@ TYPED_TEST(RocprimDeviceHistogramRange, Range)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             if(rows == 1)
@@ -621,7 +621,7 @@ TYPED_TEST(RocprimDeviceHistogramRange, Range)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             std::vector<counter_type> histogram(bins);
@@ -645,7 +645,7 @@ TYPED_TEST(RocprimDeviceHistogramRange, Range)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -873,10 +873,10 @@ TYPED_TEST(RocprimDeviceHistogramMultiEven, MultiEven)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             if(rows == 1)
@@ -913,7 +913,7 @@ TYPED_TEST(RocprimDeviceHistogramMultiEven, MultiEven)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             std::vector<counter_type> histogram[active_channels];
@@ -945,7 +945,7 @@ TYPED_TEST(RocprimDeviceHistogramMultiEven, MultiEven)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -1189,10 +1189,10 @@ TYPED_TEST(RocprimDeviceHistogramMultiRange, MultiRange)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             if(rows == 1)
@@ -1223,7 +1223,7 @@ TYPED_TEST(RocprimDeviceHistogramMultiRange, MultiRange)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             std::vector<counter_type> histogram[active_channels];
@@ -1246,7 +1246,7 @@ TYPED_TEST(RocprimDeviceHistogramMultiRange, MultiRange)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
 
             for(unsigned int channel = 0; channel < active_channels; channel++)

--- a/test/rocprim/test_device_histogram.cpp
+++ b/test/rocprim/test_device_histogram.cpp
@@ -338,7 +338,6 @@ TYPED_TEST(RocprimDeviceHistogramEven, Even)
                 );
             }
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -618,7 +617,6 @@ TYPED_TEST(RocprimDeviceHistogramRange, Range)
                                                            debug_synchronous));
             }
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -910,7 +908,6 @@ TYPED_TEST(RocprimDeviceHistogramMultiEven, MultiEven)
                     debug_synchronous)));
             }
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -1220,7 +1217,6 @@ TYPED_TEST(RocprimDeviceHistogramMultiRange, MultiRange)
                 ));
             }
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);

--- a/test/rocprim/test_device_merge.cpp
+++ b/test/rocprim/test_device_merge.cpp
@@ -229,7 +229,6 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
                 )
             );
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -437,7 +436,6 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
                 )
             );
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -571,7 +569,6 @@ void testMergeMismatchedIteratorTypes()
                              hipStreamDefault,
                              debug_synchronous));
 
-    hipGraphExec_t graph_instance;
     if(UseGraphs)
     {
         gHelper.createAndLaunchGraph(stream);

--- a/test/rocprim/test_device_merge.cpp
+++ b/test/rocprim/test_device_merge.cpp
@@ -212,10 +212,10 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
             // allocate temporary storage
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -232,7 +232,7 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -258,7 +258,7 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
             hipFree(d_temp_storage);
 
             if (TestFixture::use_graphs)
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
         }
     }
 
@@ -418,10 +418,10 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
             // allocate temporary storage
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -440,7 +440,7 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -483,7 +483,7 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
             hipFree(d_temp_storage);
 
             if (TestFixture::use_graphs)
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
         }
     }
 
@@ -554,10 +554,10 @@ void testMergeMismatchedIteratorTypes()
     void* d_temp_storage = nullptr;
     HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-    hipGraph_t graph;
+    test_utils::GraphHelper gHelper;
     if(UseGraphs)
     {
-        graph = test_utils::createGraphHelper(stream);
+        gHelper.startStreamCapture(stream);
     }
 
     HIP_CHECK(rocprim::merge(d_temp_storage,
@@ -574,7 +574,7 @@ void testMergeMismatchedIteratorTypes()
     hipGraphExec_t graph_instance;
     if(UseGraphs)
     {
-        graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+        gHelper.createAndLaunchGraph(stream);
     }
 
     std::vector<int> keys_output(expected_keys_output.size());
@@ -591,7 +591,7 @@ void testMergeMismatchedIteratorTypes()
 
     if (UseGraphs)
     {
-        test_utils::cleanupGraphHelper(graph, graph_instance);
+        gHelper.cleanupGraphHelper();
         HIP_CHECK(hipStreamDestroy(stream));
     }
 }

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -180,7 +180,6 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
                 )
             );
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -202,12 +201,12 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             // Check if output values are as expected
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
 
-            hipFree(d_input);
+            HIP_CHECK(hipFree(d_input));
             if(!in_place)
             {
-                hipFree(d_output);
+                HIP_CHECK(hipFree(d_output));
             }
-            hipFree(d_temp_storage);
+            HIP_CHECK(hipFree(d_temp_storage));
 
             if (TestFixture::use_graphs)
             {
@@ -351,7 +350,6 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
                 )
             );
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -389,14 +387,14 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected_key));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, expected_value));
 
-            hipFree(d_keys_input);
-            hipFree(d_values_input);
+            HIP_CHECK(hipFree(d_keys_input));
+            HIP_CHECK(hipFree(d_values_input));
             if(!in_place)
             {
-                hipFree(d_keys_output);
-                hipFree(d_values_output);
+                HIP_CHECK(hipFree(d_keys_output));
+                HIP_CHECK(hipFree(d_values_output));
             }
-            hipFree(d_temp_storage);
+            HIP_CHECK(hipFree(d_temp_storage));
 
             if (TestFixture::use_graphs)
             {

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -165,10 +165,10 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);;
             }
 
             // Run
@@ -183,7 +183,7 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -211,7 +211,7 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }
@@ -335,10 +335,10 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);;
             }
 
             // Run
@@ -354,7 +354,7 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -400,7 +400,7 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }

--- a/test/rocprim/test_device_nth_element.cpp
+++ b/test/rocprim/test_device_nth_element.cpp
@@ -292,10 +292,10 @@ TYPED_TEST(RocprimDeviceNthelementTests, NthelementKey)
             // allocate temporary storage
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             if(in_place)
@@ -327,7 +327,7 @@ TYPED_TEST(RocprimDeviceNthelementTests, NthelementKey)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -353,7 +353,7 @@ TYPED_TEST(RocprimDeviceNthelementTests, NthelementKey)
 
             if(TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }

--- a/test/rocprim/test_device_nth_element.cpp
+++ b/test/rocprim/test_device_nth_element.cpp
@@ -324,7 +324,6 @@ TYPED_TEST(RocprimDeviceNthelementTests, NthelementKey)
                                                        debug_synchronous));
             }
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);

--- a/test/rocprim/test_device_partial_sort.cpp
+++ b/test/rocprim/test_device_partial_sort.cpp
@@ -269,7 +269,6 @@ TYPED_TEST(RocprimDevicePartialSortTests, PartialSort)
 
                 HIP_CHECK(hipGetLastError());
 
-                hipGraphExec_t graph_instance;
                 if(TestFixture::use_graphs)
                 {
                     gHelper.createAndLaunchGraph(stream);
@@ -492,7 +491,6 @@ TYPED_TEST(RocprimDevicePartialSortTests, PartialSortCopy)
 
                 HIP_CHECK(hipGetLastError());
 
-                hipGraphExec_t graph_instance;
                 if(TestFixture::use_graphs)
                 {
                     gHelper.createAndLaunchGraph(stream);

--- a/test/rocprim/test_device_partial_sort.cpp
+++ b/test/rocprim/test_device_partial_sort.cpp
@@ -253,10 +253,10 @@ TYPED_TEST(RocprimDevicePartialSortTests, PartialSort)
                 HIP_CHECK(
                     test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-                hipGraph_t graph;
+                test_utils::GraphHelper gHelper;;
                 if(TestFixture::use_graphs)
                 {
-                    graph = test_utils::createGraphHelper(stream);
+                    gHelper.startStreamCapture(stream);
                 }
                 HIP_CHECK(rocprim::partial_sort<config>(d_temp_storage,
                                                         temp_storage_size_bytes,
@@ -272,7 +272,7 @@ TYPED_TEST(RocprimDevicePartialSortTests, PartialSort)
                 hipGraphExec_t graph_instance;
                 if(TestFixture::use_graphs)
                 {
-                    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                    gHelper.createAndLaunchGraph(stream);
                 }
 
                 std::vector<key_type> output(size);
@@ -288,7 +288,7 @@ TYPED_TEST(RocprimDevicePartialSortTests, PartialSort)
 
                 if(TestFixture::use_graphs)
                 {
-                    test_utils::cleanupGraphHelper(graph, graph_instance);
+                    gHelper.cleanupGraphHelper();
                     HIP_CHECK(hipStreamDestroy(stream));
                 }
             }
@@ -474,10 +474,10 @@ TYPED_TEST(RocprimDevicePartialSortTests, PartialSortCopy)
                 HIP_CHECK(
                     test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-                hipGraph_t graph;
+                test_utils::GraphHelper gHelper;;
                 if(TestFixture::use_graphs)
                 {
-                    graph = test_utils::createGraphHelper(stream);
+                    gHelper.startStreamCapture(stream);
                 }
 
                 HIP_CHECK(rocprim::partial_sort_copy<config>(d_temp_storage,
@@ -495,7 +495,7 @@ TYPED_TEST(RocprimDevicePartialSortTests, PartialSortCopy)
                 hipGraphExec_t graph_instance;
                 if(TestFixture::use_graphs)
                 {
-                    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                    gHelper.createAndLaunchGraph(stream);
                 }
 
                 std::vector<key_type> output(size);
@@ -512,7 +512,7 @@ TYPED_TEST(RocprimDevicePartialSortTests, PartialSortCopy)
 
                 if(TestFixture::use_graphs)
                 {
-                    test_utils::cleanupGraphHelper(graph, graph_instance);
+                    gHelper.cleanupGraphHelper();
                     HIP_CHECK(hipStreamDestroy(stream));
                 }
             }

--- a/test/rocprim/test_device_partition.cpp
+++ b/test/rocprim/test_device_partition.cpp
@@ -188,7 +188,6 @@ TYPED_TEST(RocprimDevicePartitionTests, Flagged)
                 stream,
                 debug_synchronous));
 
-            hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -310,7 +309,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateEmptyInput)
                                          stream,
                                          debug_synchronous));
 
-    hipGraphExec_t graph_instance;
+    
     if(TestFixture::use_graphs)
     {
         gHelper.createAndLaunchGraph(stream, true, false);
@@ -443,7 +442,7 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
                 stream,
                 debug_synchronous));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -604,7 +603,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
                 stream,
                 debug_synchronous));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -801,7 +800,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
                     stream,
                     debug_synchronous));
 
-                hipGraphExec_t graph_instance;
+                
                 if(TestFixture::use_graphs)
                 {
                     gHelper.createAndLaunchGraph(stream);
@@ -1183,7 +1182,7 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartition)
                                      stream,
                                      debug_synchronous));
 
-        hipGraphExec_t graph_instance;
+        
         if(use_graphs)
         {
             gHelper.createAndLaunchGraph(stream);
@@ -1305,7 +1304,7 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionTwoWay)
                                              stream,
                                              debug_synchronous));
 
-        hipGraphExec_t graph_instance;
+        
         if(use_graphs)
         {
             gHelper.createAndLaunchGraph(stream);
@@ -1436,7 +1435,7 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionThreeWay)
                                                stream,
                                                debug_synchronous));
 
-        hipGraphExec_t graph_instance;
+        
         if(use_graphs)
         {
             gHelper.createAndLaunchGraph(stream);

--- a/test/rocprim/test_device_partition.cpp
+++ b/test/rocprim/test_device_partition.cpp
@@ -170,10 +170,10 @@ TYPED_TEST(RocprimDevicePartitionTests, Flagged)
             void* d_temp_storage = nullptr;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -191,7 +191,7 @@ TYPED_TEST(RocprimDevicePartitionTests, Flagged)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             // Check if number of selected value is as expected_selected
@@ -226,7 +226,7 @@ TYPED_TEST(RocprimDevicePartitionTests, Flagged)
 
             if(TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -293,10 +293,10 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateEmptyInput)
     void* d_temp_storage = nullptr;
     HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-    hipGraph_t graph;
+    test_utils::GraphHelper gHelper;;
     if(TestFixture::use_graphs)
     {
-        graph = test_utils::createGraphHelper(stream);
+        gHelper.startStreamCapture(stream);
     }
 
     // Run
@@ -313,7 +313,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateEmptyInput)
     hipGraphExec_t graph_instance;
     if(TestFixture::use_graphs)
     {
-        graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+        gHelper.createAndLaunchGraph(stream, true, false);
     }
 
     HIP_CHECK(hipDeviceSynchronize());
@@ -335,7 +335,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateEmptyInput)
 
     if (TestFixture::use_graphs)
     {
-        test_utils::cleanupGraphHelper(graph, graph_instance);
+        gHelper.cleanupGraphHelper();
         HIP_CHECK(hipStreamDestroy(stream));
     }
 }
@@ -425,10 +425,10 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
             void* d_temp_storage = nullptr;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -446,7 +446,7 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipDeviceSynchronize());
@@ -482,7 +482,7 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
 
             if(TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -585,10 +585,10 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
             void* d_temp_storage = nullptr;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -607,7 +607,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipDeviceSynchronize());
@@ -645,7 +645,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
 
             if(TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -779,10 +779,10 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
                 void* d_temp_storage = nullptr;
                 HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
 
-                hipGraph_t graph;
+                test_utils::GraphHelper gHelper;;
                 if(TestFixture::use_graphs)
                 {
-                    graph = test_utils::createGraphHelper(stream);
+                    gHelper.startStreamCapture(stream);
                 }
 
                 // Run
@@ -804,7 +804,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
                 hipGraphExec_t graph_instance;
                 if(TestFixture::use_graphs)
                 {
-                    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                    gHelper.createAndLaunchGraph(stream);
                 }
 
                 HIP_CHECK(hipDeviceSynchronize());
@@ -858,7 +858,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
 
                 if(TestFixture::use_graphs)
                 {
-                    test_utils::cleanupGraphHelper(graph, graph_instance);
+                    gHelper.cleanupGraphHelper();
                 }
             }
         }
@@ -1167,10 +1167,10 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartition)
         ASSERT_NE(0, temporary_storage_size);
         HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_size));
 
-        hipGraph_t graph;
+        test_utils::GraphHelper gHelper;;
         if(use_graphs)
         {
-            graph = test_utils::createGraphHelper(stream);
+            gHelper.startStreamCapture(stream);
         }
 
         HIP_CHECK(rocprim::partition(d_temporary_storage,
@@ -1186,7 +1186,7 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartition)
         hipGraphExec_t graph_instance;
         if(use_graphs)
         {
-            graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+            gHelper.createAndLaunchGraph(stream);
         }
 
         size_t count_output{};
@@ -1214,7 +1214,7 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartition)
 
         if(use_graphs)
         {
-            test_utils::cleanupGraphHelper(graph, graph_instance);
+            gHelper.cleanupGraphHelper();
         }
     }
 
@@ -1288,10 +1288,10 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionTwoWay)
         ASSERT_NE(0, temporary_storage_size);
         HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_size));
 
-        hipGraph_t graph;
+        test_utils::GraphHelper gHelper;;
         if(use_graphs)
         {
-            graph = test_utils::createGraphHelper(stream);
+            gHelper.startStreamCapture(stream);
         }
 
         HIP_CHECK(rocprim::partition_two_way(d_temporary_storage,
@@ -1308,7 +1308,7 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionTwoWay)
         hipGraphExec_t graph_instance;
         if(use_graphs)
         {
-            graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+            gHelper.createAndLaunchGraph(stream);
         }
 
         size_t count_output{};
@@ -1344,7 +1344,7 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionTwoWay)
 
         if(use_graphs)
         {
-            test_utils::cleanupGraphHelper(graph, graph_instance);
+            gHelper.cleanupGraphHelper();
         }
     }
 
@@ -1417,10 +1417,10 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionThreeWay)
         ASSERT_NE(0, temporary_storage_size);
         HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_size));
 
-        hipGraph_t graph;
+        test_utils::GraphHelper gHelper;;
         if(use_graphs)
         {
-            graph = test_utils::createGraphHelper(stream);
+            gHelper.startStreamCapture(stream);
         }
 
         HIP_CHECK(rocprim::partition_three_way(d_temporary_storage,
@@ -1439,7 +1439,7 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionThreeWay)
         hipGraphExec_t graph_instance;
         if(use_graphs)
         {
-            graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+            gHelper.createAndLaunchGraph(stream);
         }
 
         size_t count_output[2]{};
@@ -1471,7 +1471,7 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionThreeWay)
 
         if(use_graphs)
         {
-            test_utils::cleanupGraphHelper(graph, graph_instance);
+            gHelper.cleanupGraphHelper();
         }
     }
 

--- a/test/rocprim/test_device_radix_sort.hpp
+++ b/test/rocprim/test_device_radix_sort.hpp
@@ -317,10 +317,10 @@ void sort_keys()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             HIP_CHECK((invoke_sort_keys<config, descending>(d_temporary_storage,
@@ -336,7 +336,7 @@ void sort_keys()
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             auto keys_output = std::make_unique<key_type[]>(size);
@@ -354,7 +354,7 @@ void sort_keys()
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_bit_eq(keys_output.get(),
@@ -632,11 +632,11 @@ void sort_pairs()
                                                     4>,
                 1024 * 512>;
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             void*  d_temporary_storage = nullptr;
@@ -655,7 +655,7 @@ void sort_pairs()
 
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             ASSERT_GT(temporary_storage_bytes, 0);
@@ -665,7 +665,7 @@ void sort_pairs()
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::resetGraphHelper(graph, graph_instance, stream);
+                gHelper.resetGraphHelper(stream);
             }
 
             HIP_CHECK((invoke_sort_pairs<config, descending>(d_temporary_storage,
@@ -682,7 +682,7 @@ void sort_pairs()
 
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             auto keys_output = std::make_unique<key_type[]>(size);
@@ -708,7 +708,7 @@ void sort_pairs()
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_bit_eq(keys_output.get(),
@@ -923,10 +923,10 @@ void sort_keys_double_buffer()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             HIP_CHECK(
@@ -942,7 +942,7 @@ void sort_keys_double_buffer()
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             HIP_CHECK(hipFree(d_temporary_storage));
@@ -958,7 +958,7 @@ void sort_keys_double_buffer()
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_bit_eq(keys_output.get(),
@@ -1210,10 +1210,10 @@ void sort_pairs_double_buffer()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             HIP_CHECK(
@@ -1230,7 +1230,7 @@ void sort_pairs_double_buffer()
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             HIP_CHECK(hipFree(d_temporary_storage));
@@ -1254,7 +1254,7 @@ void sort_pairs_double_buffer()
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_bit_eq(keys_output.get(),
@@ -1342,10 +1342,10 @@ void sort_keys_over_4g()
     void* d_temporary_storage;
     HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-    hipGraph_t graph;
+    test_utils::GraphHelper gHelper;;
     if(UseGraphs)
     {
-        graph = test_utils::createGraphHelper(stream);
+        gHelper.startStreamCapture(stream);
     }
 
     HIP_CHECK(rocprim::radix_sort_keys(d_temporary_storage,
@@ -1361,7 +1361,7 @@ void sort_keys_over_4g()
     hipGraphExec_t graph_instance;
     if(UseGraphs)
     {
-        graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+        gHelper.createAndLaunchGraph(stream);
     }
 
     std::vector<key_type> output(keys_input.size());
@@ -1386,7 +1386,7 @@ void sort_keys_over_4g()
 
     if (UseGraphs)
     {
-        test_utils::cleanupGraphHelper(graph, graph_instance);
+        gHelper.cleanupGraphHelper();
         HIP_CHECK(hipStreamDestroy(stream));
     }
 }

--- a/test/rocprim/test_device_radix_sort.hpp
+++ b/test/rocprim/test_device_radix_sort.hpp
@@ -333,7 +333,7 @@ void sort_keys()
                                                             stream,
                                                             debug_synchronous)));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -633,7 +633,7 @@ void sort_pairs()
                 1024 * 512>;
 
             test_utils::GraphHelper gHelper;;
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::params::use_graphs)
             {
                 gHelper.startStreamCapture(stream);
@@ -939,7 +939,7 @@ void sort_keys_double_buffer()
                                                                        stream,
                                                                        debug_synchronous)));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -1227,7 +1227,7 @@ void sort_pairs_double_buffer()
                                                                         stream,
                                                                         debug_synchronous)));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -1358,7 +1358,7 @@ void sort_keys_over_4g()
                                        stream,
                                        debug_synchronous));
 
-    hipGraphExec_t graph_instance;
+    
     if(UseGraphs)
     {
         gHelper.createAndLaunchGraph(stream);

--- a/test/rocprim/test_device_reduce.cpp
+++ b/test/rocprim/test_device_reduce.cpp
@@ -204,7 +204,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceEmptyInput)
         )
     );
 
-    hipGraphExec_t graph_instance;
+    
     if(TestFixture::use_graphs)
     {
         gHelper.createAndLaunchGraph(stream);
@@ -331,7 +331,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceSum)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -483,7 +483,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceArgMinimum)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -585,7 +585,7 @@ void testLargeIndices()
                                       stream,
                                       debug_synchronous));
 
-            hipGraphExec_t graph_instance;
+            
             if(use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -728,7 +728,7 @@ TYPED_TEST(RocprimDeviceReducePrecisionTests, ReduceSumInputEqualExponentFunctio
             stream,
             debug_synchronous));
 
-        hipGraphExec_t graph_instance;
+        
         if(TestFixture::use_graphs)
         {
             gHelper.createAndLaunchGraph(stream);
@@ -858,7 +858,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceMinimum)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);

--- a/test/rocprim/test_device_reduce.cpp
+++ b/test/rocprim/test_device_reduce.cpp
@@ -187,10 +187,10 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceEmptyInput)
     void * d_temp_storage = nullptr;
     HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-    hipGraph_t graph;
+    test_utils::GraphHelper gHelper;
     if(TestFixture::use_graphs)
     {
-        graph = test_utils::createGraphHelper(stream);
+        gHelper.startStreamCapture(stream);
     }
 
     // Run
@@ -207,7 +207,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceEmptyInput)
     hipGraphExec_t graph_instance;
     if(TestFixture::use_graphs)
     {
-        graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+        gHelper.createAndLaunchGraph(stream);
     }
 
     HIP_CHECK(hipDeviceSynchronize());
@@ -227,7 +227,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceEmptyInput)
 
     if (TestFixture::use_graphs)
     {
-        test_utils::cleanupGraphHelper(graph, graph_instance);
+        gHelper.cleanupGraphHelper();
         HIP_CHECK(hipStreamDestroy(stream));
     }
 }
@@ -315,10 +315,10 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceSum)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -334,7 +334,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceSum)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -360,7 +360,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceSum)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }
@@ -467,10 +467,10 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceArgMinimum)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -486,7 +486,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceArgMinimum)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -512,7 +512,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceArgMinimum)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }
@@ -569,10 +569,10 @@ void testLargeIndices()
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -588,7 +588,7 @@ void testLargeIndices()
             hipGraphExec_t graph_instance;
             if(use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -610,7 +610,7 @@ void testLargeIndices()
 
             if(use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -711,10 +711,10 @@ TYPED_TEST(RocprimDeviceReducePrecisionTests, ReduceSumInputEqualExponentFunctio
         HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
         HIP_CHECK(hipDeviceSynchronize());
 
-        hipGraph_t graph;
+        test_utils::GraphHelper gHelper;
         if(TestFixture::use_graphs)
         {
-            graph = test_utils::createGraphHelper(stream);
+            gHelper.startStreamCapture(stream);
         }
 
         // Run
@@ -731,7 +731,7 @@ TYPED_TEST(RocprimDeviceReducePrecisionTests, ReduceSumInputEqualExponentFunctio
         hipGraphExec_t graph_instance;
         if(TestFixture::use_graphs)
         {
-            graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+            gHelper.createAndLaunchGraph(stream);
         }
 
         HIP_CHECK(hipGetLastError());
@@ -751,7 +751,7 @@ TYPED_TEST(RocprimDeviceReducePrecisionTests, ReduceSumInputEqualExponentFunctio
 
         if (TestFixture::use_graphs)
         {
-            test_utils::cleanupGraphHelper(graph, graph_instance);
+            gHelper.cleanupGraphHelper();
             HIP_CHECK(hipStreamDestroy(stream));
         }
     }
@@ -833,10 +833,10 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceMinimum)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -861,7 +861,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceMinimum)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipDeviceSynchronize());
@@ -880,7 +880,7 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceMinimum)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }

--- a/test/rocprim/test_device_reduce_by_key.cpp
+++ b/test/rocprim/test_device_reduce_by_key.cpp
@@ -296,10 +296,10 @@ TYPED_TEST(RocprimDeviceReduceByKey, ReduceByKey)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+               gHelper.startStreamCapture(stream);
             }
 
             HIP_CHECK((invoke_reduce_by_key<deterministic, config>(d_temporary_storage,
@@ -318,7 +318,7 @@ TYPED_TEST(RocprimDeviceReduceByKey, ReduceByKey)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             HIP_CHECK(hipFree(d_temporary_storage));
@@ -356,7 +356,7 @@ TYPED_TEST(RocprimDeviceReduceByKey, ReduceByKey)
 
             if (TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
 
@@ -443,10 +443,10 @@ void large_indices_reduce_by_key()
         HIP_CHECK(
             test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-        hipGraph_t graph;
+        test_utils::GraphHelper gHelper;
         if(use_graphs)
         {
-            graph = test_utils::createGraphHelper(stream);
+           gHelper.startStreamCapture(stream);
         }
 
         HIP_CHECK(invoke_reduce_by_key<Deterministic>(d_temporary_storage,
@@ -465,7 +465,7 @@ void large_indices_reduce_by_key()
         hipGraphExec_t graph_instance;
         if(use_graphs)
         {
-            graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+            gHelper.createAndLaunchGraph(stream);
         }
 
         HIP_CHECK(hipFree(d_temporary_storage));
@@ -492,7 +492,7 @@ void large_indices_reduce_by_key()
 
         if(use_graphs)
         {
-            test_utils::cleanupGraphHelper(graph, graph_instance);
+            gHelper.cleanupGraphHelper();
         }
 
         ASSERT_EQ(unique_count_output[0], unique_count_expected);
@@ -598,10 +598,10 @@ void large_segment_count_reduce_by_key()
         HIP_CHECK(
             test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-        hipGraph_t graph;
+        test_utils::GraphHelper gHelper;
         if(use_graphs)
         {
-            graph = test_utils::createGraphHelper(stream);
+           gHelper.startStreamCapture(stream);
         }
 
         HIP_CHECK(invoke_reduce_by_key<Deterministic>(d_temporary_storage,
@@ -620,7 +620,7 @@ void large_segment_count_reduce_by_key()
         hipGraphExec_t graph_instance;
         if(use_graphs)
         {
-            graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+            gHelper.createAndLaunchGraph(stream);
         }
 
         HIP_CHECK(hipFree(d_temporary_storage));
@@ -636,7 +636,7 @@ void large_segment_count_reduce_by_key()
         ASSERT_EQ(unique_count_output, unique_count_expected);
 
         if (use_graphs)
-            test_utils::cleanupGraphHelper(graph, graph_instance);
+            gHelper.cleanupGraphHelper();
     }
 
     if (use_graphs)

--- a/test/rocprim/test_device_reduce_by_key.cpp
+++ b/test/rocprim/test_device_reduce_by_key.cpp
@@ -315,7 +315,7 @@ TYPED_TEST(RocprimDeviceReduceByKey, ReduceByKey)
                                                                    stream,
                                                                    debug_synchronous)));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -462,7 +462,7 @@ void large_indices_reduce_by_key()
                                                       stream,
                                                       debug_synchronous));
 
-        hipGraphExec_t graph_instance;
+        
         if(use_graphs)
         {
             gHelper.createAndLaunchGraph(stream);
@@ -617,7 +617,7 @@ void large_segment_count_reduce_by_key()
                                                       stream,
                                                       debug_synchronous));
 
-        hipGraphExec_t graph_instance;
+        
         if(use_graphs)
         {
             gHelper.createAndLaunchGraph(stream);

--- a/test/rocprim/test_device_scan.cpp
+++ b/test/rocprim/test_device_scan.cpp
@@ -306,7 +306,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanEmptyInput)
                                                    stream,
                                                    debug_synchronous));
 
-    hipGraphExec_t graph_instance;
+    
     if(TestFixture::use_graphs)
     {
         gHelper.createAndLaunchGraph(stream, true, false);
@@ -448,7 +448,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
                 stream,
                 TestFixture::debug_synchronous)));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -611,7 +611,7 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
                 stream,
                 debug_synchronous)));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -789,7 +789,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
                                                                            stream,
                                                                            debug_synchronous)));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -973,7 +973,7 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
                                                                            stream,
                                                                            debug_synchronous)));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -1155,7 +1155,7 @@ void testLargeIndicesInclusiveScan()
                                               )
                       );
 
-            hipGraphExec_t graph_instance;
+            
             if(UseGraphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -1285,7 +1285,7 @@ void testLargeIndicesExclusiveScan()
                                               )
                       );
 
-            hipGraphExec_t graph_instance;
+            
             if(UseGraphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -1536,7 +1536,7 @@ void large_indices_scan_by_key_test(ScanByKeyFun scan_by_key_fun)
                               debug_synchronous,
                               seed_value));
 
-    hipGraphExec_t graph_instance;
+    
     if(UseGraphs)
     {
         gHelper.createAndLaunchGraph(stream);
@@ -1809,7 +1809,7 @@ TYPED_TEST(RocprimDeviceScanFutureTests, ExclusiveScan)
                 debug_synchronous)));
             HIP_CHECK(hipGetLastError());
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);

--- a/test/rocprim/test_device_scan.cpp
+++ b/test/rocprim/test_device_scan.cpp
@@ -290,10 +290,10 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanEmptyInput)
     // allocate temporary storage
     HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-    hipGraph_t graph;
+    test_utils::GraphHelper gHelper;;
     if(TestFixture::use_graphs)
     {
-        graph = test_utils::createGraphHelper(stream);
+        gHelper.startStreamCapture(stream);
     }
 
     // Run
@@ -309,7 +309,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanEmptyInput)
     hipGraphExec_t graph_instance;
     if(TestFixture::use_graphs)
     {
-        graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+        gHelper.createAndLaunchGraph(stream, true, false);
     }
 
     HIP_CHECK(hipGetLastError());
@@ -322,7 +322,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanEmptyInput)
 
     if (TestFixture::use_graphs)
     {
-        test_utils::cleanupGraphHelper(graph, graph_instance);
+        gHelper.cleanupGraphHelper();
         HIP_CHECK(hipStreamDestroy(stream));
     }
 }
@@ -431,10 +431,10 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -451,7 +451,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -477,7 +477,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }
@@ -593,10 +593,10 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -614,7 +614,7 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -640,7 +640,7 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }
@@ -771,10 +771,10 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -792,7 +792,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -819,7 +819,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }
@@ -954,10 +954,10 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -976,7 +976,7 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -1003,7 +1003,7 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }
@@ -1139,10 +1139,10 @@ void testLargeIndicesInclusiveScan()
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(UseGraphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -1158,7 +1158,7 @@ void testLargeIndicesInclusiveScan()
             hipGraphExec_t graph_instance;
             if(UseGraphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -1182,7 +1182,7 @@ void testLargeIndicesInclusiveScan()
 
             if(UseGraphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -1268,10 +1268,10 @@ void testLargeIndicesExclusiveScan()
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(UseGraphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -1288,7 +1288,7 @@ void testLargeIndicesExclusiveScan()
             hipGraphExec_t graph_instance;
             if(UseGraphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -1315,7 +1315,7 @@ void testLargeIndicesExclusiveScan()
 
             if(UseGraphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -1519,10 +1519,10 @@ void large_indices_scan_by_key_test(ScanByKeyFun scan_by_key_fun)
     ASSERT_GT(temp_storage_size_bytes, 0);
     HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-    hipGraph_t graph;
+    test_utils::GraphHelper gHelper;;
     if(UseGraphs)
     {
-        graph = test_utils::createGraphHelper(stream);
+        gHelper.startStreamCapture(stream);
     }
 
     HIP_CHECK(scan_by_key_fun(d_temp_storage,
@@ -1539,7 +1539,7 @@ void large_indices_scan_by_key_test(ScanByKeyFun scan_by_key_fun)
     hipGraphExec_t graph_instance;
     if(UseGraphs)
     {
-        graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+        gHelper.createAndLaunchGraph(stream);
     }
 
     HIP_CHECK(hipGetLastError());
@@ -1557,7 +1557,7 @@ void large_indices_scan_by_key_test(ScanByKeyFun scan_by_key_fun)
 
     if (UseGraphs)
     {
-        test_utils::cleanupGraphHelper(graph, graph_instance);
+        gHelper.cleanupGraphHelper();
         HIP_CHECK(hipStreamDestroy(stream));
     }
 }
@@ -1781,10 +1781,10 @@ TYPED_TEST(RocprimDeviceScanFutureTests, ExclusiveScan)
                 &d_temp_storage, temp_storage_size_bytes + temp_storage_reduce));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Fill initial value on the device
@@ -1812,7 +1812,7 @@ TYPED_TEST(RocprimDeviceScanFutureTests, ExclusiveScan)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             // Copy output to host
@@ -1831,7 +1831,7 @@ TYPED_TEST(RocprimDeviceScanFutureTests, ExclusiveScan)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }

--- a/test/rocprim/test_device_segmented_reduce.cpp
+++ b/test/rocprim/test_device_segmented_reduce.cpp
@@ -268,10 +268,10 @@ TYPED_TEST(RocprimDeviceSegmentedReduce, Reduce)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             HIP_CHECK(rocprim::segmented_reduce<Config>(
@@ -290,7 +290,7 @@ TYPED_TEST(RocprimDeviceSegmentedReduce, Reduce)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+                gHelper.createAndLaunchGraph(stream);
             }
 
             HIP_CHECK(hipFree(d_temporary_storage));
@@ -307,7 +307,7 @@ TYPED_TEST(RocprimDeviceSegmentedReduce, Reduce)
 
             if (TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
             SCOPED_TRACE(testing::Message() << "with seed = " << seed);
@@ -413,10 +413,10 @@ void testLargeIndices()
         HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
         HIP_CHECK(hipDeviceSynchronize());
 
-        hipGraph_t graph;
+        test_utils::GraphHelper gHelper;
         if(use_graphs)
         {
-            graph = test_utils::createGraphHelper(stream);
+            gHelper.startStreamCapture(stream);
         }
 
         // Run
@@ -435,7 +435,7 @@ void testLargeIndices()
         hipGraphExec_t graph_instance;
         if(use_graphs)
         {
-            graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+            gHelper.createAndLaunchGraph(stream, true, false);
         }
 
         HIP_CHECK(hipGetLastError());
@@ -458,7 +458,7 @@ void testLargeIndices()
 
         if(use_graphs)
         {
-            test_utils::cleanupGraphHelper(graph, graph_instance);
+            gHelper.cleanupGraphHelper();
         }
     }
 

--- a/test/rocprim/test_device_segmented_reduce.cpp
+++ b/test/rocprim/test_device_segmented_reduce.cpp
@@ -287,7 +287,7 @@ TYPED_TEST(RocprimDeviceSegmentedReduce, Reduce)
                 stream,
                 debug_synchronous));
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream);
@@ -432,7 +432,7 @@ void testLargeIndices()
                                             stream,
                                             debug_synchronous));
 
-        hipGraphExec_t graph_instance;
+        
         if(use_graphs)
         {
             gHelper.createAndLaunchGraph(stream, true, false);

--- a/test/rocprim/test_device_segmented_scan.cpp
+++ b/test/rocprim/test_device_segmented_scan.cpp
@@ -229,7 +229,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, InclusiveScan)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -416,7 +416,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, ExclusiveScan)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -603,7 +603,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, InclusiveScanUsingHeadFlags)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -791,7 +791,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, ExclusiveScanUsingHeadFlags)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::params::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);

--- a/test/rocprim/test_device_segmented_scan.cpp
+++ b/test/rocprim/test_device_segmented_scan.cpp
@@ -211,10 +211,10 @@ TYPED_TEST(RocprimDeviceSegmentedScan, InclusiveScan)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             HIP_CHECK(
@@ -232,7 +232,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, InclusiveScan)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipDeviceSynchronize());
@@ -257,7 +257,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, InclusiveScan)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+               gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -398,10 +398,10 @@ TYPED_TEST(RocprimDeviceSegmentedScan, ExclusiveScan)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             HIP_CHECK(
@@ -419,7 +419,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, ExclusiveScan)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipDeviceSynchronize());
@@ -444,7 +444,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, ExclusiveScan)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+               gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -587,10 +587,10 @@ TYPED_TEST(RocprimDeviceSegmentedScan, InclusiveScanUsingHeadFlags)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -606,7 +606,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, InclusiveScanUsingHeadFlags)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipDeviceSynchronize());
@@ -631,7 +631,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, InclusiveScanUsingHeadFlags)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+               gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -776,10 +776,10 @@ TYPED_TEST(RocprimDeviceSegmentedScan, ExclusiveScanUsingHeadFlags)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::params::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -794,7 +794,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, ExclusiveScanUsingHeadFlags)
             hipGraphExec_t graph_instance;
             if(TestFixture::params::use_graphs)
             {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipDeviceSynchronize());
@@ -811,7 +811,7 @@ TYPED_TEST(RocprimDeviceSegmentedScan, ExclusiveScanUsingHeadFlags)
 
             if(TestFixture::params::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+               gHelper.cleanupGraphHelper();
             }
 
             HIP_CHECK(hipDeviceSynchronize());

--- a/test/rocprim/test_device_select.cpp
+++ b/test/rocprim/test_device_select.cpp
@@ -189,7 +189,7 @@ TYPED_TEST(RocprimDeviceSelectTests, Flagged)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -352,7 +352,7 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectOp)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -530,7 +530,7 @@ TYPED_TEST(RocprimDeviceSelectTests, Unique)
                     )
                 );
 
-                hipGraphExec_t graph_instance;
+                
                 if(TestFixture::use_graphs)
                 {
                     gHelper.createAndLaunchGraph(stream, true, false);
@@ -738,7 +738,7 @@ void testUniqueGuardedOperator()
                     )
                 );
 
-                hipGraphExec_t graph_instance;
+                
                 if(UseGraphs)
                 {
                     gHelper.createAndLaunchGraph(stream, true, false);
@@ -992,7 +992,7 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKey)
                     )
                 );
 
-                hipGraphExec_t graph_instance;
+                
                 if(TestFixture::use_graphs)
                 {
                     gHelper.createAndLaunchGraph(stream, true, false);
@@ -1195,7 +1195,7 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKeyAlias)
                     stream,
                     debug_synchronous));
 
-                hipGraphExec_t graph_instance;
+                
                 if(TestFixture::use_graphs)
                 {
                     gHelper.createAndLaunchGraph(stream);
@@ -1366,7 +1366,7 @@ TEST_P(RocprimDeviceSelectLargeInputTests, LargeInputFlagged)
             )
         );
 
-        hipGraphExec_t graph_instance;
+        
         if(use_graphs)
         {
             gHelper.createAndLaunchGraph(stream, true, false);
@@ -1483,7 +1483,7 @@ TEST_P(RocprimDeviceSelectLargeInputTests, LargeInputUnique)
                                   stream,
                                   debug_synchronous));
 
-        hipGraphExec_t graph_instance;
+        
         if(use_graphs)
         {
             gHelper.createAndLaunchGraph(stream);

--- a/test/rocprim/test_device_select.cpp
+++ b/test/rocprim/test_device_select.cpp
@@ -1198,7 +1198,7 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKeyAlias)
                 hipGraphExec_t graph_instance;
                 if(TestFixture::use_graphs)
                 {
-                    gHelper.cleanupGraphHelper();
+                    gHelper.createAndLaunchGraph(stream);
                 }
 
                 HIP_CHECK(hipDeviceSynchronize());

--- a/test/rocprim/test_device_select.cpp
+++ b/test/rocprim/test_device_select.cpp
@@ -168,10 +168,10 @@ TYPED_TEST(RocprimDeviceSelectTests, Flagged)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -192,7 +192,7 @@ TYPED_TEST(RocprimDeviceSelectTests, Flagged)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipDeviceSynchronize());
@@ -229,7 +229,7 @@ TYPED_TEST(RocprimDeviceSelectTests, Flagged)
 
             if(TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -331,10 +331,10 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectOp)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -355,7 +355,7 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectOp)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipDeviceSynchronize());
@@ -391,7 +391,7 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectOp)
 
             if(TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -509,10 +509,10 @@ TYPED_TEST(RocprimDeviceSelectTests, Unique)
                 HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
                 HIP_CHECK(hipDeviceSynchronize());
 
-                hipGraph_t graph;
+                test_utils::GraphHelper gHelper;;
                 if(TestFixture::use_graphs)
                 {
-                    graph = test_utils::createGraphHelper(stream);
+                    gHelper.startStreamCapture(stream);
                 }
 
                 // Run
@@ -533,7 +533,7 @@ TYPED_TEST(RocprimDeviceSelectTests, Unique)
                 hipGraphExec_t graph_instance;
                 if(TestFixture::use_graphs)
                 {
-                    graph_instance = graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                    gHelper.createAndLaunchGraph(stream, true, false);
                 }
 
                 HIP_CHECK(hipDeviceSynchronize());
@@ -569,7 +569,7 @@ TYPED_TEST(RocprimDeviceSelectTests, Unique)
 
                 if(TestFixture::use_graphs)
                 {
-                    test_utils::cleanupGraphHelper(graph, graph_instance);
+                    gHelper.cleanupGraphHelper();
                 }
             }
         }
@@ -717,10 +717,10 @@ void testUniqueGuardedOperator()
                 HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
                 HIP_CHECK(hipDeviceSynchronize());
 
-                hipGraph_t graph;
+                test_utils::GraphHelper gHelper;;
                 if(UseGraphs)
                 {
-                    graph = test_utils::createGraphHelper(stream);
+                    gHelper.startStreamCapture(stream);
                 }
 
                 // Run
@@ -741,7 +741,7 @@ void testUniqueGuardedOperator()
                 hipGraphExec_t graph_instance;
                 if(UseGraphs)
                 {
-                    graph_instance = graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                    gHelper.createAndLaunchGraph(stream, true, false);
                 }
 
                 HIP_CHECK(hipDeviceSynchronize());
@@ -778,7 +778,7 @@ void testUniqueGuardedOperator()
 
                 if(UseGraphs)
                 {
-                    test_utils::cleanupGraphHelper(graph, graph_instance);
+                    gHelper.cleanupGraphHelper();
                 }
             }
         }
@@ -969,10 +969,10 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKey)
                 HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
                 HIP_CHECK(hipDeviceSynchronize());
 
-                hipGraph_t graph;
+                test_utils::GraphHelper gHelper;;
                 if(TestFixture::use_graphs)
                 {
-                    graph = test_utils::createGraphHelper(stream);
+                    gHelper.startStreamCapture(stream);
                 }
 
                 // Run
@@ -995,7 +995,7 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKey)
                 hipGraphExec_t graph_instance;
                 if(TestFixture::use_graphs)
                 {
-                    graph_instance = graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                    gHelper.createAndLaunchGraph(stream, true, false);
                 }
 
                 HIP_CHECK(hipDeviceSynchronize());
@@ -1042,7 +1042,7 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKey)
 
                 if(TestFixture::use_graphs)
                 {
-                    test_utils::cleanupGraphHelper(graph, graph_instance);
+                    gHelper.cleanupGraphHelper();
                 }
             }
         }
@@ -1175,10 +1175,10 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKeyAlias)
                     test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
                 HIP_CHECK(hipDeviceSynchronize());
 
-                hipGraph_t graph;
+                test_utils::GraphHelper gHelper;;
                 if(TestFixture::use_graphs)
                 {
-                    graph = test_utils::createGraphHelper(stream);
+                    gHelper.startStreamCapture(stream);
                 }
 
                 // Run
@@ -1198,8 +1198,7 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKeyAlias)
                 hipGraphExec_t graph_instance;
                 if(TestFixture::use_graphs)
                 {
-                    graph_instance = graph_instance
-                        = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                    gHelper.cleanupGraphHelper();
                 }
 
                 HIP_CHECK(hipDeviceSynchronize());
@@ -1237,7 +1236,7 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKeyAlias)
 
                 if(TestFixture::use_graphs)
                 {
-                    test_utils::cleanupGraphHelper(graph, graph_instance);
+                    gHelper.cleanupGraphHelper();
                 }
             }
         }
@@ -1346,10 +1345,10 @@ TEST_P(RocprimDeviceSelectLargeInputTests, LargeInputFlagged)
         HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
         HIP_CHECK(hipDeviceSynchronize());
 
-        hipGraph_t graph;
+        test_utils::GraphHelper gHelper;;
         if(use_graphs)
         {
-            graph = test_utils::createGraphHelper(stream);
+            gHelper.startStreamCapture(stream);
         }
 
         // Run
@@ -1370,7 +1369,7 @@ TEST_P(RocprimDeviceSelectLargeInputTests, LargeInputFlagged)
         hipGraphExec_t graph_instance;
         if(use_graphs)
         {
-            graph_instance = graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+            gHelper.createAndLaunchGraph(stream, true, false);
         }
 
         HIP_CHECK(hipDeviceSynchronize());
@@ -1404,7 +1403,7 @@ TEST_P(RocprimDeviceSelectLargeInputTests, LargeInputFlagged)
 
         if(use_graphs)
         {
-            test_utils::cleanupGraphHelper(graph, graph_instance);
+            gHelper.cleanupGraphHelper();
         }
     }
 
@@ -1468,10 +1467,10 @@ TEST_P(RocprimDeviceSelectLargeInputTests, LargeInputUnique)
         ASSERT_GT(temp_storage_size_bytes, 0);
         HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-        hipGraph_t graph;
+        test_utils::GraphHelper gHelper;;
         if(use_graphs)
         {
-            graph = test_utils::createGraphHelper(stream);
+            gHelper.startStreamCapture(stream);
         }
 
         HIP_CHECK(rocprim::unique(d_temp_storage,
@@ -1487,7 +1486,7 @@ TEST_P(RocprimDeviceSelectLargeInputTests, LargeInputUnique)
         hipGraphExec_t graph_instance;
         if(use_graphs)
         {
-            graph_instance = graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
+            gHelper.createAndLaunchGraph(stream);
         }
 
         size_t unique_count_output{};
@@ -1513,7 +1512,7 @@ TEST_P(RocprimDeviceSelectLargeInputTests, LargeInputUnique)
         HIP_CHECK(hipFree(d_temp_storage));
 
         if (use_graphs)
-            test_utils::cleanupGraphHelper(graph, graph_instance);
+            gHelper.cleanupGraphHelper();
     }
 
     if (use_graphs)

--- a/test/rocprim/test_device_transform.cpp
+++ b/test/rocprim/test_device_transform.cpp
@@ -158,10 +158,10 @@ TYPED_TEST(RocprimDeviceTransformTests, Transform)
             std::vector<U> expected(input.size());
             std::transform(input.begin(), input.end(), expected.begin(), transform<U>());
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -176,7 +176,7 @@ TYPED_TEST(RocprimDeviceTransformTests, Transform)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -201,7 +201,7 @@ TYPED_TEST(RocprimDeviceTransformTests, Transform)
 
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                 gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }
@@ -281,10 +281,10 @@ TYPED_TEST(RocprimDeviceTransformTests, BinaryTransform)
                 expected.begin(), binary_transform<T1, T2, U>()
             );
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -299,7 +299,7 @@ TYPED_TEST(RocprimDeviceTransformTests, BinaryTransform)
             hipGraphExec_t graph_instance;
             if(TestFixture::use_graphs)
             {
-                graph_instance = graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -325,7 +325,7 @@ TYPED_TEST(RocprimDeviceTransformTests, BinaryTransform)
             
             if (TestFixture::use_graphs)
             {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                 gHelper.cleanupGraphHelper();
                 HIP_CHECK(hipStreamDestroy(stream));
             }
         }
@@ -390,10 +390,10 @@ void testLargeIndices()
                 return 0;
             };
 
-            hipGraph_t graph;
+            test_utils::GraphHelper gHelper;
             if(UseGraphs)
             {
-                graph = test_utils::createGraphHelper(stream);
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
@@ -403,7 +403,7 @@ void testLargeIndices()
             hipGraphExec_t graph_instance;
             if(UseGraphs)
             {
-                graph_instance = graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, false);
+                gHelper.createAndLaunchGraph(stream, true, false);
             }
 
             HIP_CHECK(hipGetLastError());
@@ -419,7 +419,7 @@ void testLargeIndices()
             HIP_CHECK(hipFree(d_flag));
 
             if (UseGraphs)
-                test_utils::cleanupGraphHelper(graph, graph_instance);
+                 gHelper.cleanupGraphHelper();
         }
     }
 

--- a/test/rocprim/test_device_transform.cpp
+++ b/test/rocprim/test_device_transform.cpp
@@ -173,7 +173,7 @@ TYPED_TEST(RocprimDeviceTransformTests, Transform)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -296,7 +296,7 @@ TYPED_TEST(RocprimDeviceTransformTests, BinaryTransform)
                 )
             );
 
-            hipGraphExec_t graph_instance;
+            
             if(TestFixture::use_graphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);
@@ -400,7 +400,7 @@ void testLargeIndices()
             HIP_CHECK(
                 rocprim::transform(input, output, size, flag_expected, stream, debug_synchronous));
 
-            hipGraphExec_t graph_instance;
+            
             if(UseGraphs)
             {
                 gHelper.createAndLaunchGraph(stream, true, false);

--- a/test/rocprim/test_discard_iterator.cpp
+++ b/test/rocprim/test_discard_iterator.cpp
@@ -180,4 +180,5 @@ TEST(RocprimDiscardIteratorTests, ReduceByKey)
     HIP_CHECK(hipFree(d_keys_input));
     HIP_CHECK(hipFree(d_values_input));
     HIP_CHECK(hipFree(d_aggregates_output));
+    HIP_CHECK(hipFree(d_temporary_storage));
 }

--- a/test/rocprim/test_lookback_reproducibility.cpp
+++ b/test/rocprim/test_lookback_reproducibility.cpp
@@ -304,7 +304,6 @@ TYPED_TEST(RocprimLookbackReproducibilityTests, ScanByKey)
 
             HIP_CHECK(hipFree(d_output));
             HIP_CHECK(hipFree(d_input));
-            HIP_CHECK(hipFree(d_output));
         }
     }
 }

--- a/test/rocprim/test_lookback_reproducibility.cpp
+++ b/test/rocprim/test_lookback_reproducibility.cpp
@@ -106,6 +106,8 @@ void test_reproducibility(S scan_op, F run_test)
     auto second = run_test(eepy_scan_op);
     // We want the result to be bitwise equal, even if the inputs/outputs are floats.
     ASSERT_NO_FATAL_FAILURE(test_utils::assert_bit_eq(first, second));
+
+    HIP_CHECK(hipFree(d_enable_sleep));
 }
 
 template<typename T>
@@ -199,12 +201,12 @@ TYPED_TEST(RocprimLookbackReproducibilityTests, Scan)
                                         d_output,
                                         output.size() * sizeof(T),
                                         hipMemcpyDeviceToHost));
-                    hipFree(d_temp_storage);
+                    HIP_CHECK(hipFree(d_temp_storage));
                     return output;
                 });
 
-            hipFree(d_input);
-            hipFree(d_output);
+            HIP_CHECK(hipFree(d_input));
+            HIP_CHECK(hipFree(d_output));
         }
     }
 }
@@ -296,12 +298,13 @@ TYPED_TEST(RocprimLookbackReproducibilityTests, ScanByKey)
                                         d_output,
                                         output.size() * sizeof(V),
                                         hipMemcpyDeviceToHost));
-                    hipFree(d_temp_storage);
+                    HIP_CHECK(hipFree(d_temp_storage));
                     return output;
                 });
 
-            hipFree(d_input);
-            hipFree(d_output);
+            HIP_CHECK(hipFree(d_output));
+            HIP_CHECK(hipFree(d_input));
+            HIP_CHECK(hipFree(d_output));
         }
     }
 }
@@ -409,13 +412,14 @@ TYPED_TEST(RocprimLookbackReproducibilityTests, ReduceByKey)
                                         d_output,
                                         output.size() * sizeof(V),
                                         hipMemcpyDeviceToHost));
-                    hipFree(d_temp_storage);
+                    HIP_CHECK(hipFree(d_temp_storage));
                     return output;
                 });
 
-            hipFree(d_input);
-            hipFree(d_output);
-            hipFree(d_unique_count_output);
+            HIP_CHECK(hipFree(d_keys));
+            HIP_CHECK(hipFree(d_input));
+            HIP_CHECK(hipFree(d_output));
+            HIP_CHECK(hipFree(d_unique_count_output));
         }
     }
 }

--- a/test/rocprim/test_utils_hipgraphs.hpp
+++ b/test/rocprim/test_utils_hipgraphs.hpp
@@ -60,8 +60,11 @@ namespace test_utils
                 HIP_CHECK(hipGraphInstantiate(&graph_instance, graph, nullptr, nullptr, 0));
             }
 
-            inline void launchGraph(hipStream_t & stream){
+            inline void launchGraph(hipStream_t & stream, const bool sync=false){
                 HIP_CHECK(hipGraphLaunch(graph_instance, stream));
+
+                if (sync)
+                    HIP_CHECK(hipStreamSynchronize(stream));
             }
 
             inline void createAndLaunchGraph(hipStream_t & stream, const bool launchGraph=true, const bool sync=true){

--- a/test/rocprim/test_utils_hipgraphs.hpp
+++ b/test/rocprim/test_utils_hipgraphs.hpp
@@ -19,17 +19,6 @@
 // THE SOFTWARE.
 
 
-            // test_utils::GraphHelper gHelper;
-            //     gHelper.startStreamCapture(stream);
-
-            //     gHelper.createAndLaunchGraph(stream);
-
-            //     gHelper.cleanupGraphHelper();
-
-            //     gHelper.resetGraphHelper(stream);
-
-
-
 #ifndef ROCPRIM_TEST_UTILS_HIPGRAPHS_HPP
 #define ROCPRIM_TEST_UTILS_HIPGRAPHS_HPP
 

--- a/test/rocprim/test_utils_hipgraphs.hpp
+++ b/test/rocprim/test_utils_hipgraphs.hpp
@@ -86,15 +86,6 @@ namespace test_utils
                     startStreamCapture(stream);
 
             }
-
-            inline void launchGraphHelper(hipStream_t& stream,const bool sync=false)
-            {
-                HIP_CHECK(hipGraphLaunch(this->graph_instance, stream));
-
-                // Optionally sync after the launch
-                if (sync)
-                    HIP_CHECK(hipStreamSynchronize(stream));
-            }
     };
 
 } // end namespace test_utils

--- a/test/rocprim/test_utils_hipgraphs.hpp
+++ b/test/rocprim/test_utils_hipgraphs.hpp
@@ -18,6 +18,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+
+            // test_utils::GraphHelper gHelper;
+            //     gHelper.startStreamCapture(stream);
+
+            //     gHelper.createAndLaunchGraph(stream);
+
+            //     gHelper.cleanupGraphHelper();
+
+            //     gHelper.resetGraphHelper(stream);
+
+
+
 #ifndef ROCPRIM_TEST_UTILS_HIPGRAPHS_HPP
 #define ROCPRIM_TEST_UTILS_HIPGRAPHS_HPP
 
@@ -37,32 +49,32 @@ namespace test_utils
         public:
 
             inline void startStreamCapture(hipStream_t & stream){
-                HIP_CHECK_NON_VOID(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+                HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
             }
 
             inline void endStreamCapture(hipStream_t & stream){
-                HIP_CHECK_NON_VOID(hipStreamEndCapture(stream, &graph));
+                HIP_CHECK(hipStreamEndCapture(stream, &graph));
             }
 
             inline void createAndLaunchGraph(hipStream_t & stream, const bool launchGraph=true, const bool sync=true){
                 
                 endStreamCapture(stream);
                 
-                HIP_CHECK_NON_VOID(hipGraphInstantiate(&graph_instance, graph, nullptr, nullptr, 0));
+                HIP_CHECK(hipGraphInstantiate(&graph_instance, graph, nullptr, nullptr, 0));
 
                 // Optionally launch the graph
                 if (launchGraph)
-                    HIP_CHECK_NON_VOID(hipGraphLaunch(graph_instance, stream));
+                    HIP_CHECK(hipGraphLaunch(graph_instance, stream));
 
                 // Optionally synchronize the stream when we're done
                 if (sync)
-                    HIP_CHECK_NON_VOID(hipStreamSynchronize(stream));
+                    HIP_CHECK(hipStreamSynchronize(stream));
             } 
     
             inline void cleanupGraphHelper()
             {
-                HIP_CHECK_NON_VOID(hipGraphDestroy(this->graph));
-                HIP_CHECK_NON_VOID(hipGraphExecDestroy(this->graph_instance));
+                HIP_CHECK(hipGraphDestroy(this->graph));
+                HIP_CHECK(hipGraphExecDestroy(this->graph_instance));
             }
 
             inline void resetGraphHelper(hipStream_t& stream, const bool beginCapture=true)
@@ -78,11 +90,11 @@ namespace test_utils
 
             inline void launchGraphHelper(hipStream_t& stream,const bool sync=false)
             {
-                HIP_CHECK_NON_VOID(hipGraphLaunch(this->graph_instance, stream));
+                HIP_CHECK(hipGraphLaunch(this->graph_instance, stream));
 
                 // Optionally sync after the launch
                 if (sync)
-                    HIP_CHECK_NON_VOID(hipStreamSynchronize(stream));
+                    HIP_CHECK(hipStreamSynchronize(stream));
             }
     };
 

--- a/test/rocprim/test_utils_hipgraphs.hpp
+++ b/test/rocprim/test_utils_hipgraphs.hpp
@@ -55,6 +55,14 @@ namespace test_utils
             inline void endStreamCapture(hipStream_t & stream){
                 HIP_CHECK(hipStreamEndCapture(stream, &graph));
             }
+            
+            inline void createGraph(){
+                HIP_CHECK(hipGraphInstantiate(&graph_instance, graph, nullptr, nullptr, 0));
+            }
+
+            inline void launchGraph(hipStream_t & stream){
+                HIP_CHECK(hipGraphLaunch(graph_instance, stream));
+            }
 
             inline void createAndLaunchGraph(hipStream_t & stream, const bool launchGraph=true, const bool sync=true){
                 
@@ -69,8 +77,8 @@ namespace test_utils
                 // Optionally synchronize the stream when we're done
                 if (sync)
                     HIP_CHECK(hipStreamSynchronize(stream));
-            } 
-    
+            }
+
             inline void cleanupGraphHelper()
             {
                 HIP_CHECK(hipGraphDestroy(this->graph));

--- a/test/rocprim/test_utils_hipgraphs.hpp
+++ b/test/rocprim/test_utils_hipgraphs.hpp
@@ -96,7 +96,6 @@ namespace test_utils
                 if(beginCapture)
                     startStreamCapture(stream);
 
-                createAndLaunchGraph(stream);
             }
 
             inline void launchGraphHelper(hipStream_t& stream,const bool sync=false)

--- a/test/rocprim/test_warp_scan.hpp
+++ b/test/rocprim/test_warp_scan.hpp
@@ -1212,6 +1212,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
         HIP_CHECK(hipFree(device_input));
         HIP_CHECK(hipFree(device_inclusive_output));
         HIP_CHECK(hipFree(device_exclusive_output));
+        HIP_CHECK(hipFree(device_output_reductions));
     }
 
 }


### PR DESCRIPTION
Adding missing hip free calls and fixing hip graph calls.

