### PR TITLE
[Doc] Cherry pick - Bump rocm-docs-core from 1.7.1 to 1.8.2 in /docs/sphinx (#612) 

### DIFF
--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core==1.4.1
+rocm-docs-core==1.8.2

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -92,7 +92,7 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.4.1
+rocm-docs-core==1.8.2
     # via -r requirements.in
 smmap==5.0.1
     # via gitdb


### PR DESCRIPTION
Includes updates for rocm-docs-core to keep header version number current for the "latest" version of the doc build