### PR TITLE
Update version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ if(USE_HIP_CPU)
 endif()
 
 # Setup VERSION
-set(VERSION_STRING "3.2.0")
+set(VERSION_STRING "3.2.2")
 rocm_setup_version(VERSION ${VERSION_STRING})
 
 # Print configuration summary


### PR DESCRIPTION
Several cherrypicks to 6.2 didn't include packaging version update.