### PR TITLE
Fix clang compilation error: missing-template-arg-list-after-template-kw

### DIFF
--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -526,15 +526,15 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void sort_single(KeysInputIterator    keys_i
 
     ROCPRIM_SHARED_MEMORY typename sort_single_helper::storage_type storage;
 
-    sort_single_helper().template sort_single(keys_input,
-                                              keys_output,
-                                              values_input,
-                                              values_output,
-                                              size,
-                                              decomposer,
-                                              bit,
-                                              current_radix_bits,
-                                              storage);
+    sort_single_helper().template sort_single<>(keys_input,
+                                                keys_output,
+                                                values_input,
+                                                values_output,
+                                                size,
+                                                decomposer,
+                                                bit,
+                                                current_radix_bits,
+                                                storage);
 }
 
 template<class T>


### PR DESCRIPTION
Full text of error:

  a template argument list is expected after a name prefixed by the template
  keyword [-Wmissing-template-arg-list-after-template-kw]

Found while testing a recent build of clang 20, though I think clang 19 will also complain.