### PR TITLE
Block Radix Sort improvements and Segmented Radix Sort tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projects/rocPRIM/en/latest/](https://rocm.docs.amd.com/projects/rocPRIM/en/latest/).
 
-
 ## (Unreleased) rocPRIM 3.4.0 for ROCm 6.4.0
 
 ### Added
+
 * Added extended tests to `rtest.py`. These tests are extra tests that did not fit the criteria of smoke and regression tests. These tests will take much longer to run relative to smoke and regression tests.
  * Use `python rtest.py [--emulation|-e|--test|-t]=extended` to run these tests.
 * Added regression tests to `rtest.py`. Regression tests are a subset of tests that caused hardware problems for past emulation environments.
@@ -13,12 +13,17 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Added the parallel `find_first_of` device function with autotuned configurations, this function is similar to `std::find_first_of`, it searches for the first occurrence of any of the provided elements.
 * Added `--emulation` option added for `rtest.py`
   * Unit tests can be run with `[--emulation|-e|--test|-t]=<test_name>`
+* Added tuned configurations for segmented radix sort for gfx942 to improve performance on this architecture.
 
 ### Changed
+
 * Changed the subset of tests that are run for smoke tests such that the smoke test will complete with faster run-time and to never exceed 2GB of vram usage. Use `python rtest.py [--emulation|-e|--test|-t]=smoke` to run these tests.
 * The `rtest.py` options have changed. `rtest.py` is now run with at least either `--test|-t` or `--emulation|-e`, but not both options.
+* Changed the internal algorithm of block radix sort to use rank match to improve performance of various radix sort related algorithms.
+* Disabled padding in various cases where higher occupancy resulted in better performance despite more bank conflicts.
 
 ### Resolved issues
+
 * Fixed an issue where `rmake.py` would generate wrong CMAKE commands while using Linux environment
 * Fixed an issue where `rocprim::partial_sort_copy` would yield a compile error if the input iterator is const.
 * Fixed incorrect 128-bit signed and unsigned integers type traits.

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -24,6 +24,9 @@ option(BENCHMARK_CONFIG_TUNING "Benchmark device-level functions using various c
 include(../cmake/ConfigAutotune.cmake)
 include(ConfigAutotuneSettings.cmake)
 
+option(BENCHMARK_TUNE_PARAM_NAMES "Tuning parameter names" "")
+option(BENCHMARK_TUNE_PARAMS "Tuning parameters" "")
+
 if(BENCHMARK_CONFIG_TUNING)
   add_custom_target("benchmark_config_tuning")
 endif()
@@ -35,6 +38,12 @@ function(add_rocprim_benchmark BENCHMARK_SOURCE)
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${BENCHMARK_TARGET}.parallel.cpp.in")
       message(STATUS "found ${BENCHMARK_TARGET}.parallel.cpp.in file, compiling in parallel.")
       read_config_autotune_settings(${BENCHMARK_TARGET} list_across_names list_across output_pattern_suffix)
+
+      if(BENCHMARK_TUNE_PARAM_NAMES AND BENCHMARK_TUNE_PARAMS)
+        set(list_across_names "${BENCHMARK_TUNE_PARAM_NAMES}")
+        set(list_across "${BENCHMARK_TUNE_PARAMS}")
+      endif()
+
       #make sure that variables are not empty, i.e. there actually is an entry for that benchmark in benchmark/ConfigAutotuneSettings.cmake
       if(list_across_names)
         add_executable(${BENCHMARK_TARGET} ${BENCHMARK_SOURCE})

--- a/benchmark/ConfigAutotuneSettings.cmake
+++ b/benchmark/ConfigAutotuneSettings.cmake
@@ -82,6 +82,7 @@ ${TUNING_TYPES};${LIMITED_TUNING_TYPES};using_warp_scan reduce_then_scan" PARENT
 binary_search upper_bound lower_bound;${TUNING_TYPES};${LIMITED_TUNING_TYPES};64 128 256;1 2 4 8 16" PARENT_SCOPE)
     set(output_pattern_suffix "@SubAlgorithm@_@ValueType@_@OutputType@_@BlockSize@_@ItemsPerThread@" PARENT_SCOPE)
   elseif(file STREQUAL "benchmark_device_segmented_radix_sort_keys")
+    # !!!
     set(list_across_names "\
 KeyType;BlockSize;ItemsPerThread;PartitionAllowed" PARENT_SCOPE)
     set(list_across "${TUNING_TYPES};128 256;4 8 16;false" PARENT_SCOPE)

--- a/benchmark/ConfigAutotuneSettings.cmake
+++ b/benchmark/ConfigAutotuneSettings.cmake
@@ -82,18 +82,17 @@ ${TUNING_TYPES};${LIMITED_TUNING_TYPES};using_warp_scan reduce_then_scan" PARENT
 binary_search upper_bound lower_bound;${TUNING_TYPES};${LIMITED_TUNING_TYPES};64 128 256;1 2 4 8 16" PARENT_SCOPE)
     set(output_pattern_suffix "@SubAlgorithm@_@ValueType@_@OutputType@_@BlockSize@_@ItemsPerThread@" PARENT_SCOPE)
   elseif(file STREQUAL "benchmark_device_segmented_radix_sort_keys")
-    # !!!
     set(list_across_names "\
-KeyType;BlockSize;ItemsPerThread;PartitionAllowed" PARENT_SCOPE)
-    set(list_across "${TUNING_TYPES};128 256;4 8 16;false" PARENT_SCOPE)
+KeyType;LongBits;BlockSize;ItemsPerThread;WarpSmallLWS;WarpSmallIPT;WarpSmallBS;WarpPartition;WarpMediumLWS;WarpMediumIPT;WarpMediumBS" PARENT_SCOPE)
+    set(list_across "${TUNING_TYPES};8;256;4 8 16;8;4;256;64;16;8;256" PARENT_SCOPE)
     set(output_pattern_suffix "\
-@KeyType@_@BlockSize@_@ItemsPerThread@_@PartitionAllowed@" PARENT_SCOPE)
+@KeyType@_@LongBits@_@BlockSize@_@ItemsPerThread@_@WarpSmallLWS@_@WarpSmallIPT@_@WarpSmallBS@_@WarpPartition@_@WarpMediumLWS@_@WarpMediumIPT@_@WarpMediumBS@" PARENT_SCOPE)
   elseif(file STREQUAL "benchmark_device_segmented_radix_sort_pairs")
     set(list_across_names "\
-KeyType;ValueType;BlockSize;ItemsPerThread;PartitionAllowed" PARENT_SCOPE)
-    set(list_across "${TUNING_TYPES};int8_t;64;4 8 16;true false" PARENT_SCOPE)
+KeyType;ValueType;LongBits;BlockSize;ItemsPerThread;WarpSmallLWS;WarpSmallIPT;WarpSmallBS;WarpPartition;WarpMediumLWS;WarpMediumIPT;WarpMediumBS" PARENT_SCOPE)
+    set(list_across "${TUNING_TYPES};int8_t;8;256;4 8 16;8;4;256;64;16;8;256" PARENT_SCOPE)
     set(output_pattern_suffix "\
-@KeyType@_@ValueType@_@BlockSize@_@ItemsPerThread@_@PartitionAllowed@" PARENT_SCOPE)
+@KeyType@_@ValueType@_@LongBits@_@BlockSize@_@ItemsPerThread@_@WarpSmallLWS@_@WarpSmallIPT@_@WarpSmallBS@_@WarpPartition@_@WarpMediumLWS@_@WarpMediumIPT@_@WarpMediumBS@" PARENT_SCOPE)
   elseif(file STREQUAL "benchmark_device_transform")
     set(list_across_names "\
 DataType;BlockSize;" PARENT_SCOPE)

--- a/benchmark/benchmark_device_segmented_radix_sort_keys.cpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_keys.cpp
@@ -291,7 +291,7 @@ int main(int argc, char* argv[])
     config_autotune_register::register_benchmark_subset(benchmarks,
                                                         parallel_instance,
                                                         parallel_instances,
-                                                        size,
+                                                        min_size,
                                                         seed,
                                                         stream);
 #else

--- a/benchmark/benchmark_device_segmented_radix_sort_keys.parallel.cpp.in
+++ b/benchmark/benchmark_device_segmented_radix_sort_keys.parallel.cpp.in
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,8 +27,20 @@
 
 namespace
 {
-auto benchmarks = config_autotune_register::create_bulk(device_segmented_radix_sort_benchmark_generator<@BlockSize@,
-                                                                                                        @ItemsPerThread@,
-                                                                                                        @KeyType@,
-                                                                                                        @PartitionAllowed@>::create);
+auto benchmarks = config_autotune_register::create_bulk(
+    device_segmented_radix_sort_benchmark_generator<
+        @LongBits@,
+        @ShortBits@,
+        @BlockSize@,
+        @ItemsPerThread@,
+        @WarpSmallLWS@,
+        @WarpSmallIPT@,
+        @WarpSmallBS@,
+        @WarpPartition@,
+        @WarpMediumLWS@,
+        @WarpMediumIPT@,
+        @WarpMediumBS@,
+        @KeyType@,
+        true
+    >::create);
 } // namespace

--- a/benchmark/benchmark_device_segmented_radix_sort_keys.parallel.cpp.in
+++ b/benchmark/benchmark_device_segmented_radix_sort_keys.parallel.cpp.in
@@ -30,7 +30,7 @@ namespace
 auto benchmarks = config_autotune_register::create_bulk(
     device_segmented_radix_sort_benchmark_generator<
         @LongBits@,
-        @ShortBits@,
+        0,
         @BlockSize@,
         @ItemsPerThread@,
         @WarpSmallLWS@,

--- a/benchmark/benchmark_device_segmented_radix_sort_keys.parallel.hpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_keys.parallel.hpp
@@ -261,92 +261,38 @@ struct device_segmented_radix_sort_benchmark : public config_autotune_interface
 
 template<typename Tp, template<Tp> class T, bool enable, Tp... Idx>
 struct decider;
-template<unsigned int BlockSize, unsigned int ItemsPerThread, typename Key, bool PartitionAllowed>
+
+template<unsigned int LongBits,
+         unsigned int ShortBits,
+         unsigned int BlockSize,
+         unsigned int ItemsPerThread,
+         unsigned int WarpSmallLWS,
+         unsigned int WarpSmallIPT,
+         unsigned int WarpSmallBS,
+         unsigned int WarpPartition,
+         unsigned int WarpMediumLWS,
+         unsigned int WarpMediumIPT,
+         unsigned int WarpMediumBS,
+         typename Key,
+         bool UnpartitionWarpAllowed = true>
 struct device_segmented_radix_sort_benchmark_generator
 {
-    template<unsigned int LongBits>
-    struct create_lrb
-    {
-        template<unsigned int ShortBits>
-        struct create_srb
-        {
-            template<bool EnableUnpartitionedWarpSort>
-            struct create_euws
-            {
-                template<unsigned int LogicalWarpSizeSmall>
-                struct create_lwss
-                {
-                    template<unsigned int PartitioningThreshold>
-                    struct create_pt
-                    {
-                        void operator()(
-                            std::vector<std::unique_ptr<config_autotune_interface>>& storage)
-                        {
-                            storage.emplace_back(
-                                std::make_unique<device_segmented_radix_sort_benchmark<
-                                    Key,
-                                    rocprim::segmented_radix_sort_config<
-                                        LongBits,
-                                        ShortBits,
-                                        rocprim::kernel_config<BlockSize, ItemsPerThread>,
-                                        rocprim::WarpSortConfig<LogicalWarpSizeSmall / 2,
-                                                                ItemsPerThread / 2,
-                                                                BlockSize,
-                                                                PartitioningThreshold,
-                                                                LogicalWarpSizeSmall,
-                                                                ItemsPerThread,
-                                                                BlockSize>,
-                                        EnableUnpartitionedWarpSort>>>());
-                        }
-                    };
-
-                    void
-                        operator()(std::vector<std::unique_ptr<config_autotune_interface>>& storage)
-                    {
-                        static_for_each<std::integer_sequence<unsigned int, 5>, create_pt>(storage);
-                    }
-                };
-
-                void operator()(std::vector<std::unique_ptr<config_autotune_interface>>& storage)
-                {
-                    if(PartitionAllowed)
-                    {
-
-                        static_for_each<std::integer_sequence<unsigned int, 8, 16, 32>,
-                                        create_lwss>(storage);
-                    }
-                    else
-                    {
-                        storage.emplace_back(
-                            std::make_unique<device_segmented_radix_sort_benchmark<
-                                Key,
-                                rocprim::segmented_radix_sort_config<
-                                    LongBits,
-                                    ShortBits,
-                                    rocprim::kernel_config<BlockSize, ItemsPerThread>,
-                                    rocprim::DisabledWarpSortConfig,
-                                    EnableUnpartitionedWarpSort>>>());
-                    }
-                }
-            };
-
-            void operator()(std::vector<std::unique_ptr<config_autotune_interface>>& storage)
-            {
-                decider<bool, create_euws, 1u << ShortBits <= BlockSize, true>::do_the_thing(
-                    storage);
-            }
-        };
-
-        void operator()(std::vector<std::unique_ptr<config_autotune_interface>>& storage)
-        {
-            decider<unsigned int, create_srb, 1u << LongBits <= BlockSize, 3, 5>::do_the_thing(
-                storage);
-        }
-    };
-
     static void create(std::vector<std::unique_ptr<config_autotune_interface>>& storage)
     {
-        static_for_each<std::integer_sequence<unsigned int, 4, 5>, create_lrb>(storage);
+        storage.emplace_back(std::make_unique<device_segmented_radix_sort_benchmark<
+                                 Key,
+                                 rocprim::segmented_radix_sort_config<
+                                     LongBits,
+                                     ShortBits,
+                                     rocprim::kernel_config<BlockSize, ItemsPerThread>,
+                                     rocprim::WarpSortConfig<WarpSmallLWS,
+                                                             WarpSmallIPT,
+                                                             WarpSmallBS,
+                                                             WarpPartition,
+                                                             WarpMediumLWS,
+                                                             WarpMediumIPT,
+                                                             WarpMediumBS>,
+                                     UnpartitionWarpAllowed>>>());
     }
 };
 

--- a/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.cpp.in
+++ b/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.cpp.in
@@ -30,7 +30,7 @@ namespace
 auto benchmarks = config_autotune_register::create_bulk(
     device_segmented_radix_sort_benchmark_generator<
         @LongBits@,
-        @ShortBits@,
+        8,
         @BlockSize@,
         @ItemsPerThread@,
         @WarpSmallLWS@,

--- a/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.cpp.in
+++ b/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.cpp.in
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,9 +27,21 @@
 
 namespace
 {
-auto benchmarks = config_autotune_register::create_bulk(device_segmented_radix_sort_benchmark_generator<@BlockSize@,
-                                                                                                        @ItemsPerThread@,
-                                                                                                        @KeyType@,
-                                                                                                        @ValueType@,
-                                                                                                        @PartitionAllowed@>::create);
+auto benchmarks = config_autotune_register::create_bulk(
+    device_segmented_radix_sort_benchmark_generator<
+        @LongBits@,
+        @ShortBits@,
+        @BlockSize@,
+        @ItemsPerThread@,
+        @WarpSmallLWS@,
+        @WarpSmallIPT@,
+        @WarpSmallBS@,
+        @WarpPartition@,
+        @WarpMediumLWS@,
+        @WarpMediumIPT@,
+        @WarpMediumBS@,
+        @KeyType@,
+        @ValueType@,
+        true
+    >::create);
 } // namespace

--- a/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.hpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.hpp
@@ -286,97 +286,40 @@ struct device_segmented_radix_sort_benchmark : public config_autotune_interface
 
 template<typename Tp, template<Tp> class T, bool enable, Tp... Idx>
 struct decider;
-template<unsigned int BlockSize,
+
+template<unsigned int LongBits,
+         unsigned int ShortBits,
+         unsigned int BlockSize,
          unsigned int ItemsPerThread,
+         unsigned int WarpSmallLWS,
+         unsigned int WarpSmallIPT,
+         unsigned int WarpSmallBS,
+         unsigned int WarpPartition,
+         unsigned int WarpMediumLWS,
+         unsigned int WarpMediumIPT,
+         unsigned int WarpMediumBS,
          typename Key,
          typename Value,
-         bool PartitionAllowed>
+         bool UnpartitionWarpAllowed = true>
 struct device_segmented_radix_sort_benchmark_generator
 {
-    template<unsigned int LongBits>
-    struct create_lrb
-    {
-        template<unsigned int ShortBits>
-        struct create_srb
-        {
-            template<bool EnableUnpartitionedWarpSort>
-            struct create_euws
-            {
-                template<unsigned int LogicalWarpSizeSmall>
-                struct create_lwss
-                {
-                    template<unsigned int PartitioningThreshold>
-                    struct create_pt
-                    {
-                        void operator()(
-                            std::vector<std::unique_ptr<config_autotune_interface>>& storage)
-                        {
-                            storage.emplace_back(
-                                std::make_unique<device_segmented_radix_sort_benchmark<
-                                    Key,
-                                    Value,
-                                    rocprim::segmented_radix_sort_config<
-                                        LongBits,
-                                        ShortBits,
-                                        rocprim::kernel_config<BlockSize, ItemsPerThread>,
-                                        rocprim::WarpSortConfig<LogicalWarpSizeSmall / 2,
-                                                                ItemsPerThread / 2,
-                                                                BlockSize,
-                                                                PartitioningThreshold,
-                                                                LogicalWarpSizeSmall,
-                                                                ItemsPerThread,
-                                                                BlockSize>,
-                                        EnableUnpartitionedWarpSort>>>());
-                        }
-                    };
-
-                    void
-                        operator()(std::vector<std::unique_ptr<config_autotune_interface>>& storage)
-                    {
-                        static_for_each<std::integer_sequence<unsigned int, 5>, create_pt>(storage);
-                    }
-                };
-
-                void operator()(std::vector<std::unique_ptr<config_autotune_interface>>& storage)
-                {
-                    if(PartitionAllowed)
-                    {
-
-                        static_for_each<std::integer_sequence<unsigned int, 8, 16, 32>,
-                                        create_lwss>(storage);
-                    }
-                    else
-                    {
-                        storage.emplace_back(
-                            std::make_unique<device_segmented_radix_sort_benchmark<
-                                Key,
-                                Value,
-                                rocprim::segmented_radix_sort_config<
-                                    LongBits,
-                                    ShortBits,
-                                    rocprim::kernel_config<BlockSize, ItemsPerThread>,
-                                    rocprim::DisabledWarpSortConfig,
-                                    EnableUnpartitionedWarpSort>>>());
-                    }
-                }
-            };
-
-            void operator()(std::vector<std::unique_ptr<config_autotune_interface>>& storage)
-            {
-                static_for_each<std::integer_sequence<bool, true>, create_euws>(storage);
-            }
-        };
-
-        void operator()(std::vector<std::unique_ptr<config_autotune_interface>>& storage)
-        {
-            decider<unsigned int, create_srb, 1u << LongBits <= BlockSize, 2, 4>::do_the_thing(
-                storage);
-        }
-    };
-
     static void create(std::vector<std::unique_ptr<config_autotune_interface>>& storage)
     {
-        static_for_each<std::integer_sequence<unsigned int, 6, 7>, create_lrb>(storage);
+        storage.emplace_back(std::make_unique<device_segmented_radix_sort_benchmark<
+                                 Key,
+                                 Value,
+                                 rocprim::segmented_radix_sort_config<
+                                     LongBits,
+                                     ShortBits,
+                                     rocprim::kernel_config<BlockSize, ItemsPerThread>,
+                                     rocprim::WarpSortConfig<WarpSmallLWS,
+                                                             WarpSmallIPT,
+                                                             WarpSmallBS,
+                                                             WarpPartition,
+                                                             WarpMediumLWS,
+                                                             WarpMediumIPT,
+                                                             WarpMediumBS>,
+                                     UnpartitionWarpAllowed>>>());
     }
 };
 

--- a/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.hpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.hpp
@@ -131,9 +131,9 @@ struct device_segmented_radix_sort_benchmark : public config_autotune_interface
                                         seed.get_0());
 
         std::vector<value_type> values_input
-            = get_random_data<key_type>(size,
-                                        generate_limits<key_type>::min(),
-                                        generate_limits<key_type>::max(),
+            = get_random_data<value_type>(size,
+                                        generate_limits<value_type>::min(),
+                                        generate_limits<value_type>::max(),
                                         seed.get_0());
 
         size_t batch_size = 1;

--- a/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.hpp
+++ b/benchmark/benchmark_device_segmented_radix_sort_pairs.parallel.hpp
@@ -132,9 +132,9 @@ struct device_segmented_radix_sort_benchmark : public config_autotune_interface
 
         std::vector<value_type> values_input
             = get_random_data<value_type>(size,
-                                        generate_limits<value_type>::min(),
-                                        generate_limits<value_type>::max(),
-                                        seed.get_0());
+                                          generate_limits<value_type>::min(),
+                                          generate_limits<value_type>::max(),
+                                          seed.get_0());
 
         size_t batch_size = 1;
         if(size < target_size)

--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -208,7 +208,10 @@ inline auto generate_random_data_n(OutputIterator it,
     using T = typename std::iterator_traits<OutputIterator>::value_type;
 
     // Generate floats when T is half
-    using dis_type = std::conditional_t<std::is_same<rocprim::half, T>::value, float, T>;
+    using dis_type = std::conditional_t<std::is_same<rocprim::half, T>::value
+                                            || std::is_same<rocprim::bfloat16, T>::value,
+                                        float,
+                                        T>;
     std::uniform_real_distribution<dis_type> distribution((dis_type)min, (dis_type)max);
     std::generate_n(it, std::min(size, max_random_size), [&]() { return distribution(gen); });
     for(size_t i = max_random_size; i < size; i += max_random_size)
@@ -929,6 +932,11 @@ template<>
 inline const char* Traits<rocprim::half>::name()
 {
     return "rocprim::half";
+}
+template<>
+inline const char* Traits<rocprim::bfloat16>::name()
+{
+    return "rocprim::bfloat16";
 }
 template<>
 inline const char* Traits<long long>::name()

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -597,6 +597,41 @@ public:
         }
     }
 
+    template<unsigned int WarpSize = device_warp_size(), class U, class Offset>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void scatter_to_warp_striped(const T (&input)[ItemsPerThread],
+                                 U (&output)[ItemsPerThread],
+                                 const Offset (&ranks)[ItemsPerThread],
+                                 storage_type& storage)
+    {
+        static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
+                      "WarpSize must be a power of two and equal or less"
+                      "than the size of hardware warp.");
+        const unsigned int flat_id
+            = ::rocprim::flat_block_thread_id<BlockSizeX, BlockSizeY, BlockSizeZ>();
+        const unsigned int thread_id     = detail::logical_lane_id<WarpSize>();
+        const unsigned int warp_id       = flat_id / WarpSize;
+        const unsigned int warp_offset   = warp_id * WarpSize * ItemsPerThread;
+        const unsigned int thread_offset = thread_id + warp_offset;
+
+        ROCPRIM_UNROLL
+        for(unsigned int i = 0; i < ItemsPerThread; i++)
+        {
+            const Offset rank = ranks[i];
+            storage.buffer.emplace(index(rank), input[i]);
+        }
+
+        ::rocprim::syncthreads();
+
+        const auto& storage_buffer = storage.buffer.get_unsafe_array();
+
+        ROCPRIM_UNROLL
+        for(unsigned int i = 0; i < ItemsPerThread; i++)
+        {
+            output[i] = storage_buffer[index(thread_offset + i * WarpSize)];
+        }
+    }
+
     /// \brief Scatters items to a striped arrangement based on their ranks
     /// across the thread block, guarded by rank.
     ///

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -86,21 +86,44 @@ class block_exchange
     static constexpr unsigned int warp_size =
         detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
     // Number of warps in block
-    static constexpr unsigned int warps_no = (BlockSize + warp_size - 1) / warp_size;
-
-    // Minimize LDS bank conflicts for power-of-two strides, i.e. when items accessed
-    // using `thread_id * ItemsPerThread` pattern where ItemsPerThread is power of two
-    // (all exchanges from/to blocked).
-    static constexpr bool has_bank_conflicts
-        = ItemsPerThread >= 2 && ::rocprim::detail::is_power_of_two(ItemsPerThread);
+    static constexpr unsigned int warps_no = ::rocprim::detail::ceiling_div(BlockSize, warp_size);
     static constexpr unsigned int banks_no = ::rocprim::detail::get_lds_banks_no();
     static constexpr unsigned int buffer_size
         = static_cast<unsigned int>(rocprim::max(size_t{1}, size_t{4} / sizeof(T)));
-    static constexpr unsigned int bank_conflicts_padding
-        = has_bank_conflicts ? (BlockSize * ItemsPerThread / banks_no) : 0;
 
-    static constexpr unsigned int storage_count
-        = BlockSize * ItemsPerThread + bank_conflicts_padding;
+    struct unpadded_config {
+        static constexpr bool         has_bank_conflicts = false;
+        static constexpr unsigned int padding            = 0;
+    };
+
+    struct padded_config
+    {
+        // Minimize LDS bank conflicts for power-of-two strides, i.e. when items accessed
+        // using `thread_id * ItemsPerThread` pattern where ItemsPerThread is power of two
+        // (all exchanges from/to blocked).
+        static constexpr bool has_bank_conflicts
+            = ItemsPerThread >= 2 && ::rocprim::detail::is_power_of_two(ItemsPerThread);
+        static constexpr unsigned int padding
+            = has_bank_conflicts ? (BlockSize * ItemsPerThread / banks_no) : 0;
+    };
+
+    template<typename Config>
+    struct build_config : Config
+    {
+        static constexpr unsigned int storage_count = BlockSize * ItemsPerThread + Config::padding;
+        static constexpr unsigned int storage_size  = sizeof(T) * storage_count;
+        static constexpr unsigned int occupancy     = detail::get_min_lds_size() / storage_size;
+
+        // score is requried for 'select_max_by_score_t'
+        static constexpr unsigned int score = occupancy;
+    };
+
+    using config
+        = detail::select_max_by_score_t<build_config<padded_config>, build_config<unpadded_config>>;
+
+    static constexpr bool         has_bank_conflicts     = config::has_bank_conflicts;
+    static constexpr unsigned int bank_conflicts_padding = config::padding;
+    static constexpr unsigned int storage_count          = config::storage_count;
 
     struct storage_type_
     {

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -27,6 +27,9 @@
 #include "../functional.hpp"
 #include "../intrinsics.hpp"
 #include "../types.hpp"
+
+#include "config.hpp"
+
 #include <cstddef>
 
 /// \addtogroup blockmodule
@@ -34,25 +37,13 @@
 
 BEGIN_ROCPRIM_NAMESPACE
 
-/// \brief Available padding options for \p block_exchange .
-enum block_exchange_padding_mode
-{
-    /// Use padding to avoid bank conflicts when applicable.
-    use_padding = 0,
-
-    /// Never use padding.
-    no_padding = 1,
-
-    /// Only use padding when there is no cost to occupancy.
-    max_occupancy = 2,
-};
-
 /// \brief The \p block_exchange class is a block level parallel primitive which provides
 /// methods for rearranging items partitioned across threads in a block.
 ///
 /// \tparam T - the input type.
 /// \tparam BlockSize - the number of threads in a block.
 /// \tparam ItemsPerThread - the number of items contributed by each thread.
+/// \tparam PaddingHint - a hint that decides when to use padding. May not always be applicable.
 ///
 /// \par Overview
 /// * The \p block_exchange class supports the following rearrangement methods:
@@ -91,7 +82,7 @@ template<
     unsigned int ItemsPerThread,
     unsigned int BlockSizeY = 1,
     unsigned int BlockSizeZ = 1,
-    block_exchange_padding_mode PaddingMode = block_exchange_padding_mode::use_padding
+    block_padding_hint PaddingHint = block_padding_hint::avoid_conflicts
 >
 class block_exchange
 {
@@ -128,18 +119,11 @@ class block_exchange
         static constexpr unsigned int storage_count = BlockSize * ItemsPerThread + Config::padding;
         static constexpr unsigned int storage_size  = sizeof(T) * storage_count;
         static constexpr unsigned int occupancy     = detail::get_min_lds_size() / storage_size;
-
-        // score is requried for 'select_max_by_score_t'
-        static constexpr unsigned int score = occupancy;
     };
 
-    using config = std::conditional_t<
-        PaddingMode == block_exchange_padding_mode::use_padding,
-        build_config<padded_config>,
-        std::conditional_t<PaddingMode == block_exchange_padding_mode::no_padding,
-                           build_config<unpadded_config>,
-                           detail::select_max_by_score_t<build_config<padded_config>,
-                                                         build_config<unpadded_config>>>>;
+    using config = detail::select_block_padding_config<PaddingHint,
+                                                       build_config<padded_config>,
+                                                       build_config<unpadded_config>>;
 
     static constexpr bool         has_bank_conflicts     = config::has_bank_conflicts;
     static constexpr unsigned int bank_conflicts_padding = config::padding;

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -91,7 +91,8 @@ class block_exchange
     static constexpr unsigned int buffer_size
         = static_cast<unsigned int>(rocprim::max(size_t{1}, size_t{4} / sizeof(T)));
 
-    struct unpadded_config {
+    struct unpadded_config
+    {
         static constexpr bool         has_bank_conflicts = false;
         static constexpr unsigned int padding            = 0;
     };

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -621,6 +621,38 @@ public:
         }
     }
 
+    /// \brief Scatters items to a *warp* striped arrangement based on their ranks
+    /// across the thread block, using temporary storage.
+    ///
+    /// \tparam U - [inferred] the output type.
+    /// \tparam Offset - [inferred] the rank type.
+    ///
+    /// \param [in] input - array that data is loaded from.
+    /// \param [out] output - array that data is loaded to.
+    /// \param [out] ranks - array that has rank of data.
+    /// \param [in] storage - reference to a temporary storage object of type storage_type.
+    ///
+    /// \par Storage reusage
+    /// Synchronization barrier should be placed before \p storage is reused
+    /// or repurposed: \p __syncthreads() or \p rocprim::syncthreads().
+    ///
+    /// \par Example.
+    /// \code{.cpp}
+    /// __global__ void example_kernel(...)
+    /// {
+    ///     // specialize block_exchange for int, block of 128 threads and 8 items per thread
+    ///     using block_exchange_int = rocprim::block_exchange<int, 128, 8>;
+    ///     // allocate storage in shared memory
+    ///     __shared__ block_exchange_int::storage_type storage;
+    ///
+    ///     int items[8];
+    ///     int ranks[8];
+    ///     ...
+    ///     block_exchange_int b_exchange;
+    ///     b_exchange.scatter_to_warp_striped(items, items, ranks, storage);
+    ///     ...
+    /// }
+    /// \endcode
     template<unsigned int WarpSize = device_warp_size(), class U, class Offset>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void scatter_to_warp_striped(const T (&input)[ItemsPerThread],

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -34,6 +34,19 @@
 
 BEGIN_ROCPRIM_NAMESPACE
 
+/// \brief Available padding options for \p block_exchange .
+enum block_exchange_padding_mode
+{
+    /// Use padding to avoid bank conflicts when applicable.
+    use_padding = 0,
+
+    /// Never use padding.
+    no_padding = 1,
+
+    /// Only use padding when there is no cost to occupancy.
+    max_occupancy = 2,
+};
+
 /// \brief The \p block_exchange class is a block level parallel primitive which provides
 /// methods for rearranging items partitioned across threads in a block.
 ///
@@ -77,7 +90,8 @@ template<
     unsigned int BlockSizeX,
     unsigned int ItemsPerThread,
     unsigned int BlockSizeY = 1,
-    unsigned int BlockSizeZ = 1
+    unsigned int BlockSizeZ = 1,
+    block_exchange_padding_mode PaddingMode = block_exchange_padding_mode::use_padding
 >
 class block_exchange
 {
@@ -119,8 +133,13 @@ class block_exchange
         static constexpr unsigned int score = occupancy;
     };
 
-    using config
-        = detail::select_max_by_score_t<build_config<padded_config>, build_config<unpadded_config>>;
+    using config = std::conditional_t<
+        PaddingMode == block_exchange_padding_mode::use_padding,
+        build_config<padded_config>,
+        std::conditional_t<PaddingMode == block_exchange_padding_mode::no_padding,
+                           build_config<unpadded_config>,
+                           detail::select_max_by_score_t<build_config<padded_config>,
+                                                         build_config<unpadded_config>>>>;
 
     static constexpr bool         has_bank_conflicts     = config::has_bank_conflicts;
     static constexpr unsigned int bank_conflicts_padding = config::padding;

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -28,8 +28,8 @@
 #include "../thread/radix_key_codec.hpp"
 #include "../warp/detail/warp_scan_crosslane.hpp"
 
-#include "../intrinsics.hpp"
 #include "../functional.hpp"
+#include "../intrinsics.hpp"
 #include "../types.hpp"
 
 #include "block_exchange.hpp"
@@ -97,10 +97,10 @@ BEGIN_ROCPRIM_NAMESPACE
 template<class Key,
          unsigned int BlockSizeX,
          unsigned int ItemsPerThread,
-         class Value                   = empty_type,
-         unsigned int BlockSizeY       = 1,
-         unsigned int BlockSizeZ       = 1,
-         unsigned int RadixBitsPerPass = 4,
+         class Value                                   = empty_type,
+         unsigned int               BlockSizeY         = 1,
+         unsigned int               BlockSizeZ         = 1,
+         unsigned int               RadixBitsPerPass   = 4,
          block_radix_rank_algorithm RadixRankAlgorithm = block_radix_rank_algorithm::basic_memoize>
 class block_radix_sort
 {
@@ -108,14 +108,11 @@ class block_radix_sort
                   "The RadixBitsPerPass should be larger than 0 and smaller than the size "
                   "of an unsigned int");
 
-    static constexpr unsigned int BlockSize           = BlockSizeX * BlockSizeY * BlockSizeZ;
-    static constexpr bool         with_values         = !std::is_same<Value, empty_type>::value;
+    static constexpr unsigned int BlockSize   = BlockSizeX * BlockSizeY * BlockSizeZ;
+    static constexpr bool         with_values = !std::is_same<Value, empty_type>::value;
 
-    using block_rank_type = ::rocprim::block_radix_rank<BlockSizeX,
-                                                        RadixBitsPerPass,
-                                                        RadixRankAlgorithm,
-                                                        BlockSizeY,
-                                                        BlockSizeZ>;
+    using block_rank_type = ::rocprim::
+        block_radix_rank<BlockSizeX, RadixBitsPerPass, RadixRankAlgorithm, BlockSizeY, BlockSizeZ>;
     using keys_exchange_type
         = ::rocprim::block_exchange<Key, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ>;
     using values_exchange_type
@@ -124,28 +121,27 @@ class block_radix_sort
     // Struct used for creating a raw_storage object for this primitive's temporary storage.
     union storage_type_
     {
-        typename keys_exchange_type::storage_type     keys_exchange;
-        typename values_exchange_type::storage_type   values_exchange;
-        typename block_rank_type::storage_type        rank;
+        typename keys_exchange_type::storage_type   keys_exchange;
+        typename values_exchange_type::storage_type values_exchange;
+        typename block_rank_type::storage_type      rank;
     };
 
 public:
-
-    /// \brief Struct used to allocate a temporary memory that is required for thread
-    /// communication during operations provided by related parallel primitive.
-    ///
-    /// Depending on the implemention the operations exposed by parallel primitive may
-    /// require a temporary storage for thread communication. The storage should be allocated
-    /// using keywords <tt>__shared__</tt>. It can be aliased to
-    /// an externally allocated memory, or be a part of a union type with other storage types
-    /// to increase shared memory reusability.
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS // hides storage_type implementation for Doxygen
+/// \brief Struct used to allocate a temporary memory that is required for thread
+/// communication during operations provided by related parallel primitive.
+///
+/// Depending on the implemention the operations exposed by parallel primitive may
+/// require a temporary storage for thread communication. The storage should be allocated
+/// using keywords <tt>__shared__</tt>. It can be aliased to
+/// an externally allocated memory, or be a part of a union type with other storage types
+/// to increase shared memory reusability.
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // hides storage_type implementation for Doxygen
     ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_WITH_PUSH
     using storage_type = detail::raw_storage<storage_type_>;
     ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_POP
-    #else
+#else
     using storage_type = storage_type_; // only for Doxygen
-    #endif
+#endif
 
     /// \brief Performs ascending radix sort over keys partitioned across threads in a block.
     ///
@@ -194,11 +190,12 @@ public:
     /// then after sort they will be equal <tt>{[1, 2], [3, 4]  ..., [255, 256]}</tt>.
     /// \endparblock
     template<class Decomposer = ::rocprim::identity_decomposer>
-    ROCPRIM_DEVICE ROCPRIM_INLINE void sort(Key (&keys)[ItemsPerThread],
-                                            storage_type& storage,
-                                            unsigned int  begin_bit  = 0,
-                                            unsigned int  end_bit    = 8 * sizeof(Key),
-                                            Decomposer    decomposer = {})
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort(Key (&keys)[ItemsPerThread],
+              storage_type& storage,
+              unsigned int  begin_bit  = 0,
+              unsigned int  end_bit    = 8 * sizeof(Key),
+              Decomposer    decomposer = {})
     {
         empty_type values[ItemsPerThread];
         sort_impl<false>(keys, values, storage, begin_bit, end_bit, decomposer);
@@ -225,7 +222,8 @@ public:
                                                   unsigned int end_bit    = 8 * sizeof(Key),
                                                   Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY storage_type storage;
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
         sort(keys, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -276,11 +274,12 @@ public:
     /// then after sort they will be equal <tt>{[256, 255], ..., [4, 3], [2, 1]}</tt>.
     /// \endparblock
     template<class Decomposer = ::rocprim::identity_decomposer>
-    ROCPRIM_DEVICE ROCPRIM_INLINE void sort_desc(Key (&keys)[ItemsPerThread],
-                                                 storage_type& storage,
-                                                 unsigned int  begin_bit  = 0,
-                                                 unsigned int  end_bit    = 8 * sizeof(Key),
-                                                 Decomposer    decomposer = {})
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_desc(Key (&keys)[ItemsPerThread],
+                   storage_type& storage,
+                   unsigned int  begin_bit  = 0,
+                   unsigned int  end_bit    = 8 * sizeof(Key),
+                   Decomposer    decomposer = {})
     {
         empty_type values[ItemsPerThread];
         sort_impl<true>(keys, values, storage, begin_bit, end_bit, decomposer);
@@ -309,7 +308,8 @@ public:
                                                        unsigned int end_bit    = 8 * sizeof(Key),
                                                        Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY storage_type storage;
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
         sort_desc(keys, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -368,13 +368,13 @@ public:
     /// equal <tt>{[128, 128], [127, 127]  ..., [2, 2], [1, 1]}</tt>.
     /// \endparblock
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
-    ROCPRIM_DEVICE ROCPRIM_INLINE void
-        sort(Key (&keys)[ItemsPerThread],
-             typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
-             storage_type& storage,
-             unsigned int  begin_bit  = 0,
-             unsigned int  end_bit    = 8 * sizeof(Key),
-             Decomposer    decomposer = {})
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort(Key (&keys)[ItemsPerThread],
+              typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
+              storage_type& storage,
+              unsigned int  begin_bit  = 0,
+              unsigned int  end_bit    = 8 * sizeof(Key),
+              Decomposer    decomposer = {})
     {
         sort_impl<false>(keys, values, storage, begin_bit, end_bit, decomposer);
     }
@@ -408,7 +408,8 @@ public:
              unsigned int end_bit    = 8 * sizeof(Key),
              Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY storage_type storage;
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
         sort(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -467,13 +468,13 @@ public:
     /// will be equal <tt>{[1, 1], [2, 2]  ..., [128, 128]}</tt>.
     /// \endparblock
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
-    ROCPRIM_DEVICE ROCPRIM_INLINE void
-        sort_desc(Key (&keys)[ItemsPerThread],
-                  typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
-                  storage_type& storage,
-                  unsigned int  begin_bit  = 0,
-                  unsigned int  end_bit    = 8 * sizeof(Key),
-                  Decomposer    decomposer = {})
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_desc(Key (&keys)[ItemsPerThread],
+                   typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
+                   storage_type& storage,
+                   unsigned int  begin_bit  = 0,
+                   unsigned int  end_bit    = 8 * sizeof(Key),
+                   Decomposer    decomposer = {})
     {
         sort_impl<true>(keys, values, storage, begin_bit, end_bit, decomposer);
     }
@@ -507,7 +508,8 @@ public:
                   unsigned int end_bit    = 8 * sizeof(Key),
                   Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY storage_type storage;
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
         sort_desc(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -559,11 +561,12 @@ public:
     /// then after sort they will be equal <tt>{[1, 129], [2, 130]  ..., [128, 256]}</tt>.
     /// \endparblock
     template<class Decomposer = ::rocprim::identity_decomposer>
-    ROCPRIM_DEVICE ROCPRIM_INLINE void sort_to_striped(Key (&keys)[ItemsPerThread],
-                                                       storage_type& storage,
-                                                       unsigned int  begin_bit  = 0,
-                                                       unsigned int  end_bit    = 8 * sizeof(Key),
-                                                       Decomposer    decomposer = {})
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_to_striped(Key (&keys)[ItemsPerThread],
+                         storage_type& storage,
+                         unsigned int  begin_bit  = 0,
+                         unsigned int  end_bit    = 8 * sizeof(Key),
+                         Decomposer    decomposer = {})
     {
         empty_type values[ItemsPerThread];
         sort_impl<false, true>(keys, values, storage, begin_bit, end_bit, decomposer);
@@ -593,7 +596,8 @@ public:
                                                              unsigned int end_bit = 8 * sizeof(Key),
                                                              Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY storage_type storage;
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
         sort_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -645,11 +649,12 @@ public:
     /// then after sort they will be equal <tt>{[256, 128], ..., [130, 2], [129, 1]}</tt>.
     /// \endparblock
     template<class Decomposer = ::rocprim::identity_decomposer>
-    ROCPRIM_DEVICE ROCPRIM_INLINE void sort_desc_to_striped(Key (&keys)[ItemsPerThread],
-                                                            storage_type& storage,
-                                                            unsigned int  begin_bit = 0,
-                                                            unsigned int  end_bit = 8 * sizeof(Key),
-                                                            Decomposer    decomposer = {})
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_desc_to_striped(Key (&keys)[ItemsPerThread],
+                              storage_type& storage,
+                              unsigned int  begin_bit  = 0,
+                              unsigned int  end_bit    = 8 * sizeof(Key),
+                              Decomposer    decomposer = {})
     {
         empty_type values[ItemsPerThread];
         sort_impl<true, true>(keys, values, storage, begin_bit, end_bit, decomposer);
@@ -680,7 +685,8 @@ public:
                                                                   = 8 * sizeof(Key),
                                                                   Decomposer decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY storage_type storage;
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
         sort_desc_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -739,13 +745,13 @@ public:
     /// equal <tt>{[-8, -4], [-7, -3], [-6, -2], [-5, -1]}</tt>.
     /// \endparblock
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
-    ROCPRIM_DEVICE ROCPRIM_INLINE void
-        sort_to_striped(Key (&keys)[ItemsPerThread],
-                        typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
-                        storage_type& storage,
-                        unsigned int  begin_bit  = 0,
-                        unsigned int  end_bit    = 8 * sizeof(Key),
-                        Decomposer    decomposer = {})
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_to_striped(Key (&keys)[ItemsPerThread],
+                         typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
+                         storage_type& storage,
+                         unsigned int  begin_bit  = 0,
+                         unsigned int  end_bit    = 8 * sizeof(Key),
+                         Decomposer    decomposer = {})
     {
         sort_impl<false, true>(keys, values, storage, begin_bit, end_bit, decomposer);
     }
@@ -777,7 +783,8 @@ public:
                         unsigned int end_bit    = 8 * sizeof(Key),
                         Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY storage_type storage;
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
         sort_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -836,7 +843,8 @@ public:
     /// equal <tt>{[10, 50], [20, 60], [30, 70], [40, 80]}</tt>.
     /// \endparblock
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
-    ROCPRIM_DEVICE ROCPRIM_INLINE void sort_desc_to_striped(
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_desc_to_striped(
         Key (&keys)[ItemsPerThread],
         typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
         storage_type& storage,
@@ -874,18 +882,20 @@ public:
         unsigned int end_bit    = 8 * sizeof(Key),
         Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY storage_type storage;
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
         sort_desc_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
 private:
     template<bool Descending, bool ToStriped = false, class SortedValue, class Decomposer>
-    ROCPRIM_DEVICE ROCPRIM_INLINE void sort_impl(Key (&keys)[ItemsPerThread],
-                                                 SortedValue (&values)[ItemsPerThread],
-                                                 storage_type& storage,
-                                                 unsigned int  begin_bit,
-                                                 unsigned int  end_bit,
-                                                 Decomposer    decomposer)
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_impl(Key (&keys)[ItemsPerThread],
+                   SortedValue (&values)[ItemsPerThread],
+                   storage_type& storage,
+                   unsigned int  begin_bit,
+                   unsigned int  end_bit,
+                   Decomposer    decomposer)
     {
         using key_codec = ::rocprim::radix_key_codec<Key, Descending>;
 
@@ -895,11 +905,11 @@ private:
             key_codec::encode_inplace(keys[i], decomposer);
         }
 
+        unsigned int ranks[ItemsPerThread];
         while(true)
         {
             const int pass_bits = min(RadixBitsPerPass, end_bit - begin_bit);
 
-            unsigned int ranks[ItemsPerThread];
             block_rank_type().rank_keys(
                 keys,
                 ranks,
@@ -908,13 +918,13 @@ private:
                 { return key_codec::extract_digit(key, begin_bit, pass_bits, decomposer); });
             begin_bit += RadixBitsPerPass;
 
-            exchange_keys(storage, keys, ranks);
-            exchange_values(storage, values, ranks);
-
             if(begin_bit >= end_bit)
             {
                 break;
             }
+
+            exchange_keys(storage, keys, ranks);
+            exchange_values(storage, values, ranks);
 
             // Synchronization required to make block_rank wait on the next iteration.
             ::rocprim::syncthreads();
@@ -922,8 +932,13 @@ private:
 
         if ROCPRIM_IF_CONSTEXPR(ToStriped)
         {
-            to_striped_keys(storage, keys);
-            to_striped_values(storage, values);
+            exchange_to_striped_keys(storage, keys, ranks);
+            exchange_to_striped_values(storage, values, ranks);
+        }
+        else
+        {
+            exchange_keys(storage, keys, ranks);
+            exchange_values(storage, values, ranks);
         }
 
         ROCPRIM_UNROLL
@@ -933,9 +948,10 @@ private:
         }
     }
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE void exchange_keys(storage_type& storage,
-                                                     Key (&keys)[ItemsPerThread],
-                                                     const unsigned int (&ranks)[ItemsPerThread])
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exchange_keys(storage_type& storage,
+                       Key (&keys)[ItemsPerThread],
+                       const unsigned int (&ranks)[ItemsPerThread])
     {
         storage_type_& storage_ = storage.get();
         ::rocprim::syncthreads(); // Storage will be reused (union), synchronization is needed
@@ -958,35 +974,39 @@ private:
                          empty_type (&values)[ItemsPerThread],
                          const unsigned int (&ranks)[ItemsPerThread])
     {
-        (void) storage;
-        (void) values;
-        (void) ranks;
+        (void)storage;
+        (void)values;
+        (void)ranks;
     }
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE void to_striped_keys(storage_type& storage,
-                                                       Key (&keys)[ItemsPerThread])
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exchange_to_striped_keys(storage_type& storage,
+                                  Key (&keys)[ItemsPerThread],
+                                  const unsigned int (&ranks)[ItemsPerThread])
     {
         storage_type_& storage_ = storage.get();
         ::rocprim::syncthreads(); // Storage will be reused (union), synchronization is needed
-        keys_exchange_type().blocked_to_striped(keys, keys, storage_.keys_exchange);
+        keys_exchange_type().scatter_to_striped(keys, keys, ranks, storage_.keys_exchange);
     }
 
     template<class SortedValue>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    void to_striped_values(storage_type& storage,
-                           SortedValue (&values)[ItemsPerThread])
+    void exchange_to_striped_values(storage_type& storage,
+                                    SortedValue (&values)[ItemsPerThread],
+                                    const unsigned int (&ranks)[ItemsPerThread])
     {
         storage_type_& storage_ = storage.get();
         ::rocprim::syncthreads(); // Storage will be reused (union), synchronization is needed
-        values_exchange_type().blocked_to_striped(values, values, storage_.values_exchange);
+        values_exchange_type().scatter_to_striped(values, values, ranks, storage_.values_exchange);
     }
 
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    void to_striped_values(storage_type& storage,
-                           empty_type * values)
+    void exchange_to_striped_values(storage_type& storage,
+                                    empty_type*   values,
+                                    const unsigned int (&ranks)[ItemsPerThread])
     {
-        (void) storage;
-        (void) values;
+        (void)storage;
+        (void)values;
     }
 };
 

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -100,7 +100,8 @@ template<class Key,
          class Value                   = empty_type,
          unsigned int BlockSizeY       = 1,
          unsigned int BlockSizeZ       = 1,
-         unsigned int RadixBitsPerPass = 4>
+         unsigned int RadixBitsPerPass = 4,
+         block_radix_rank_algorithm RadixRankAlgorithm = block_radix_rank_algorithm::basic_memoize>
 class block_radix_sort
 {
     static_assert(RadixBitsPerPass > 0 && RadixBitsPerPass < 32,
@@ -112,7 +113,7 @@ class block_radix_sort
 
     using block_rank_type = ::rocprim::block_radix_rank<BlockSizeX,
                                                         RadixBitsPerPass,
-                                                        block_radix_rank_algorithm::basic_memoize,
+                                                        RadixRankAlgorithm,
                                                         BlockSizeY,
                                                         BlockSizeZ>;
     using keys_exchange_type

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -110,6 +110,7 @@ class block_radix_sort
 
     static constexpr unsigned int BlockSize   = BlockSizeX * BlockSizeY * BlockSizeZ;
     static constexpr bool         with_values = !std::is_same<Value, empty_type>::value;
+    static constexpr bool warp_striped = RadixRankAlgorithm == block_radix_rank_algorithm::match;
 
     using block_rank_type = ::rocprim::
         block_radix_rank<BlockSizeX, RadixBitsPerPass, RadixRankAlgorithm, BlockSizeY, BlockSizeZ>;
@@ -923,8 +924,16 @@ private:
                 break;
             }
 
-            exchange_keys(storage, keys, ranks);
-            exchange_values(storage, values, ranks);
+            if ROCPRIM_IF_CONSTEXPR(warp_striped)
+            {
+                exchange_keys_warp_striped(storage, keys, ranks);
+                exchange_values_warp_striped(storage, values, ranks);
+            }
+            else
+            {
+                exchange_keys(storage, keys, ranks);
+                exchange_values(storage, values, ranks);
+            }
 
             // Synchronization required to make block_rank wait on the next iteration.
             ::rocprim::syncthreads();
@@ -973,6 +982,40 @@ private:
     void exchange_values(storage_type& storage,
                          empty_type (&values)[ItemsPerThread],
                          const unsigned int (&ranks)[ItemsPerThread])
+    {
+        (void)storage;
+        (void)values;
+        (void)ranks;
+    }
+
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exchange_keys_warp_striped(storage_type& storage,
+                                    Key (&keys)[ItemsPerThread],
+                                    const unsigned int (&ranks)[ItemsPerThread])
+    {
+        storage_type_& storage_ = storage.get();
+        ::rocprim::syncthreads(); // Storage will be reused (union), synchronization is needed
+        keys_exchange_type().scatter_to_warp_striped(keys, keys, ranks, storage_.keys_exchange);
+    }
+
+    template<class SortedValue>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exchange_values_warp_striped(storage_type& storage,
+                                      SortedValue (&values)[ItemsPerThread],
+                                      const unsigned int (&ranks)[ItemsPerThread])
+    {
+        storage_type_& storage_ = storage.get();
+        ::rocprim::syncthreads(); // Storage will be reused (union), synchronization is needed
+        values_exchange_type().scatter_to_warp_striped(values,
+                                                       values,
+                                                       ranks,
+                                                       storage_.values_exchange);
+    }
+
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exchange_values_warp_striped(storage_type& storage,
+                                      empty_type (&values)[ItemsPerThread],
+                                      const unsigned int (&ranks)[ItemsPerThread])
     {
         (void)storage;
         (void)values;

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -33,6 +33,7 @@
 #include "../warp/warp_exchange.hpp"
 #include "block_exchange.hpp"
 #include "block_radix_rank.hpp"
+#include "rocprim/block/config.hpp"
 
 /// \addtogroup blockmodule
 /// @{
@@ -106,7 +107,8 @@ template<class Key,
          block_radix_rank_algorithm RadixRankAlgorithm
          = (BlockSizeX * BlockSizeY * BlockSizeZ) % device_warp_size() == 0
                ? block_radix_rank_algorithm::match
-               : block_radix_rank_algorithm::basic_memoize>
+               : block_radix_rank_algorithm::basic_memoize,
+         block_padding_hint PaddingHint = block_padding_hint::lds_occupancy_bound>
 class block_radix_sort
 {
     static_assert(RadixBitsPerPass > 0 && RadixBitsPerPass < 32,
@@ -127,11 +129,11 @@ class block_radix_sort
         = alignof(Key) == alignof(Value) && sizeof(Key) == sizeof(Value);
 
     using block_rank_type = ::rocprim::
-        block_radix_rank<BlockSizeX, RadixBitsPerPass, RadixRankAlgorithm, BlockSizeY, BlockSizeZ>;
+        block_radix_rank<BlockSizeX, RadixBitsPerPass, RadixRankAlgorithm, BlockSizeY, BlockSizeZ, PaddingHint>;
     using keys_exchange_type
-        = ::rocprim::block_exchange<Key, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ, block_exchange_padding_mode::max_occupancy>;
+        = ::rocprim::block_exchange<Key, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ, PaddingHint>;
     using values_exchange_type
-        = ::rocprim::block_exchange<Value, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ, block_exchange_padding_mode::max_occupancy>;
+        = ::rocprim::block_exchange<Value, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ, PaddingHint>;
 
     // Struct used for creating a raw_storage object for this primitive's temporary storage.
     union storage_type_

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -97,10 +97,12 @@ BEGIN_ROCPRIM_NAMESPACE
 template<class Key,
          unsigned int BlockSizeX,
          unsigned int ItemsPerThread,
-         class Value                                 = empty_type,
-         unsigned int               BlockSizeY       = 1,
-         unsigned int               BlockSizeZ       = 1,
-         unsigned int               RadixBitsPerPass = 4,
+         class Value             = empty_type,
+         unsigned int BlockSizeY = 1,
+         unsigned int BlockSizeZ = 1,
+         unsigned int RadixBitsPerPass
+         = (BlockSizeX * BlockSizeY * BlockSizeZ) % device_warp_size() == 0 ? 8 /* match */
+                                                                            : 4 /* basic_memoize */,
          block_radix_rank_algorithm RadixRankAlgorithm
          = (BlockSizeX * BlockSizeY * BlockSizeZ) % device_warp_size() == 0
                ? block_radix_rank_algorithm::match

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -894,6 +894,10 @@ public:
         sort_desc_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
+    /// \brief Performs ascending radix sort over key-value pairs in a *warp-striped order*
+    /// partitioned across threads in a block, results are saved in a striped arrangement.
+    ///
+    /// \see block_radix_sort::sort_to_striped
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_warp_striped_to_striped(
@@ -911,6 +915,10 @@ public:
         sort_impl<false, true, false>(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
+    /// \brief Performs ascending radix sort over key-value pairs in a *warp-striped order*
+    ///
+    /// \see block_radix_sort::sort_to_striped
+    /// partitioned across threads in a block, results are saved in a striped arrangement.
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_warp_striped_to_striped(
@@ -928,6 +936,10 @@ public:
         sort_warp_striped_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
+    /// \brief Performs ascending radix sort over key-value pairs in a *warp-striped order*
+    /// partitioned across threads in a block, results are saved in a striped arrangement.
+    ///
+    /// \see block_radix_sort::sort_to_striped
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_warp_striped_to_striped(Key (&keys)[ItemsPerThread],
@@ -944,6 +956,10 @@ public:
         sort_impl<false, true, false>(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
+    /// \brief Performs ascending radix sort over key-value pairs in a *warp-striped order*
+    /// partitioned across threads in a block, results are saved in a striped arrangement.
+    ///
+    /// \see block_radix_sort::sort_to_striped
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_warp_striped_to_striped(Key (&keys)[ItemsPerThread],
@@ -959,6 +975,10 @@ public:
         sort_warp_striped_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
 
+    /// \brief Performs descending radix sort over key-value pairs in a *warp-striped order*
+    /// partitioned across threads in a block, results are saved in a striped arrangement.
+    ///
+    /// \see block_radix_sort::sort_desc_to_striped
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc_warp_striped_to_striped(
@@ -976,6 +996,10 @@ public:
         sort_impl<true, true, false>(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
+    /// \brief Performs descending radix sort over key-value pairs in a *warp-striped order*
+    /// partitioned across threads in a block, results are saved in a striped arrangement.
+    ///
+    /// \see block_radix_sort::sort_desc_to_striped
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc_warp_striped_to_striped(
@@ -993,6 +1017,10 @@ public:
         sort_desc_warp_striped_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
+    /// \brief Performs descending radix sort over key-value pairs in a *warp-striped order*
+    /// partitioned across threads in a block, results are saved in a striped arrangement.
+    ///
+    /// \see block_radix_sort::sort_desc_to_striped
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc_warp_striped_to_striped(Key (&keys)[ItemsPerThread],
@@ -1009,6 +1037,10 @@ public:
         sort_impl<true, true, false>(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
+    /// \brief Performs descending radix sort over key-value pairs in a *warp-striped order*
+    /// partitioned across threads in a block, results are saved in a striped arrangement.
+    ///
+    /// \see block_radix_sort::sort_desc_to_striped
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_desc_warp_striped_to_striped(Key (&keys)[ItemsPerThread],

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -31,9 +31,9 @@
 #include "../type_traits"
 #include "../types.hpp"
 
+#include "../warp/warp_exchange.hpp"
 #include "block_exchange.hpp"
 #include "block_radix_rank.hpp"
-#include "../warp/warp_exchange.hpp"
 
 /// \addtogroup blockmodule
 /// @{
@@ -124,7 +124,8 @@ class block_radix_sort
                   "multiple of the warp size");
 #endif
 
-    static constexpr bool is_key_and_value_aligned = alignof(Key) == alignof(Value) && sizeof(Key) == sizeof(Value);
+    static constexpr bool is_key_and_value_aligned
+        = alignof(Key) == alignof(Value) && sizeof(Key) == sizeof(Value);
 
     using block_rank_type = ::rocprim::
         block_radix_rank<BlockSizeX, RadixBitsPerPass, RadixRankAlgorithm, BlockSizeY, BlockSizeZ>;
@@ -237,8 +238,7 @@ public:
                                                   unsigned int end_bit    = 8 * sizeof(Key),
                                                   Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort(keys, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -323,8 +323,7 @@ public:
                                                        unsigned int end_bit    = 8 * sizeof(Key),
                                                        Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort_desc(keys, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -423,8 +422,7 @@ public:
              unsigned int end_bit    = 8 * sizeof(Key),
              Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -523,8 +521,7 @@ public:
                   unsigned int end_bit    = 8 * sizeof(Key),
                   Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort_desc(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -611,8 +608,7 @@ public:
                                                              unsigned int end_bit = 8 * sizeof(Key),
                                                              Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -700,8 +696,7 @@ public:
                                                                   = 8 * sizeof(Key),
                                                                   Decomposer decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort_desc_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -798,8 +793,7 @@ public:
                         unsigned int end_bit    = 8 * sizeof(Key),
                         Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -897,8 +891,7 @@ public:
         unsigned int end_bit    = 8 * sizeof(Key),
         Decomposer   decomposer = {})
     {
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort_desc_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -924,9 +917,9 @@ public:
     void sort_warp_striped_to_striped(
         Key (&keys)[ItemsPerThread],
         typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
-        unsigned int  begin_bit  = 0,
-        unsigned int  end_bit    = 8 * sizeof(Key),
-        Decomposer    decomposer = {})
+        unsigned int begin_bit  = 0,
+        unsigned int end_bit    = 8 * sizeof(Key),
+        Decomposer   decomposer = {})
     {
         static_assert(warp_striped,
                       "'sort_warp_striped_to_striped' can only be used with "
@@ -938,12 +931,11 @@ public:
 
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    void sort_warp_striped_to_striped(
-        Key (&keys)[ItemsPerThread],
-        storage_type& storage,
-        unsigned int  begin_bit  = 0,
-        unsigned int  end_bit    = 8 * sizeof(Key),
-        Decomposer    decomposer = {})
+    void sort_warp_striped_to_striped(Key (&keys)[ItemsPerThread],
+                                      storage_type& storage,
+                                      unsigned int  begin_bit  = 0,
+                                      unsigned int  end_bit    = 8 * sizeof(Key),
+                                      Decomposer    decomposer = {})
     {
         static_assert(warp_striped,
                       "'sort_warp_striped_to_striped' can only be used with "
@@ -955,18 +947,16 @@ public:
 
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    void sort_warp_striped_to_striped(
-        Key (&keys)[ItemsPerThread],
-        unsigned int  begin_bit  = 0,
-        unsigned int  end_bit    = 8 * sizeof(Key),
-        Decomposer    decomposer = {})
+    void sort_warp_striped_to_striped(Key (&keys)[ItemsPerThread],
+                                      unsigned int begin_bit  = 0,
+                                      unsigned int end_bit    = 8 * sizeof(Key),
+                                      Decomposer   decomposer = {})
     {
         static_assert(warp_striped,
                       "'sort_warp_striped_to_striped' can only be used with "
                       "'block_radix_rank_algorithm::match'.");
 
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort_warp_striped_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
 
@@ -992,27 +982,25 @@ public:
     void sort_desc_warp_striped_to_striped(
         Key (&keys)[ItemsPerThread],
         typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
-        unsigned int  begin_bit  = 0,
-        unsigned int  end_bit    = 8 * sizeof(Key),
-        Decomposer    decomposer = {})
+        unsigned int begin_bit  = 0,
+        unsigned int end_bit    = 8 * sizeof(Key),
+        Decomposer   decomposer = {})
     {
         static_assert(warp_striped,
                       "'sort_warp_striped_to_striped' can only be used with "
                       "'block_radix_rank_algorithm::match'.");
 
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort_desc_warp_striped_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    void sort_desc_warp_striped_to_striped(
-        Key (&keys)[ItemsPerThread],
-        storage_type& storage,
-        unsigned int  begin_bit  = 0,
-        unsigned int  end_bit    = 8 * sizeof(Key),
-        Decomposer    decomposer = {})
+    void sort_desc_warp_striped_to_striped(Key (&keys)[ItemsPerThread],
+                                           storage_type& storage,
+                                           unsigned int  begin_bit  = 0,
+                                           unsigned int  end_bit    = 8 * sizeof(Key),
+                                           Decomposer    decomposer = {})
     {
         static_assert(warp_striped,
                       "'sort_warp_striped_to_striped' can only be used with "
@@ -1024,23 +1012,22 @@ public:
 
     template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    void sort_desc_warp_striped_to_striped(
-        Key (&keys)[ItemsPerThread],
-        unsigned int  begin_bit  = 0,
-        unsigned int  end_bit    = 8 * sizeof(Key),
-        Decomposer    decomposer = {})
+    void sort_desc_warp_striped_to_striped(Key (&keys)[ItemsPerThread],
+                                           unsigned int begin_bit  = 0,
+                                           unsigned int end_bit    = 8 * sizeof(Key),
+                                           Decomposer   decomposer = {})
     {
         static_assert(warp_striped,
                       "'sort_warp_striped_to_striped' can only be used with "
                       "'block_radix_rank_algorithm::match'.");
 
-        ROCPRIM_SHARED_MEMORY
-        storage_type storage;
+        ROCPRIM_SHARED_MEMORY storage_type storage;
         sort_desc_warp_striped_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
 
 private:
-    static constexpr bool use_warp_exchange = device_warp_size() % ItemsPerThread == 0 && ItemsPerThread <= 4;
+    static constexpr bool use_warp_exchange
+        = device_warp_size() % ItemsPerThread == 0 && ItemsPerThread <= 4;
 
     template<class SortedValue>
     ROCPRIM_DEVICE ROCPRIM_INLINE

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -129,9 +129,9 @@ class block_radix_sort
     using block_rank_type = ::rocprim::
         block_radix_rank<BlockSizeX, RadixBitsPerPass, RadixRankAlgorithm, BlockSizeY, BlockSizeZ>;
     using keys_exchange_type
-        = ::rocprim::block_exchange<Key, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ>;
+        = ::rocprim::block_exchange<Key, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ, block_exchange_padding_mode::max_occupancy>;
     using values_exchange_type
-        = ::rocprim::block_exchange<Value, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ>;
+        = ::rocprim::block_exchange<Value, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ, block_exchange_padding_mode::max_occupancy>;
 
     // Struct used for creating a raw_storage object for this primitive's temporary storage.
     union storage_type_

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -1039,7 +1039,7 @@ private:
         if ROCPRIM_IF_CONSTEXPR(is_key_and_value_aligned)
         {
             // If keys and values are aligned, then the LDS for both exchanges is
-            // local per wave. We can relax the data depedency!
+            // local per wave. We can relax the data dependency!
             ::rocprim::wave_barrier();
         }
         else

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -1048,6 +1048,7 @@ private:
                                     empty_type*   values,
                                     const unsigned int (&ranks)[ItemsPerThread])
     {
+        (void)ranks;
         (void)storage;
         (void)values;
     }

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -1056,7 +1056,7 @@ private:
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void blocked_to_warp_striped(Key (&keys)[ItemsPerThread],
                                  SortedValue (&values)[ItemsPerThread],
-                                 storage_type& storage,
+                                 storage_type& /* storage */,
                                  std::true_type)
     {
         ::rocprim::warp_exchange<Key, ItemsPerThread>{}.blocked_to_striped_shuffle(keys, keys);

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -25,11 +25,10 @@
 
 #include "../config.hpp"
 #include "../detail/various.hpp"
-#include "../thread/radix_key_codec.hpp"
-#include "../warp/detail/warp_scan_crosslane.hpp"
-
 #include "../functional.hpp"
-#include "../intrinsics.hpp"
+#include "../intrinsics/thread.hpp"
+#include "../thread/radix_key_codec.hpp"
+#include "../type_traits"
 #include "../types.hpp"
 
 #include "block_exchange.hpp"
@@ -50,6 +49,7 @@ BEGIN_ROCPRIM_NAMESPACE
 /// \tparam Value - the value type. Default type empty_type indicates
 /// a keys-only sort.
 /// \tparam RadixBitsPerPass - amount of bits to sort per pass. The Default is 4.
+/// \tparam RadixRankAlgorithm the rank algorithm used.
 ///
 /// \par Overview
 /// * \p Key type must be an arithmetic type (that is, an integral type or a floating-point
@@ -97,11 +97,14 @@ BEGIN_ROCPRIM_NAMESPACE
 template<class Key,
          unsigned int BlockSizeX,
          unsigned int ItemsPerThread,
-         class Value                                   = empty_type,
-         unsigned int               BlockSizeY         = 1,
-         unsigned int               BlockSizeZ         = 1,
-         unsigned int               RadixBitsPerPass   = 4,
-         block_radix_rank_algorithm RadixRankAlgorithm = block_radix_rank_algorithm::basic_memoize>
+         class Value                                 = empty_type,
+         unsigned int               BlockSizeY       = 1,
+         unsigned int               BlockSizeZ       = 1,
+         unsigned int               RadixBitsPerPass = 4,
+         block_radix_rank_algorithm RadixRankAlgorithm
+         = (BlockSizeX * BlockSizeY * BlockSizeZ) % device_warp_size() == 0
+               ? block_radix_rank_algorithm::match
+               : block_radix_rank_algorithm::basic_memoize>
 class block_radix_sort
 {
     static_assert(RadixBitsPerPass > 0 && RadixBitsPerPass < 32,
@@ -111,6 +114,12 @@ class block_radix_sort
     static constexpr unsigned int BlockSize   = BlockSizeX * BlockSizeY * BlockSizeZ;
     static constexpr bool         with_values = !std::is_same<Value, empty_type>::value;
     static constexpr bool warp_striped = RadixRankAlgorithm == block_radix_rank_algorithm::match;
+
+#if __HIP_DEVICE_COMPILE__
+    static_assert(!warp_striped || (BlockSize % device_warp_size()) == 0,
+                  "When using 'block_radix_rank_algorithm::match', the block size should be a "
+                  "multiple of the warp size");
+#endif
 
     using block_rank_type = ::rocprim::
         block_radix_rank<BlockSizeX, RadixBitsPerPass, RadixRankAlgorithm, BlockSizeY, BlockSizeZ>;
@@ -888,8 +897,145 @@ public:
         sort_desc_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 
+    template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_warp_striped_to_striped(
+        Key (&keys)[ItemsPerThread],
+        typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
+        storage_type& storage,
+        unsigned int  begin_bit  = 0,
+        unsigned int  end_bit    = 8 * sizeof(Key),
+        Decomposer    decomposer = {})
+    {
+        static_assert(warp_striped,
+                      "'sort_warp_striped_to_striped' can only be used with "
+                      "'block_radix_rank_algorithm::match'.");
+
+        sort_impl<false, true, false>(keys, values, storage, begin_bit, end_bit, decomposer);
+    }
+
+    template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_warp_striped_to_striped(
+        Key (&keys)[ItemsPerThread],
+        typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
+        unsigned int  begin_bit  = 0,
+        unsigned int  end_bit    = 8 * sizeof(Key),
+        Decomposer    decomposer = {})
+    {
+        static_assert(warp_striped,
+                      "'sort_warp_striped_to_striped' can only be used with "
+                      "'block_radix_rank_algorithm::match'.");
+
+        ROCPRIM_SHARED_MEMORY storage_type storage;
+        sort_warp_striped_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
+    }
+
+    template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_warp_striped_to_striped(
+        Key (&keys)[ItemsPerThread],
+        storage_type& storage,
+        unsigned int  begin_bit  = 0,
+        unsigned int  end_bit    = 8 * sizeof(Key),
+        Decomposer    decomposer = {})
+    {
+        static_assert(warp_striped,
+                      "'sort_warp_striped_to_striped' can only be used with "
+                      "'block_radix_rank_algorithm::match'.");
+
+        empty_type values[ItemsPerThread];
+        sort_impl<false, true, false>(keys, values, storage, begin_bit, end_bit, decomposer);
+    }
+
+    template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_warp_striped_to_striped(
+        Key (&keys)[ItemsPerThread],
+        unsigned int  begin_bit  = 0,
+        unsigned int  end_bit    = 8 * sizeof(Key),
+        Decomposer    decomposer = {})
+    {
+        static_assert(warp_striped,
+                      "'sort_warp_striped_to_striped' can only be used with "
+                      "'block_radix_rank_algorithm::match'.");
+
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
+        sort_warp_striped_to_striped(keys, storage, begin_bit, end_bit, decomposer);
+    }
+
+    template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_desc_warp_striped_to_striped(
+        Key (&keys)[ItemsPerThread],
+        typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
+        storage_type& storage,
+        unsigned int  begin_bit  = 0,
+        unsigned int  end_bit    = 8 * sizeof(Key),
+        Decomposer    decomposer = {})
+    {
+        static_assert(warp_striped,
+                      "'sort_warp_striped_to_striped' can only be used with "
+                      "'block_radix_rank_algorithm::match'.");
+
+        sort_impl<true, true, false>(keys, values, storage, begin_bit, end_bit, decomposer);
+    }
+
+    template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_desc_warp_striped_to_striped(
+        Key (&keys)[ItemsPerThread],
+        typename std::enable_if<WithValues, Value>::type (&values)[ItemsPerThread],
+        unsigned int  begin_bit  = 0,
+        unsigned int  end_bit    = 8 * sizeof(Key),
+        Decomposer    decomposer = {})
+    {
+        static_assert(warp_striped,
+                      "'sort_warp_striped_to_striped' can only be used with "
+                      "'block_radix_rank_algorithm::match'.");
+
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
+        sort_desc_warp_striped_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
+    }
+
+    template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_desc_warp_striped_to_striped(
+        Key (&keys)[ItemsPerThread],
+        storage_type& storage,
+        unsigned int  begin_bit  = 0,
+        unsigned int  end_bit    = 8 * sizeof(Key),
+        Decomposer    decomposer = {})
+    {
+        static_assert(warp_striped,
+                      "'sort_warp_striped_to_striped' can only be used with "
+                      "'block_radix_rank_algorithm::match'.");
+
+        empty_type values[ItemsPerThread];
+        sort_impl<true, true, false>(keys, values, storage, begin_bit, end_bit, decomposer);
+    }
+
+    template<bool WithValues = with_values, class Decomposer = ::rocprim::identity_decomposer>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_desc_warp_striped_to_striped(
+        Key (&keys)[ItemsPerThread],
+        unsigned int  begin_bit  = 0,
+        unsigned int  end_bit    = 8 * sizeof(Key),
+        Decomposer    decomposer = {})
+    {
+        static_assert(warp_striped,
+                      "'sort_warp_striped_to_striped' can only be used with "
+                      "'block_radix_rank_algorithm::match'.");
+
+        ROCPRIM_SHARED_MEMORY
+        storage_type storage;
+        sort_desc_warp_striped_to_striped(keys, storage, begin_bit, end_bit, decomposer);
+    }
+
 private:
-    template<bool Descending, bool ToStriped = false, class SortedValue, class Decomposer>
+    template<bool Descending, bool ToStriped = false, bool TryEmulateWarpStriped = true, class SortedValue, class Decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_impl(Key (&keys)[ItemsPerThread],
                    SortedValue (&values)[ItemsPerThread],
@@ -899,6 +1045,16 @@ private:
                    Decomposer    decomposer)
     {
         using key_codec = ::rocprim::radix_key_codec<Key, Descending>;
+
+        // If we're using warp striped radix rank but our input is in a blocked layout, we
+        // can emulate the correct input through an exchange to a warp striped layout.
+        if ROCPRIM_IF_CONSTEXPR(TryEmulateWarpStriped && warp_striped)
+        {
+            keys_exchange_type().blocked_to_warp_striped(keys, keys, storage.get().keys_exchange);
+            ::rocprim::syncthreads();
+            values_exchange_type().blocked_to_warp_striped(values, values, storage.get().values_exchange);
+            ::rocprim::syncthreads();
+        }
 
         ROCPRIM_UNROLL
         for(unsigned int i = 0; i < ItemsPerThread; i++)

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -124,6 +124,8 @@ class block_radix_sort
                   "multiple of the warp size");
 #endif
 
+    static constexpr bool is_key_and_value_aligned = alignof(Key) == alignof(Value) && sizeof(Key) == sizeof(Value);
+
     using block_rank_type = ::rocprim::
         block_radix_rank<BlockSizeX, RadixBitsPerPass, RadixRankAlgorithm, BlockSizeY, BlockSizeZ>;
     using keys_exchange_type
@@ -1048,11 +1050,19 @@ private:
                                  std::false_type)
     {
         keys_exchange_type().blocked_to_warp_striped(keys, keys, storage.get().keys_exchange);
-        ::rocprim::syncthreads();
+        if ROCPRIM_IF_CONSTEXPR(is_key_and_value_aligned)
+        {
+            // If keys and values are aligned, then the LDS for both exchanges is
+            // local per wave. We can relax the data depedency!
+            ::rocprim::wave_barrier();
+        }
+        else
+        {
+            ::rocprim::syncthreads();
+        }
         values_exchange_type().blocked_to_warp_striped(values,
                                                        values,
                                                        storage.get().values_exchange);
-        ::rocprim::syncthreads();
     }
 
     template<class SortedValue>
@@ -1093,6 +1103,9 @@ private:
                                     values,
                                     storage,
                                     std::integral_constant<bool, use_warp_exchange>{});
+            // Storage has been dirtied. 'rank_keys' does not always align nicely with this
+            // so a full block synchronization is needed.
+            ::rocprim::syncthreads();
         }
 
         ROCPRIM_UNROLL

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -33,6 +33,7 @@
 
 #include "block_exchange.hpp"
 #include "block_radix_rank.hpp"
+#include "../warp/warp_exchange.hpp"
 
 /// \addtogroup blockmodule
 /// @{
@@ -1037,7 +1038,40 @@ public:
     }
 
 private:
-    template<bool Descending, bool ToStriped = false, bool TryEmulateWarpStriped = true, class SortedValue, class Decomposer>
+    static constexpr bool use_warp_exchange = device_warp_size() % ItemsPerThread == 0 && ItemsPerThread <= 4;
+
+    template<class SortedValue>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void blocked_to_warp_striped(Key (&keys)[ItemsPerThread],
+                                 SortedValue (&values)[ItemsPerThread],
+                                 storage_type& storage,
+                                 std::false_type)
+    {
+        keys_exchange_type().blocked_to_warp_striped(keys, keys, storage.get().keys_exchange);
+        ::rocprim::syncthreads();
+        values_exchange_type().blocked_to_warp_striped(values,
+                                                       values,
+                                                       storage.get().values_exchange);
+        ::rocprim::syncthreads();
+    }
+
+    template<class SortedValue>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void blocked_to_warp_striped(Key (&keys)[ItemsPerThread],
+                                 SortedValue (&values)[ItemsPerThread],
+                                 storage_type& storage,
+                                 std::true_type)
+    {
+        ::rocprim::warp_exchange<Key, ItemsPerThread>{}.blocked_to_striped_shuffle(keys, keys);
+        ::rocprim::warp_exchange<SortedValue, ItemsPerThread>{}.blocked_to_striped_shuffle(values,
+                                                                                           values);
+    }
+
+    template<bool Descending,
+             bool ToStriped             = false,
+             bool TryEmulateWarpStriped = true,
+             class SortedValue,
+             class Decomposer>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void sort_impl(Key (&keys)[ItemsPerThread],
                    SortedValue (&values)[ItemsPerThread],
@@ -1050,12 +1084,15 @@ private:
 
         // If we're using warp striped radix rank but our input is in a blocked layout, we
         // can emulate the correct input through an exchange to a warp striped layout.
-        if ROCPRIM_IF_CONSTEXPR(TryEmulateWarpStriped && warp_striped)
+        if ROCPRIM_IF_CONSTEXPR(TryEmulateWarpStriped && warp_striped && ItemsPerThread > 1)
         {
-            keys_exchange_type().blocked_to_warp_striped(keys, keys, storage.get().keys_exchange);
-            ::rocprim::syncthreads();
-            values_exchange_type().blocked_to_warp_striped(values, values, storage.get().values_exchange);
-            ::rocprim::syncthreads();
+            // This appears to be slower with high large items per thread.
+            constexpr bool use_warp_exchange
+                = device_warp_size() % ItemsPerThread == 0 && ItemsPerThread <= 4;
+            blocked_to_warp_striped(keys,
+                                    values,
+                                    storage,
+                                    std::integral_constant<bool, use_warp_exchange>{});
         }
 
         ROCPRIM_UNROLL

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -28,7 +28,6 @@
 #include "../functional.hpp"
 #include "../intrinsics/thread.hpp"
 #include "../thread/radix_key_codec.hpp"
-#include "../type_traits"
 #include "../types.hpp"
 
 #include "../warp/warp_exchange.hpp"

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -1092,6 +1092,14 @@ private:
     {
         using key_codec = ::rocprim::radix_key_codec<Key, Descending>;
 
+        // 'rank_keys' may be invoked multiple times. We encode the key once and move the
+        // encoded during the majority of sort to save on some compute.
+        ROCPRIM_UNROLL
+        for(unsigned int i = 0; i < ItemsPerThread; i++)
+        {
+            key_codec::encode_inplace(keys[i], decomposer);
+        }
+
         // If we're using warp striped radix rank but our input is in a blocked layout, we
         // can emulate the correct input through an exchange to a warp striped layout.
         if ROCPRIM_IF_CONSTEXPR(TryEmulateWarpStriped && warp_striped && ItemsPerThread > 1)
@@ -1106,12 +1114,6 @@ private:
             // Storage has been dirtied. 'rank_keys' does not always align nicely with this
             // so a full block synchronization is needed.
             ::rocprim::syncthreads();
-        }
-
-        ROCPRIM_UNROLL
-        for(unsigned int i = 0; i < ItemsPerThread; i++)
-        {
-            key_codec::encode_inplace(keys[i], decomposer);
         }
 
         unsigned int ranks[ItemsPerThread];
@@ -1158,6 +1160,7 @@ private:
             exchange_values(storage, values, ranks);
         }
 
+        // Done with 'rank_keys' so we can decode back to the original key.
         ROCPRIM_UNROLL
         for(unsigned int i = 0; i < ItemsPerThread; i++)
         {

--- a/rocprim/include/rocprim/block/config.hpp
+++ b/rocprim/include/rocprim/block/config.hpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ROCPRIM_BLOCK_CONFIG_HELPER_HPP_
+#define ROCPRIM_BLOCK_CONFIG_HELPER_HPP_
+
+#include "../config.hpp"
+#include "../detail/various.hpp"
+
+BEGIN_ROCPRIM_NAMESPACE
+
+/// \brief Padding hints for algorithms. Padding can be used to reduce bank
+/// conflicts at the cost of increasing LDS usage and potentially reducing
+/// occupancy.
+enum class block_padding_hint {
+    /// Use padding to avoid bank conflicts, if applicable. This allows an
+    /// algorithm to use more shared memory to reduce bank conflicts.
+    avoid_conflicts = 0,
+
+    /// Never use padding. This is useful when occupancy needs to be
+    /// maximized, and bank conflicts are known to be not an issue.
+    never_pad = 1,
+
+    /// Similar to \p block_padding_hint::avoid_conflicts , but only allows
+    /// padding when it does not affect theorethical occupancy limited by
+    /// shared memory. It's advised to use this when LDS usage is restricting
+    /// occupancy.
+    lds_occupancy_bound = 2,
+};
+
+namespace detail
+{
+/// \brief Utility wrapper to expose a static constexpr member occupancy of
+/// type T as a static constexpr value.
+template<typename T>
+struct map_occupancy_to_value
+{
+    /// \brief The original type.
+    using type = T;
+
+    /// \brief The value to order this by.
+    static constexpr auto value = T::occupancy;
+};
+
+/// \brief Selects the config depending on the padding hint.
+template<block_padding_hint PaddingHint, typename PaddedConfig, typename UnpaddedConfig>
+using select_block_padding_config
+    = std::conditional_t<PaddingHint == block_padding_hint::avoid_conflicts,
+                         PaddedConfig,
+                         std::conditional_t<PaddingHint == block_padding_hint::never_pad,
+                                            UnpaddedConfig,
+                                            typename detail::select_max_by_value_t<
+                                                map_occupancy_to_value<PaddedConfig>,
+                                                map_occupancy_to_value<UnpaddedConfig>>::type>>;
+} // namespace detail
+
+END_ROCPRIM_NAMESPACE
+#endif

--- a/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
+++ b/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
@@ -52,6 +52,22 @@ class block_radix_rank_match
     static constexpr unsigned int block_size   = BlockSizeX * BlockSizeY * BlockSizeZ;
     static constexpr unsigned int radix_digits = 1 << RadixBits;
 
+    /// \brief Emulate the LDS usage for a set number of warps.
+    ///
+    /// \warning This function behaves differently between device and host due to device
+    /// specifications not being available on host!
+    ROCPRIM_HOST_DEVICE
+    static constexpr unsigned int emulate_lds_usage(unsigned int warps)
+    {
+        const unsigned int active_counters = warps * radix_digits;
+        const unsigned int counters_per_thread
+            = ::rocprim::detail::ceiling_div(active_counters, block_size);
+        const unsigned int counters = counters_per_thread * block_size;
+        const size_t       lds_size = max(sizeof(digit_counter_type) * counters,
+                                    sizeof(typename block_scan_type::storage_type));
+        return lds_size;
+    }
+
     /// \brief Get the number of warps for this algorithm.
     ///
     /// Using an even number of warps may increase LDS bank conflicts. However padding the number
@@ -59,35 +75,21 @@ class block_radix_rank_match
     /// padding is a multiple of the required LDS.  Higher occupancy is preferred to hide latency
     /// as opposed to decreasaing bank conflicts. But, if the occupancy between padded and non-
     /// padded is the the same, we can pad for free!
+    ///
+    /// \warning This function behaves differently between device and host due to device
+    /// specifications not being available on host!
     ROCPRIM_HOST_DEVICE
     static constexpr unsigned int get_num_warps()
     {
         const unsigned int warps = ::rocprim::detail::ceiling_div(block_size, device_warp_size());
         const unsigned int padded_warps = warps | 1u;
 
-        const unsigned int active_counters        = warps * radix_digits;
-        const unsigned int padded_active_counters = padded_warps * radix_digits;
-
-        const unsigned int counters_per_thread
-            = ::rocprim::detail::ceiling_div(active_counters, block_size);
-        const unsigned int padded_counters_per_thread
-            = ::rocprim::detail::ceiling_div(padded_active_counters, block_size);
-
-        const unsigned int counters        = counters_per_thread * block_size;
-        const unsigned int padded_counters = padded_counters_per_thread * block_size;
-
-        // Get projected LDS size.
-        const size_t lds_size        = max(sizeof(digit_counter_type) * counters,
-                                    sizeof(typename block_scan_type::storage_type));
-        const size_t padded_lds_size = max(sizeof(digit_counter_type) * padded_counters,
-                                           sizeof(typename block_scan_type::storage_type));
-
         // LDS available on this architecture.
         const unsigned int available_lds = detail::get_min_lds_size();
 
         // Check occupancy limited by LDS.
-        const unsigned int occupancy        = available_lds / lds_size;
-        const unsigned int padded_occupancy = available_lds / padded_lds_size;
+        const unsigned int occupancy        = available_lds / emulate_lds_usage(warps);
+        const unsigned int padded_occupancy = available_lds / emulate_lds_usage(padded_warps);
 
         // Check if we can pad without hurting occupancy.
         return padded_occupancy >= occupancy ? padded_warps : warps;

--- a/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
+++ b/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
@@ -148,7 +148,12 @@ private:
 
             // Get the digit counter for this key on the current warp.
             digit_counters[i] = &get_digit_counter(digit, warp_id, storage);
-            const digit_counter_type warp_digit_prefix = *digit_counters[i];
+
+            // Read the prefix sum of that digit. We already know it's 0 on the first iteration. So
+            // we can skip a read-after-write depedency. The conditional gets optimized out due to
+            // loop unrolling.
+            const digit_counter_type warp_digit_prefix
+                = i == 0 ? digit_counter_type(0) : *digit_counters[i];
 
             // Construct a mask of threads in this wave which have the same digit.
             ::rocprim::lane_mask_type peer_mask = ::rocprim::match_any<RadixBits>(digit);

--- a/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
+++ b/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
@@ -29,16 +29,18 @@
 #include "../../thread/radix_key_codec.hpp"
 
 #include "../block_scan.hpp"
+#include "../config.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
 
-template<unsigned int BlockSizeX,
-         unsigned int RadixBits,
-         unsigned int BlockSizeY = 1,
-         unsigned int BlockSizeZ = 1>
+template<unsigned int       BlockSizeX,
+         unsigned int       RadixBits,
+         unsigned int       BlockSizeY  = 1,
+         unsigned int       BlockSizeZ  = 1,
+         block_padding_hint PaddingHint = block_padding_hint::avoid_conflicts>
 class block_radix_rank_match
 {
     using digit_counter_type = unsigned int;
@@ -75,13 +77,11 @@ class block_radix_rank_match
         static constexpr size_t       lds_size  = max(sizeof(digit_counter_type) * counters,
                                                sizeof(typename block_scan_type::storage_type));
         static constexpr unsigned int occupancy = detail::get_min_lds_size() / lds_size;
-
-        // score is requried for 'select_max_by_score_t'
-        static constexpr unsigned int score = occupancy;
     };
 
-    using config
-        = detail::select_max_by_score_t<build_config<padded_config>, build_config<unpadded_config>>;
+    using config = detail::select_block_padding_config<PaddingHint,
+                                                       build_config<padded_config>,
+                                                       build_config<unpadded_config>>;
 
     static constexpr unsigned int warps = config::warps;
     // The number of counters that are actively being used.

--- a/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
+++ b/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
@@ -52,59 +52,43 @@ class block_radix_rank_match
     static constexpr unsigned int block_size   = BlockSizeX * BlockSizeY * BlockSizeZ;
     static constexpr unsigned int radix_digits = 1 << RadixBits;
 
-    /// \brief Emulate the LDS usage for a set number of warps.
-    ///
-    /// \warning This function behaves differently between device and host due to device
-    /// specifications not being available on host!
-    ROCPRIM_HOST_DEVICE
-    static constexpr unsigned int emulate_lds_usage(unsigned int warps)
+    struct unpadded_config {
+        static constexpr unsigned int warps = ::rocprim::detail::ceiling_div(block_size, device_warp_size());
+    };
+
+    struct padded_config {
+        static constexpr unsigned int warps = unpadded_config::warps | 1u;
+    };
+
+    template<typename Config>
+    struct build_config : Config
     {
-        const unsigned int active_counters = warps * radix_digits;
-        const unsigned int counters_per_thread
+        static constexpr unsigned int  active_counters = Config::warps * radix_digits;
+        static constexpr unsigned int  counters_per_thread
             = ::rocprim::detail::ceiling_div(active_counters, block_size);
-        const unsigned int counters = counters_per_thread * block_size;
-        const size_t       lds_size = max(sizeof(digit_counter_type) * counters,
-                                    sizeof(typename block_scan_type::storage_type));
-        return lds_size;
-    }
+        static constexpr unsigned int counters  = counters_per_thread * block_size;
 
-    /// \brief Get the number of warps for this algorithm.
-    ///
-    /// Using an even number of warps may increase LDS bank conflicts. However padding the number
-    /// warps increases LDS usage. This can cause a lower occupancy when the available LDS before
-    /// padding is a multiple of the required LDS.  Higher occupancy is preferred to hide latency
-    /// as opposed to decreasaing bank conflicts. But, if the occupancy between padded and non-
-    /// padded is the the same, we can pad for free!
-    ///
-    /// \warning This function behaves differently between device and host due to device
-    /// specifications not being available on host!
-    ROCPRIM_HOST_DEVICE
-    static constexpr unsigned int get_num_warps()
-    {
-        const unsigned int warps = ::rocprim::detail::ceiling_div(block_size, device_warp_size());
-        const unsigned int padded_warps = warps | 1u;
+        // Compute local data share and theorethical occupancy
+        static constexpr size_t       lds_size  = max(sizeof(digit_counter_type) * counters,
+                                               sizeof(typename block_scan_type::storage_type));
+        static constexpr unsigned int occupancy = detail::get_min_lds_size() / lds_size;
 
-        // LDS available on this architecture.
-        const unsigned int available_lds = detail::get_min_lds_size();
+        // score is requried for 'select_max_by_score_t'
+        static constexpr unsigned int score = occupancy;
+    };
 
-        // Check occupancy limited by LDS.
-        const unsigned int occupancy        = available_lds / emulate_lds_usage(warps);
-        const unsigned int padded_occupancy = available_lds / emulate_lds_usage(padded_warps);
+    using config
+        = detail::select_max_by_score_t<build_config<padded_config>, build_config<unpadded_config>>;
 
-        // Check if we can pad without hurting occupancy.
-        return padded_occupancy >= occupancy ? padded_warps : warps;
-    }
-
-    static constexpr unsigned int warps = get_num_warps();
+    static constexpr unsigned int warps = config::warps;
     // The number of counters that are actively being used.
-    static constexpr unsigned int active_counters = warps * radix_digits;
+    static constexpr unsigned int active_counters = config::active_counters;
     // We want to use a regular block scan to scan the per-warp counters. This requires the
     // total number of counters to be divisible by the block size. To facilitate this, just add
     // a bunch of counters that are not otherwise used.
-    static constexpr unsigned int counters_per_thread
-        = ::rocprim::detail::ceiling_div(active_counters, block_size);
+    static constexpr unsigned int counters_per_thread = config::counters_per_thread;
     // The total number of counters, factoring in the unused ones for the block scan.
-    static constexpr unsigned int counters = counters_per_thread * block_size;
+    static constexpr unsigned int counters = config::counters;
 
 public:
     constexpr static unsigned int digits_per_thread

--- a/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
+++ b/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
@@ -52,21 +52,24 @@ class block_radix_rank_match
     static constexpr unsigned int block_size   = BlockSizeX * BlockSizeY * BlockSizeZ;
     static constexpr unsigned int radix_digits = 1 << RadixBits;
 
-    struct unpadded_config {
-        static constexpr unsigned int warps = ::rocprim::detail::ceiling_div(block_size, device_warp_size());
+    struct unpadded_config
+    {
+        static constexpr unsigned int warps
+            = ::rocprim::detail::ceiling_div(block_size, device_warp_size());
     };
 
-    struct padded_config {
+    struct padded_config
+    {
         static constexpr unsigned int warps = unpadded_config::warps | 1u;
     };
 
     template<typename Config>
     struct build_config : Config
     {
-        static constexpr unsigned int  active_counters = Config::warps * radix_digits;
-        static constexpr unsigned int  counters_per_thread
+        static constexpr unsigned int active_counters = Config::warps * radix_digits;
+        static constexpr unsigned int counters_per_thread
             = ::rocprim::detail::ceiling_div(active_counters, block_size);
-        static constexpr unsigned int counters  = counters_per_thread * block_size;
+        static constexpr unsigned int counters = counters_per_thread * block_size;
 
         // Compute local data share and theorethical occupancy
         static constexpr size_t       lds_size  = max(sizeof(digit_counter_type) * counters,

--- a/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
+++ b/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
@@ -139,7 +139,7 @@ private:
             digit_counters[i] = &get_digit_counter(digit, warp_id, storage);
 
             // Read the prefix sum of that digit. We already know it's 0 on the first iteration. So
-            // we can skip a read-after-write depedency. The conditional gets optimized out due to
+            // we can skip a read-after-write dependency. The conditional gets optimized out due to
             // loop unrolling.
             const digit_counter_type warp_digit_prefix
                 = i == 0 ? digit_counter_type(0) : *digit_counters[i];

--- a/rocprim/include/rocprim/detail/various.hpp
+++ b/rocprim/include/rocprim/detail/various.hpp
@@ -154,6 +154,18 @@ constexpr unsigned int get_lds_banks_no()
     return 32;
 }
 
+/// \brief Returns the minimum LDS size in bytes available on this device architecture.
+ROCPRIM_HOST_DEVICE
+constexpr unsigned int get_min_lds_size()
+{
+#if defined(__GFX11__) || defined(__GFX10__)
+    return (1 << 17) /* 128 KiB*/;
+#else
+    // On host the lowest should be returned!
+    return (1 << 16) /* 64 KiB */;
+#endif
+}
+
 // Finds biggest fundamental type for type T that sizeof(T) is
 // a multiple of that type's size.
 template<class T>

--- a/rocprim/include/rocprim/detail/various.hpp
+++ b/rocprim/include/rocprim/detail/various.hpp
@@ -420,6 +420,21 @@ ROCPRIM_HOST_DEVICE auto bit_cast(const Source& source)
 #endif
 }
 
+template<typename... Ts>
+struct select_max_by_score;
+
+template<typename T>
+struct select_max_by_score<T> { using type = T; };
+
+template<typename T, typename U, typename... Vs>
+struct select_max_by_score<T, U, Vs...> {
+    using tail = typename select_max_by_score<U, Vs...>::type;
+    using type = std::conditional_t<(T::score >= tail::score), T, tail>;
+};
+
+template<typename... Ts>
+using select_max_by_score_t = typename select_max_by_score<Ts...>::type;
+
 } // end namespace detail
 END_ROCPRIM_NAMESPACE
 

--- a/rocprim/include/rocprim/detail/various.hpp
+++ b/rocprim/include/rocprim/detail/various.hpp
@@ -424,10 +424,14 @@ template<typename... Ts>
 struct select_max_by_score;
 
 template<typename T>
-struct select_max_by_score<T> { using type = T; };
+struct select_max_by_score<T>
+{
+    using type = T;
+};
 
 template<typename T, typename U, typename... Vs>
-struct select_max_by_score<T, U, Vs...> {
+struct select_max_by_score<T, U, Vs...>
+{
     using tail = typename select_max_by_score<U, Vs...>::type;
     using type = std::conditional_t<(T::score >= tail::score), T, tail>;
 };

--- a/rocprim/include/rocprim/detail/various.hpp
+++ b/rocprim/include/rocprim/detail/various.hpp
@@ -421,23 +421,23 @@ ROCPRIM_HOST_DEVICE auto bit_cast(const Source& source)
 }
 
 template<typename... Ts>
-struct select_max_by_score;
+struct select_max_by_value;
 
 template<typename T>
-struct select_max_by_score<T>
+struct select_max_by_value<T>
 {
     using type = T;
 };
 
 template<typename T, typename U, typename... Vs>
-struct select_max_by_score<T, U, Vs...>
+struct select_max_by_value<T, U, Vs...>
 {
-    using tail = typename select_max_by_score<U, Vs...>::type;
-    using type = std::conditional_t<(T::score >= tail::score), T, tail>;
+    using tail = typename select_max_by_value<U, Vs...>::type;
+    using type = std::conditional_t<(T::value >= tail::value), T, tail>;
 };
 
 template<typename... Ts>
-using select_max_by_score_t = typename select_max_by_score<Ts...>::type;
+using select_max_by_value_t = typename select_max_by_value<Ts...>::type;
 
 } // end namespace detail
 END_ROCPRIM_NAMESPACE

--- a/rocprim/include/rocprim/device/detail/config/device_radix_sort_block_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/config/device_radix_sort_block_sort.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -54,7 +54,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 31>
+                      && (sizeof(value_type) > 4))>> : kernel_config<64, 25>
 {};
 
 // Based on key_type = double, value_type = int
@@ -65,7 +65,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 31>
+                      && (sizeof(value_type) > 2))>> : kernel_config<64, 25>
 {};
 
 // Based on key_type = double, value_type = short
@@ -76,7 +76,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 31>
+                      && (sizeof(value_type) > 1))>> : kernel_config<128, 26>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -88,7 +88,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 31>
+    : kernel_config<128, 28>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -100,7 +100,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 31>
+    : kernel_config<64, 32>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -111,7 +111,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 31>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 25>
 {};
 
 // Based on key_type = float, value_type = int
@@ -122,7 +122,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 32>
+                      && (sizeof(value_type) > 2))>> : kernel_config<128, 29>
 {};
 
 // Based on key_type = float, value_type = short
@@ -133,7 +133,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 32>
+                      && (sizeof(value_type) > 1))>> : kernel_config<128, 31>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -145,7 +145,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 32>
+    : kernel_config<64, 31>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -157,7 +157,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<128, 32>
+    : kernel_config<64, 32>
 {};
 
 // Based on key_type = rocprim::half, value_type = int64_t
@@ -168,7 +168,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
-    : kernel_config<512, 11>
+    : kernel_config<256, 25>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -179,7 +179,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
-    : kernel_config<1024, 14>
+    : kernel_config<256, 32>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -190,7 +190,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
-    : kernel_config<512, 8>
+    : kernel_config<128, 29>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -202,7 +202,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 18>
+    : kernel_config<128, 31>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -213,7 +213,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 14>
+    : kernel_config<128, 32>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -224,7 +224,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 31>
+                      && (sizeof(value_type) > 4))>> : kernel_config<64, 25>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -235,7 +235,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 31>
+                      && (sizeof(value_type) > 2))>> : kernel_config<128, 30>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -246,7 +246,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 31>
+                      && (sizeof(value_type) > 1))>> : kernel_config<128, 29>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -258,7 +258,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 31>
+    : kernel_config<64, 28>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -270,7 +270,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 31>
+    : kernel_config<64, 28>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -281,7 +281,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 31>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 25>
 {};
 
 // Based on key_type = int, value_type = int
@@ -292,7 +292,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 32>
+                      && (sizeof(value_type) > 2))>> : kernel_config<128, 29>
 {};
 
 // Based on key_type = int, value_type = short
@@ -303,7 +303,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 32>
+                      && (sizeof(value_type) > 1))>> : kernel_config<128, 31>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -315,7 +315,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 32>
+    : kernel_config<128, 31>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -327,7 +327,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<128, 32>
+    : kernel_config<64, 32>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -338,7 +338,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 16>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 26>
 {};
 
 // Based on key_type = short, value_type = int
@@ -360,7 +360,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 32>
+                      && (sizeof(value_type) > 1))>> : kernel_config<128, 29>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -372,7 +372,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 32>
+    : kernel_config<64, 31>
 {};
 
 // Based on key_type = short, value_type = empty_type
@@ -384,7 +384,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<512, 32>
+    : kernel_config<64, 32>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -395,7 +395,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
-    : kernel_config<1024, 7>
+    : kernel_config<512, 15>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -406,7 +406,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
-    : kernel_config<1024, 15>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -417,7 +417,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
-    : kernel_config<256, 32>
+    : kernel_config<256, 31>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -429,7 +429,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 28>
+    : kernel_config<64, 31>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -440,262 +440,659 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<512, 32>
+    : kernel_config<64, 32>
 {};
 
 // Based on key_type = double, value_type = int64_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<128, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<128, 25>
 {};
 
 // Based on key_type = double, value_type = int
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<128, 25>
 {};
 
 // Based on key_type = double, value_type = short
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 14>
+                      && (sizeof(value_type) > 1))>> : kernel_config<128, 25>
 {};
 
 // Based on key_type = double, value_type = int8_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<64, 28>
 {};
 
 // Based on key_type = double, value_type = empty_type
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<128, 32>
 {};
 
 // Based on key_type = float, value_type = int64_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<128, 25>
 {};
 
 // Based on key_type = float, value_type = int
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<128, 17>
+                      && (sizeof(value_type) > 2))>> : kernel_config<64, 31>
 {};
 
 // Based on key_type = float, value_type = short
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 15>
+                      && (sizeof(value_type) > 1))>> : kernel_config<64, 30>
 {};
 
 // Based on key_type = float, value_type = int8_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 17>
+    : kernel_config<64, 30>
 {};
 
 // Based on key_type = float, value_type = empty_type
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<512, 21>
+    : kernel_config<128, 32>
 {};
 
 // Based on key_type = rocprim::half, value_type = int64_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
-    : kernel_config<512, 5>
+    : kernel_config<256, 25>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
-    : kernel_config<256, 9>
+    : kernel_config<128, 30>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
-    : kernel_config<256, 7>
+    : kernel_config<128, 31>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 10>
+    : kernel_config<64, 27>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 12>
+    : kernel_config<64, 32>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<64, 29>
+                      && (sizeof(value_type) > 4))>> : kernel_config<128, 25>
 {};
 
 // Based on key_type = int64_t, value_type = int
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<128, 25>
 {};
 
 // Based on key_type = int64_t, value_type = short
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 14>
+                      && (sizeof(value_type) > 1))>> : kernel_config<128, 25>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<64, 28>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<128, 32>
 {};
 
 // Based on key_type = int, value_type = int64_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<128, 25>
 {};
 
 // Based on key_type = int, value_type = int
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<128, 17>
+                      && (sizeof(value_type) > 2))>> : kernel_config<64, 31>
 {};
 
 // Based on key_type = int, value_type = short
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<64, 30>
+{};
+
+// Based on key_type = int, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<64, 30>
+{};
+
+// Based on key_type = int, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<64, 30>
+{};
+
+// Based on key_type = short, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 25>
+{};
+
+// Based on key_type = short, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<128, 30>
+{};
+
+// Based on key_type = short, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<64, 31>
+{};
+
+// Based on key_type = short, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<128, 30>
+{};
+
+// Based on key_type = short, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<64, 32>
+{};
+
+// Based on key_type = int8_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = int8_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : kernel_config<256, 30>
+{};
+
+// Based on key_type = int8_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : kernel_config<128, 30>
+{};
+
+// Based on key_type = int8_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<64, 31>
+{};
+
+// Based on key_type = int8_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx1100),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<64, 32>
+{};
+
+// Based on key_type = double, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
+{};
+
+// Based on key_type = double, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 12>
+{};
+
+// Based on key_type = double, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 13>
+{};
+
+// Based on key_type = double, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 12>
+{};
+
+// Based on key_type = double, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = float, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
+{};
+
+// Based on key_type = float, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 18>
+{};
+
+// Based on key_type = float, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = float, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 15>
+{};
+
+// Based on key_type = float, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<512, 23>
+{};
+
+// Based on key_type = rocprim::half, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : kernel_config<256, 12>
+{};
+
+// Based on key_type = rocprim::half, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : kernel_config<256, 15>
+{};
+
+// Based on key_type = rocprim::half, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : kernel_config<256, 19>
+{};
+
+// Based on key_type = rocprim::half, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<512, 17>
+{};
+
+// Based on key_type = rocprim::half, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<512, 23>
+{};
+
+// Based on key_type = int64_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
+{};
+
+// Based on key_type = int64_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 12>
+{};
+
+// Based on key_type = int64_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 13>
+{};
+
+// Based on key_type = int64_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 12>
+{};
+
+// Based on key_type = int64_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = int, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
+{};
+
+// Based on key_type = int, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 19>
+{};
+
+// Based on key_type = int, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
@@ -706,138 +1103,138 @@ struct default_radix_sort_block_sort_config<
 // Based on key_type = int, value_type = int8_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 18>
+    : kernel_config<256, 15>
 {};
 
 // Based on key_type = int, value_type = empty_type
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 21>
+    : kernel_config<512, 23>
 {};
 
 // Based on key_type = short, value_type = int64_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<512, 5>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = short, value_type = int
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 9>
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 14>
 {};
 
 // Based on key_type = short, value_type = short
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 7>
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 19>
 {};
 
 // Based on key_type = short, value_type = int8_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 10>
+    : kernel_config<256, 15>
 {};
 
 // Based on key_type = short, value_type = empty_type
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 32>
+    : kernel_config<256, 23>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
-    : kernel_config<1024, 6>
+    : kernel_config<256, 13>
 {};
 
 // Based on key_type = int8_t, value_type = int
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
-    : kernel_config<512, 7>
+    : kernel_config<256, 10>
 {};
 
 // Based on key_type = int8_t, value_type = short
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
-    : kernel_config<512, 7>
+    : kernel_config<256, 16>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 20>
+    : kernel_config<256, 17>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
 template<class key_type, class value_type>
 struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx900),
+    static_cast<unsigned int>(target_arch::gfx906),
     key_type,
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<512, 32>
+    : kernel_config<256, 22>
 {};
 
 // Based on key_type = double, value_type = int64_t
@@ -848,7 +1245,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = double, value_type = int
@@ -859,7 +1256,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = double, value_type = short
@@ -870,7 +1267,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 14>
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 13>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -882,7 +1279,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<128, 15>
+    : kernel_config<256, 12>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -894,7 +1291,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<256, 16>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -905,7 +1302,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = float, value_type = int
@@ -927,7 +1324,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<1024, 15>
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 31>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -939,7 +1336,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 15>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -962,7 +1359,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
-    : kernel_config<256, 7>
+    : kernel_config<256, 12>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -973,7 +1370,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
-    : kernel_config<256, 9>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -984,7 +1381,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
-    : kernel_config<256, 7>
+    : kernel_config<512, 32>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -996,7 +1393,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 10>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -1007,7 +1404,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 12>
+    : kernel_config<1024, 23>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -1018,7 +1415,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -1029,7 +1426,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -1040,7 +1437,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 14>
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 8>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -1052,7 +1449,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<256, 12>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -1064,7 +1461,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<256, 16>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -1075,7 +1472,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = int, value_type = int
@@ -1097,7 +1494,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<1024, 15>
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 31>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -1109,7 +1506,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 15>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -1121,7 +1518,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 15>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -1132,7 +1529,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<512, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = short, value_type = int
@@ -1143,7 +1540,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<1024, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<512, 31>
 {};
 
 // Based on key_type = short, value_type = short
@@ -1154,7 +1551,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<64, 32>
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 32>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -1178,7 +1575,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 32>
+    : kernel_config<1024, 23>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -1189,7 +1586,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
-    : kernel_config<512, 14>
+    : kernel_config<256, 13>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -1200,7 +1597,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
-    : kernel_config<512, 24>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -1211,7 +1608,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
-    : kernel_config<256, 7>
+    : kernel_config<512, 32>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -1223,7 +1620,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 20>
+    : kernel_config<512, 32>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -1234,7 +1631,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 25>
+    : kernel_config<1024, 23>
 {};
 
 // Based on key_type = double, value_type = int64_t
@@ -1245,7 +1642,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = double, value_type = int
@@ -1256,7 +1653,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = double, value_type = short
@@ -1267,7 +1664,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 14>
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 13>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -1279,7 +1676,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<128, 15>
+    : kernel_config<256, 12>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -1291,7 +1688,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<256, 16>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -1302,7 +1699,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = float, value_type = int
@@ -1324,7 +1721,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<1024, 15>
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 31>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -1336,7 +1733,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 15>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -1359,7 +1756,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
-    : kernel_config<256, 7>
+    : kernel_config<256, 12>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -1370,7 +1767,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
-    : kernel_config<256, 9>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -1381,7 +1778,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
-    : kernel_config<256, 7>
+    : kernel_config<512, 32>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -1393,7 +1790,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 10>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -1404,7 +1801,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 12>
+    : kernel_config<1024, 23>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -1415,7 +1812,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -1426,7 +1823,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -1437,7 +1834,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 14>
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 8>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -1449,7 +1846,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<256, 12>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -1461,7 +1858,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<256, 16>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -1472,7 +1869,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = int, value_type = int
@@ -1494,7 +1891,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<1024, 15>
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 31>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -1506,7 +1903,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 15>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -1518,7 +1915,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 15>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -1529,7 +1926,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<512, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = short, value_type = int
@@ -1540,7 +1937,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<1024, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<512, 31>
 {};
 
 // Based on key_type = short, value_type = short
@@ -1551,7 +1948,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<64, 32>
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 32>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -1575,7 +1972,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 32>
+    : kernel_config<1024, 23>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -1586,7 +1983,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
-    : kernel_config<512, 14>
+    : kernel_config<256, 13>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -1597,7 +1994,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
-    : kernel_config<512, 24>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -1608,7 +2005,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
-    : kernel_config<256, 7>
+    : kernel_config<512, 32>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -1620,7 +2017,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 20>
+    : kernel_config<512, 32>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -1631,7 +2028,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 25>
+    : kernel_config<1024, 23>
 {};
 
 // Based on key_type = double, value_type = int64_t
@@ -1642,7 +2039,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = double, value_type = int
@@ -1653,7 +2050,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = double, value_type = short
@@ -1664,7 +2061,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 14>
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 13>
 {};
 
 // Based on key_type = double, value_type = int8_t
@@ -1676,7 +2073,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<128, 15>
+    : kernel_config<256, 12>
 {};
 
 // Based on key_type = double, value_type = empty_type
@@ -1688,7 +2085,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<256, 16>
 {};
 
 // Based on key_type = float, value_type = int64_t
@@ -1699,7 +2096,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = float, value_type = int
@@ -1721,7 +2118,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<1024, 15>
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 31>
 {};
 
 // Based on key_type = float, value_type = int8_t
@@ -1733,7 +2130,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 15>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = float, value_type = empty_type
@@ -1756,7 +2153,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
-    : kernel_config<256, 7>
+    : kernel_config<256, 12>
 {};
 
 // Based on key_type = rocprim::half, value_type = int
@@ -1767,7 +2164,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
-    : kernel_config<256, 9>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = rocprim::half, value_type = short
@@ -1778,7 +2175,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
-    : kernel_config<256, 7>
+    : kernel_config<512, 32>
 {};
 
 // Based on key_type = rocprim::half, value_type = int8_t
@@ -1790,7 +2187,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 10>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = rocprim::half, value_type = empty_type
@@ -1801,7 +2198,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 12>
+    : kernel_config<1024, 23>
 {};
 
 // Based on key_type = int64_t, value_type = int64_t
@@ -1812,7 +2209,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = int64_t, value_type = int
@@ -1823,7 +2220,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = int64_t, value_type = short
@@ -1834,7 +2231,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<256, 14>
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 8>
 {};
 
 // Based on key_type = int64_t, value_type = int8_t
@@ -1846,7 +2243,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<256, 12>
 {};
 
 // Based on key_type = int64_t, value_type = empty_type
@@ -1858,7 +2255,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
                       && (sizeof(key_type) > 4)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
+    : kernel_config<256, 16>
 {};
 
 // Based on key_type = int, value_type = int64_t
@@ -1869,7 +2266,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<256, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = int, value_type = int
@@ -1891,7 +2288,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<1024, 15>
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 31>
 {};
 
 // Based on key_type = int, value_type = int8_t
@@ -1903,7 +2300,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 15>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = int, value_type = empty_type
@@ -1915,7 +2312,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
                       && (sizeof(key_type) > 2)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 15>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = short, value_type = int64_t
@@ -1926,7 +2323,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
-                      && (sizeof(value_type) > 4))>> : kernel_config<512, 13>
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 12>
 {};
 
 // Based on key_type = short, value_type = int
@@ -1937,7 +2334,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
-                      && (sizeof(value_type) > 2))>> : kernel_config<1024, 13>
+                      && (sizeof(value_type) > 2))>> : kernel_config<512, 31>
 {};
 
 // Based on key_type = short, value_type = short
@@ -1948,7 +2345,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
-                      && (sizeof(value_type) > 1))>> : kernel_config<64, 32>
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 32>
 {};
 
 // Based on key_type = short, value_type = int8_t
@@ -1972,7 +2369,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
                       && (sizeof(key_type) > 1)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 32>
+    : kernel_config<1024, 23>
 {};
 
 // Based on key_type = int8_t, value_type = int64_t
@@ -1983,7 +2380,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
-    : kernel_config<512, 14>
+    : kernel_config<256, 13>
 {};
 
 // Based on key_type = int8_t, value_type = int
@@ -1994,7 +2391,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
-    : kernel_config<512, 24>
+    : kernel_config<512, 31>
 {};
 
 // Based on key_type = int8_t, value_type = short
@@ -2005,7 +2402,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
-    : kernel_config<256, 7>
+    : kernel_config<512, 32>
 {};
 
 // Based on key_type = int8_t, value_type = int8_t
@@ -2017,7 +2414,7 @@ struct default_radix_sort_block_sort_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (sizeof(value_type) <= 1)
                       && (!std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 20>
+    : kernel_config<512, 32>
 {};
 
 // Based on key_type = int8_t, value_type = empty_type
@@ -2028,172 +2425,7 @@ struct default_radix_sort_block_sort_config<
     value_type,
     std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
                       && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<1024, 25>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906), double>
-    : kernel_config<256, 15>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906), float>
-    : kernel_config<512, 25>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906),
-                                            int,
-                                            double> : kernel_config<256, 13>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906),
-                                            int,
-                                            double2> : kernel_config<256, 5>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906),
-                                            int,
-                                            float> : kernel_config<64, 17>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906), int>
-    : kernel_config<512, 25>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906),
-                                            int64_t,
-                                            double> : kernel_config<256, 13>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906),
-                                            int64_t,
-                                            float> : kernel_config<256, 13>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906), int64_t>
-    : kernel_config<256, 15>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906),
-                                            int8_t,
-                                            int8_t> : kernel_config<256, 20>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906), int8_t>
-    : kernel_config<256, 32>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906),
-                                            rocprim::half> : kernel_config<256, 12>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906),
-                                            rocprim::half,
-                                            rocprim::half> : kernel_config<512, 6>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906), short>
-    : kernel_config<256, 32>
-{};
-
-template<>
-struct default_radix_sort_block_sort_config<static_cast<unsigned int>(target_arch::gfx906),
-                                            uint8_t,
-                                            uint8_t> : kernel_config<256, 20>
-{};
-
-// Based on key_type = double, value_type = rocprim::empty_type
-template<class key_type, class value_type>
-struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx906),
-    key_type,
-    value_type,
-    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
-                      && (sizeof(key_type) > 4)
-                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
-{};
-
-// Based on key_type = float, value_type = rocprim::empty_type
-template<class key_type, class value_type>
-struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx906),
-    key_type,
-    value_type,
-    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
-                      && (sizeof(key_type) > 2)
-                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<512, 25>
-{};
-
-// Based on key_type = rocprim::half, value_type = rocprim::empty_type
-template<class key_type, class value_type>
-struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx906),
-    key_type,
-    value_type,
-    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
-                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 12>
-{};
-
-// Based on key_type = int64_t, value_type = rocprim::empty_type
-template<class key_type, class value_type>
-struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx906),
-    key_type,
-    value_type,
-    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
-                      && (sizeof(key_type) > 4)
-                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 15>
-{};
-
-// Based on key_type = int, value_type = rocprim::empty_type
-template<class key_type, class value_type>
-struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx906),
-    key_type,
-    value_type,
-    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
-                      && (sizeof(key_type) > 2)
-                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<512, 25>
-{};
-
-// Based on key_type = short, value_type = rocprim::empty_type
-template<class key_type, class value_type>
-struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx906),
-    key_type,
-    value_type,
-    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
-                      && (sizeof(key_type) > 1)
-                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 32>
-{};
-
-// Based on key_type = int8_t, value_type = rocprim::empty_type
-template<class key_type, class value_type>
-struct default_radix_sort_block_sort_config<
-    static_cast<unsigned int>(target_arch::gfx906),
-    key_type,
-    value_type,
-    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
-                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
-    : kernel_config<256, 32>
+    : kernel_config<1024, 23>
 {};
 
 } // end namespace detail

--- a/rocprim/include/rocprim/device/detail/config/device_radix_sort_block_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/config/device_radix_sort_block_sort.hpp
@@ -2428,6 +2428,403 @@ struct default_radix_sort_block_sort_config<
     : kernel_config<1024, 23>
 {};
 
+// Based on key_type = double, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = double, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = double, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = double, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = double, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = float, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = float, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<512, 16>
+{};
+
+// Based on key_type = float, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 32>
+{};
+
+// Based on key_type = float, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = float, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = rocprim::half, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : kernel_config<512, 8>
+{};
+
+// Based on key_type = rocprim::half, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = rocprim::half, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : kernel_config<512, 18>
+{};
+
+// Based on key_type = rocprim::half, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = rocprim::half, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<512, 21>
+{};
+
+// Based on key_type = int64_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = int64_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = int64_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = int64_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = int64_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = int, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 10>
+{};
+
+// Based on key_type = int, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 32>
+{};
+
+// Based on key_type = int, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 32>
+{};
+
+// Based on key_type = int, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = int, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = short, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = short, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 11>
+{};
+
+// Based on key_type = short, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 18>
+{};
+
+// Based on key_type = short, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = short, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<512, 23>
+{};
+
+// Based on key_type = int8_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = int8_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : kernel_config<256, 21>
+{};
+
+// Based on key_type = int8_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : kernel_config<256, 21>
+{};
+
+// Based on key_type = int8_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 23>
+{};
+
+// Based on key_type = int8_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<512, 21>
+{};
+
 } // end namespace detail
 
 END_ROCPRIM_NAMESPACE

--- a/rocprim/include/rocprim/device/detail/config/device_radix_sort_onesweep.hpp
+++ b/rocprim/include/rocprim/device/detail/config/device_radix_sort_onesweep.hpp
@@ -3148,6 +3148,523 @@ struct default_radix_sort_onesweep_config<
                                  block_radix_rank_algorithm::match>
 {};
 
+// Based on key_type = double, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 12>,
+                                 kernel_config<512, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 22>,
+                                 kernel_config<512, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 22>,
+                                 kernel_config<512, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 22>,
+                                 kernel_config<512, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 12>,
+                                 kernel_config<512, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 22>,
+                                 kernel_config<512, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 22>,
+                                 kernel_config<512, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 6>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 22>,
+                                 kernel_config<512, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 22>,
+                                 kernel_config<1024, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
 } // end namespace detail
 
 END_ROCPRIM_NAMESPACE

--- a/rocprim/include/rocprim/device/detail/config/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/config/device_segmented_radix_sort.hpp
@@ -4631,6 +4631,663 @@ struct default_segmented_radix_sort_config<
           1>
 {};
 
+// Based on key_type = double, value_type = int64_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 16>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 1024, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = double, value_type = int
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 8>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 2, 256, 2048, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = double, value_type = short
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 256, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = double, value_type = int8_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 13>,
+          typename std::conditional<1,
+                                    WarpSortConfig<16, 4, 256, 2048, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = double, value_type = empty_type
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          0,
+          kernel_config<256, 13>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 8, 256, 4096, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = float, value_type = int64_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 16>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 1024, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = float, value_type = int
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 16>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 2048, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = float, value_type = short
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 2, 256, 2048, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = float, value_type = int8_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 16>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 128, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = float, value_type = empty_type
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          0,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 4096, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = rocprim::half, value_type = int64_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 8>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 2, 256, 2048, 64, 4, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = rocprim::half, value_type = int
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 8>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 2, 256, 4096, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = rocprim::half, value_type = short
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 2, 256, 2048, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = rocprim::half, value_type = int8_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 16>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 1024, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = rocprim::half, value_type = empty_type
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          0,
+          kernel_config<256, 16>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 8, 256, 4096, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int64_t, value_type = int64_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<16, 4, 256, 1024, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int64_t, value_type = int
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 13>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 2, 256, 1024, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int64_t, value_type = short
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 2, 256, 64, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int64_t, value_type = int8_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 13>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 2, 256, 256, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int64_t, value_type = empty_type
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          0,
+          kernel_config<256, 13>,
+          typename std::conditional<1,
+                                    WarpSortConfig<16, 4, 256, 1024, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int, value_type = int64_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 16>,
+          typename std::conditional<1,
+                                    WarpSortConfig<16, 4, 256, 1024, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int, value_type = int
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 2048, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int, value_type = short
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<16, 4, 256, 256, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int, value_type = int8_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 16>,
+          typename std::conditional<1,
+                                    WarpSortConfig<16, 4, 256, 256, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int, value_type = empty_type
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          0,
+          kernel_config<256, 16>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 1024, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = short, value_type = int64_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 8>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 2, 256, 4096, 32, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = short, value_type = int
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<16, 4, 256, 2048, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = short, value_type = short
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 2048, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = short, value_type = int8_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 1024, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = short, value_type = empty_type
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          0,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<16, 4, 256, 4096, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int8_t, value_type = int64_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 8>,
+          typename std::conditional<1,
+                                    WarpSortConfig<32, 2, 256, 2048, 16, 4, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int8_t, value_type = int
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 8>,
+          typename std::conditional<1,
+                                    WarpSortConfig<16, 4, 256, 4096, 64, 4, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int8_t, value_type = short
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 8>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 4096, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int8_t, value_type = int8_t
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          8,
+          kernel_config<256, 8>,
+          typename std::conditional<1,
+                                    WarpSortConfig<16, 4, 256, 4096, 64, 8, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
+// Based on key_type = int8_t, value_type = empty_type
+template<class key_type, typename value_type>
+struct default_segmented_radix_sort_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : segmented_radix_sort_config<
+          8,
+          0,
+          kernel_config<256, 17>,
+          typename std::conditional<1,
+                                    WarpSortConfig<8, 8, 256, 4096, 32, 16, 256>,
+                                    DisabledWarpSortConfig>::type,
+          1>
+{};
+
 } // end namespace detail
 
 END_ROCPRIM_NAMESPACE

--- a/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -470,6 +470,7 @@ struct segmented_radix_sort_config_params
     /// \brief Number of bits in long iterations.
     unsigned int long_radix_bits = 0;
     /// \brief Number of bits in short iterations.
+    /// \deprecated The short radix bits parameter is no longer used and will be removed in a future version.
     unsigned int short_radix_bits = 0;
     /// \brief If set to \p true, warp sort can be used to sort the small segments, even if no partitioning happens.
     bool enable_unpartitioned_warp_sort = true;
@@ -567,6 +568,7 @@ struct DisabledWarpSortConfig
 ///
 /// \tparam LongRadixBits - number of bits in long iterations.
 /// \tparam ShortRadixBits - number of bits in short iterations, must be equal to or less than `LongRadixBits`.
+/// Deprecated and no longer used.
 /// \tparam SortConfig - configuration of radix sort kernel. Must be `kernel_config`.
 /// \tparam WarpSortConfig - configuration of the warp sort that is used on the short segments.
 template<unsigned int LongRadixBits,
@@ -584,6 +586,7 @@ struct segmented_radix_sort_config : public detail::segmented_radix_sort_config_
     static constexpr unsigned int long_radix_bits = LongRadixBits;
 
     /// \brief Number of bits in short iterations.
+    /// \deprecated The short radix bits parameter is no longer used and will be removed in a future version.
     static constexpr unsigned int short_radix_bits = ShortRadixBits;
 
     /// \brief Number of threads in a block.

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -54,7 +54,7 @@ template<bool Descending = false,
          class SortValue,
          unsigned int ItemsPerThread,
          class Decomposer>
-ROCPRIM_DEVICE ROCPRIM_INLINE void sort_block(SortType sorter,
+ROCPRIM_DEVICE ROCPRIM_INLINE void sort_block_to_striped(SortType sorter,
                                               SortKey (&keys)[ItemsPerThread],
                                               SortValue (&values)[ItemsPerThread],
                                               typename SortType::storage_type& storage,
@@ -64,11 +64,11 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void sort_block(SortType sorter,
 {
     if ROCPRIM_IF_CONSTEXPR(Descending)
     {
-        sorter.sort_desc(keys, values, storage, begin_bit, end_bit, decomposer);
+        sorter.sort_desc_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
     else
     {
-        sorter.sort(keys, values, storage, begin_bit, end_bit, decomposer);
+        sorter.sort_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 }
 
@@ -77,7 +77,7 @@ template<bool Descending = false,
          class SortKey,
          unsigned int ItemsPerThread,
          class Decomposer>
-ROCPRIM_DEVICE ROCPRIM_INLINE void sort_block(SortType sorter,
+ROCPRIM_DEVICE ROCPRIM_INLINE void sort_block_to_striped(SortType sorter,
                                               SortKey (&keys)[ItemsPerThread],
                                               ::rocprim::empty_type (&values)[ItemsPerThread],
                                               typename SortType::storage_type& storage,
@@ -88,11 +88,11 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void sort_block(SortType sorter,
     (void) values;
     if ROCPRIM_IF_CONSTEXPR(Descending)
     {
-        sorter.sort_desc(keys, storage, begin_bit, end_bit, decomposer);
+        sorter.sort_desc_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
     else
     {
-        sorter.sort(keys, storage, begin_bit, end_bit, decomposer);
+        sorter.sort_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
 }
 
@@ -278,7 +278,7 @@ struct radix_sort_single_helper
             }
         }
 
-        sort_block<Descending>(sort_type(),
+        sort_block_to_striped<Descending>(sort_type(),
                                keys,
                                values,
                                storage.sort,
@@ -289,21 +289,21 @@ struct radix_sort_single_helper
         // Store keys and values
         if(!is_incomplete_block)
         {
-            block_store_direct_blocked(flat_id, keys_output + block_offset, keys);
+            block_store_direct_striped<BlockSize>(flat_id, keys_output + block_offset, keys);
             if ROCPRIM_IF_CONSTEXPR(with_values)
             {
-                block_store_direct_blocked(flat_id, values_output + block_offset, values);
+                block_store_direct_striped<BlockSize>(flat_id, values_output + block_offset, values);
             }
         }
         else
         {
-            block_store_direct_blocked(flat_id,
+            block_store_direct_striped<BlockSize>(flat_id,
                                        keys_output + block_offset,
                                        keys,
                                        valid_in_last_block);
             if ROCPRIM_IF_CONSTEXPR(with_values)
             {
-                block_store_direct_blocked(flat_id,
+                block_store_direct_striped<BlockSize>(flat_id,
                                            values_output + block_offset,
                                            values,
                                            valid_in_last_block);

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -62,7 +62,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void sort_block(SortType sorter,
                                               unsigned int                     begin_bit,
                                               unsigned int                     end_bit)
 {
-    if(Descending)
+    if ROCPRIM_IF_CONSTEXPR(Descending)
     {
         sorter.sort_desc(keys, values, storage, begin_bit, end_bit, decomposer);
     }
@@ -86,7 +86,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void sort_block(SortType sorter,
                                               unsigned int                     end_bit)
 {
     (void) values;
-    if(Descending)
+    if ROCPRIM_IF_CONSTEXPR(Descending)
     {
         sorter.sort_desc(keys, storage, begin_bit, end_bit, decomposer);
     }

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -54,21 +54,22 @@ template<bool Descending = false,
          class SortValue,
          unsigned int ItemsPerThread,
          class Decomposer>
-ROCPRIM_DEVICE ROCPRIM_INLINE void sort_block_to_striped(SortType sorter,
-                                              SortKey (&keys)[ItemsPerThread],
-                                              SortValue (&values)[ItemsPerThread],
-                                              typename SortType::storage_type& storage,
-                                              Decomposer                       decomposer,
-                                              unsigned int                     begin_bit,
-                                              unsigned int                     end_bit)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void sort_warp_striped_to_striped(SortType sorter,
+                                  SortKey (&keys)[ItemsPerThread],
+                                  SortValue (&values)[ItemsPerThread],
+                                  typename SortType::storage_type& storage,
+                                  Decomposer                       decomposer,
+                                  unsigned int                     begin_bit,
+                                  unsigned int                     end_bit)
 {
     if ROCPRIM_IF_CONSTEXPR(Descending)
     {
-        sorter.sort_desc_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
+        sorter.sort_desc_warp_striped_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
     else
     {
-        sorter.sort_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
+        sorter.sort_warp_striped_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
     }
 }
 
@@ -77,22 +78,23 @@ template<bool Descending = false,
          class SortKey,
          unsigned int ItemsPerThread,
          class Decomposer>
-ROCPRIM_DEVICE ROCPRIM_INLINE void sort_block_to_striped(SortType sorter,
-                                              SortKey (&keys)[ItemsPerThread],
-                                              ::rocprim::empty_type (&values)[ItemsPerThread],
-                                              typename SortType::storage_type& storage,
-                                              Decomposer                       decomposer,
-                                              unsigned int                     begin_bit,
-                                              unsigned int                     end_bit)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void sort_warp_striped_to_striped(SortType sorter,
+                                  SortKey (&keys)[ItemsPerThread],
+                                  ::rocprim::empty_type (&values)[ItemsPerThread],
+                                  typename SortType::storage_type& storage,
+                                  Decomposer                       decomposer,
+                                  unsigned int                     begin_bit,
+                                  unsigned int                     end_bit)
 {
     (void) values;
     if ROCPRIM_IF_CONSTEXPR(Descending)
     {
-        sorter.sort_desc_to_striped(keys, storage, begin_bit, end_bit, decomposer);
+        sorter.sort_desc_warp_striped_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
     else
     {
-        sorter.sort_to_striped(keys, storage, begin_bit, end_bit, decomposer);
+        sorter.sort_warp_striped_to_striped(keys, storage, begin_bit, end_bit, decomposer);
     }
 }
 
@@ -278,13 +280,13 @@ struct radix_sort_single_helper
             }
         }
 
-        sort_block_to_striped<Descending>(sort_type(),
-                               keys,
-                               values,
-                               storage.sort,
-                               decomposer,
-                               bit,
-                               bit + current_radix_bits);
+        sort_warp_striped_to_striped<Descending>(sort_type(),
+                                                 keys,
+                                                 values,
+                                                 storage.sort,
+                                                 decomposer,
+                                                 bit,
+                                                 bit + current_radix_bits);
 
         // Store keys and values
         if(!is_incomplete_block)

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -65,7 +65,12 @@ void sort_warp_striped_to_striped(SortType sorter,
 {
     if ROCPRIM_IF_CONSTEXPR(Descending)
     {
-        sorter.sort_desc_warp_striped_to_striped(keys, values, storage, begin_bit, end_bit, decomposer);
+        sorter.sort_desc_warp_striped_to_striped(keys,
+                                                 values,
+                                                 storage,
+                                                 begin_bit,
+                                                 end_bit,
+                                                 decomposer);
     }
     else
     {
@@ -294,21 +299,23 @@ struct radix_sort_single_helper
             block_store_direct_striped<BlockSize>(flat_id, keys_output + block_offset, keys);
             if ROCPRIM_IF_CONSTEXPR(with_values)
             {
-                block_store_direct_striped<BlockSize>(flat_id, values_output + block_offset, values);
+                block_store_direct_striped<BlockSize>(flat_id,
+                                                      values_output + block_offset,
+                                                      values);
             }
         }
         else
         {
             block_store_direct_striped<BlockSize>(flat_id,
-                                       keys_output + block_offset,
-                                       keys,
-                                       valid_in_last_block);
+                                                  keys_output + block_offset,
+                                                  keys,
+                                                  valid_in_last_block);
             if ROCPRIM_IF_CONSTEXPR(with_values)
             {
                 block_store_direct_striped<BlockSize>(flat_id,
-                                           values_output + block_offset,
-                                           values,
-                                           valid_in_last_block);
+                                                      values_output + block_offset,
+                                                      values,
+                                                      valid_in_last_block);
             }
         }
     }

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -157,9 +157,16 @@ struct radix_digit_count_helper
         const unsigned int flat_id = ::rocprim::detail::block_thread_id<0>();
         const unsigned int stripe  = flat_id % atomic_stripes;
 
-        for(unsigned int i = flat_id; i < counters; i += BlockSize)
+        constexpr bool block_size_divides_counters_nicely = counters % BlockSize == 0;
+
+        ROCPRIM_UNROLL
+        for(unsigned int i = 0; i < counters; i += BlockSize)
         {
-            storage.digit_counters[i] = 0;
+            const unsigned int offset = i + flat_id;
+            if(block_size_divides_counters_nicely || offset < counters)
+            {
+                storage.digit_counters[offset] = 0;
+            }
         }
 
         ::rocprim::syncthreads();

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -262,26 +262,26 @@ struct radix_sort_single_helper
         value_type values[ItemsPerThread];
         if(!is_incomplete_block)
         {
-            block_load_direct_blocked(flat_id, keys_input + block_offset, keys);
+            block_load_direct_warp_striped(flat_id, keys_input + block_offset, keys);
             if ROCPRIM_IF_CONSTEXPR(with_values)
             {
-                block_load_direct_blocked(flat_id, values_input + block_offset, values);
+                block_load_direct_warp_striped(flat_id, values_input + block_offset, values);
             }
         }
         else
         {
             const key_type out_of_bounds = key_codec::get_out_of_bounds_key(decomposer);
-            block_load_direct_blocked(flat_id,
-                                      keys_input + block_offset,
-                                      keys,
-                                      valid_in_last_block,
-                                      out_of_bounds);
+            block_load_direct_warp_striped(flat_id,
+                                           keys_input + block_offset,
+                                           keys,
+                                           valid_in_last_block,
+                                           out_of_bounds);
             if ROCPRIM_IF_CONSTEXPR(with_values)
             {
-                block_load_direct_blocked(flat_id,
-                                          values_input + block_offset,
-                                          values,
-                                          valid_in_last_block);
+                block_load_direct_warp_striped(flat_id,
+                                               values_input + block_offset,
+                                               values,
+                                               valid_in_last_block);
             }
         }
 

--- a/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
@@ -724,6 +724,13 @@ void segmented_sort(KeysInputIterator keys_input,
         value_type,
         block_size,
         Descending>;
+    // using warp_sort_helper_type = segmented_radix_sort_single_block_helper<
+    //     key_type, value_type,
+    //     params.warp_sort_config.logical_warp_size_small, params.warp_sort_config.items_per_thread_small,
+    //     Descending
+    // >;
+
+    // static constexpr unsigned int items_per_warp = params.warp_sort_config.logical_warp_size_small * params.warp_sort_config.items_per_thread_small;
     static constexpr unsigned int items_per_warp = warp_sort_helper_type::items_per_warp;
 
     ROCPRIM_SHARED_MEMORY union

--- a/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
@@ -407,13 +407,13 @@ public:
         }
 
         ::rocprim::syncthreads();
-        sort_block_to_striped<Descending>(sort_type(),
-                                          keys,
-                                          values,
-                                          storage.sort,
-                                          identity_decomposer{},
-                                          begin_bit,
-                                          end_bit);
+        sort_warp_striped_to_striped<Descending>(sort_type(),
+                                                 keys,
+                                                 values,
+                                                 storage.sort,
+                                                 identity_decomposer{},
+                                                 begin_bit,
+                                                 end_bit);
 
         ::rocprim::syncthreads();
         block_store_direct_striped<BlockSize>(flat_id, keys_output + begin_offset, keys, valid_count);

--- a/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
@@ -36,8 +36,8 @@
 #include "../../block/block_store.hpp"
 #include "../../block/block_scan.hpp"
 
-#include "../../warp/warp_load.hpp"
 #include "../../warp/detail/warp_sort_stable.hpp"
+#include "../../warp/warp_load.hpp"
 #include "../../warp/warp_store.hpp"
 
 #include "../../thread/radix_key_codec.hpp"
@@ -76,7 +76,7 @@ public:
 
     union storage_type
     {
-        typename count_helper_type::storage_type count_helper;
+        typename count_helper_type::storage_type       count_helper;
         typename sort_and_scatter_helper::storage_type sort_and_scatter_helper;
     };
 
@@ -274,9 +274,16 @@ template<
 >
 class segmented_radix_sort_single_block_helper
 {
-    using key_codec = radix_key_codec<Key, Descending>;
+    using key_codec    = radix_key_codec<Key, Descending>;
     using bit_key_type = typename key_codec::bit_key_type;
-    using sort_type = ::rocprim::block_radix_sort<Key, BlockSize, ItemsPerThread, Value, 1, 1, 8, block_radix_rank_algorithm::match>;
+    using sort_type    = ::rocprim::block_radix_sort<Key,
+                                                  BlockSize,
+                                                  ItemsPerThread,
+                                                  Value,
+                                                  1,
+                                                  1,
+                                                  8,
+                                                  block_radix_rank_algorithm::match>;
 
     static constexpr bool with_values = !std::is_same<Value, ::rocprim::empty_type>::value;
 
@@ -287,25 +294,23 @@ public:
         typename sort_type::storage_type sort;
     };
 
-    template<
-        class KeysInputIterator,
-        class KeysOutputIterator,
-        class ValuesInputIterator,
-        class ValuesOutputIterator
-    >
+    template<class KeysInputIterator,
+             class KeysOutputIterator,
+             class ValuesInputIterator,
+             class ValuesOutputIterator>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    void sort(KeysInputIterator keys_input,
-              Key* keys_tmp,
-              KeysOutputIterator keys_output,
-              ValuesInputIterator values_input,
-              Value* values_tmp,
+    void sort(KeysInputIterator    keys_input,
+              Key*                 keys_tmp,
+              KeysOutputIterator   keys_output,
+              ValuesInputIterator  values_input,
+              Value*               values_tmp,
               ValuesOutputIterator values_output,
-              bool to_output,
-              unsigned int begin_offset,
-              unsigned int end_offset,
-              unsigned int begin_bit,
-              unsigned int end_bit,
-              storage_type& storage)
+              bool                 to_output,
+              unsigned int         begin_offset,
+              unsigned int         end_offset,
+              unsigned int         begin_bit,
+              unsigned int         end_bit,
+              storage_type&        storage)
     {
         if(to_output)
         {
@@ -329,17 +334,17 @@ public:
 
     // When all iterators are raw pointers, this overload is used to minimize code duplication in the kernel
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    void sort(Key* keys_input,
-              Key* keys_tmp,
-              Key* keys_output,
-              Value* values_input,
-              Value* values_tmp,
-              Value* values_output,
-              bool to_output,
-              unsigned int begin_offset,
-              unsigned int end_offset,
-              unsigned int begin_bit,
-              unsigned int end_bit,
+    void sort(Key*          keys_input,
+              Key*          keys_tmp,
+              Key*          keys_output,
+              Value*        values_input,
+              Value*        values_tmp,
+              Value*        values_output,
+              bool          to_output,
+              unsigned int  begin_offset,
+              unsigned int  end_offset,
+              unsigned int  begin_bit,
+              unsigned int  end_bit,
               storage_type& storage)
     {
         sort(
@@ -369,10 +374,12 @@ public:
     {
         constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
-        using shorter_single_block_helper = segmented_radix_sort_single_block_helper<
-            Key, Value,
-            BlockSize, ItemsPerThread / 2, Descending
-        >;
+        using shorter_single_block_helper
+            = segmented_radix_sort_single_block_helper<Key,
+                                                       Value,
+                                                       BlockSize,
+                                                       ItemsPerThread / 2,
+                                                       Descending>;
 
         // Segment is longer than supported by this function
         if(end_offset - begin_offset > items_per_block)
@@ -395,15 +402,22 @@ public:
 
         const unsigned int flat_id = ::rocprim::flat_block_thread_id();
 
-        Key keys[ItemsPerThread];
-        Value values[ItemsPerThread];
+        Key                keys[ItemsPerThread];
+        Value              values[ItemsPerThread];
         const unsigned int valid_count = end_offset - begin_offset;
         // Sort will leave "invalid" (out of size) items at the end of the sorted sequence
         const Key out_of_bounds = key_codec::get_out_of_bounds_key();
-        block_load_direct_warp_striped(flat_id, keys_input + begin_offset, keys, valid_count, out_of_bounds);
+        block_load_direct_warp_striped(flat_id,
+                                       keys_input + begin_offset,
+                                       keys,
+                                       valid_count,
+                                       out_of_bounds);
         if(with_values)
         {
-            block_load_direct_warp_striped(flat_id, values_input + begin_offset, values, valid_count);
+            block_load_direct_warp_striped(flat_id,
+                                           values_input + begin_offset,
+                                           values,
+                                           valid_count);
         }
 
         ::rocprim::syncthreads();
@@ -416,10 +430,16 @@ public:
                                                  end_bit);
 
         ::rocprim::syncthreads();
-        block_store_direct_striped<BlockSize>(flat_id, keys_output + begin_offset, keys, valid_count);
+        block_store_direct_striped<BlockSize>(flat_id,
+                                              keys_output + begin_offset,
+                                              keys,
+                                              valid_count);
         if ROCPRIM_IF_CONSTEXPR(with_values)
         {
-            block_store_direct_striped<BlockSize>(flat_id, values_output + begin_offset, values, valid_count);
+            block_store_direct_striped<BlockSize>(flat_id,
+                                                  values_output + begin_offset,
+                                                  values,
+                                                  valid_count);
         }
 
         return true;
@@ -485,14 +505,7 @@ using select_warp_sort_helper_config_t
                          WarpSortHelperConfig<logical_warp_size, items_per_thread, block_size>,
                          DisabledWarpSortHelperConfig>;
 
-template<
-    class Config,
-    class Key,
-    class Value,
-    int BlockSize,
-    bool Descending,
-    class Enable = void
->
+template<class Config, class Key, class Value, int BlockSize, bool Descending, class Enable = void>
 struct segmented_warp_sort_helper
 {
     static constexpr unsigned int items_per_warp = 0;
@@ -520,13 +533,15 @@ class segmented_warp_sort_helper<
     using key_codec    = ::rocprim::radix_key_codec<Key, Descending>;
     using bit_key_type = typename key_codec::bit_key_type;
 
-    using keys_load_type        = ::rocprim::warp_load<Key, items_per_thread, logical_warp_size>;
-    using values_load_type      = ::rocprim::warp_load<Value, items_per_thread, logical_warp_size>;
-    using keys_store_type       = ::rocprim::warp_store<Key, items_per_thread, logical_warp_size>;
-    using values_store_type     = ::rocprim::warp_store<Value, items_per_thread, logical_warp_size>;
+    using keys_load_type    = ::rocprim::warp_load<Key, items_per_thread, logical_warp_size>;
+    using values_load_type  = ::rocprim::warp_load<Value, items_per_thread, logical_warp_size>;
+    using keys_store_type   = ::rocprim::warp_store<Key, items_per_thread, logical_warp_size>;
+    using values_store_type = ::rocprim::warp_store<Value, items_per_thread, logical_warp_size>;
     template<bool UseRadixMask>
-    using radix_comparator_type = ::rocprim::detail::radix_merge_compare<Descending, UseRadixMask, Key>;
-    using sort_type             = ::rocprim::detail::warp_sort_stable<Key, BlockSize, logical_warp_size, items_per_thread, Value>;
+    using radix_comparator_type
+        = ::rocprim::detail::radix_merge_compare<Descending, UseRadixMask, Key>;
+    using sort_type = ::rocprim::detail::
+        warp_sort_stable<Key, BlockSize, logical_warp_size, items_per_thread, Value>;
 
     static constexpr bool with_values = !std::is_same<Value, ::rocprim::empty_type>::value;
 
@@ -567,12 +582,12 @@ private:
     }
 
     template<class K = Key>
-    ROCPRIM_DEVICE auto invoke_warp_sort(Key (&keys)[items_per_thread],
-                                         Value (&values)[items_per_thread],
-                                         storage_type& storage,
-                                         unsigned int  begin_bit,
-                                         unsigned int  end_bit)
-        -> std::enable_if_t<!is_integral<K>::value>
+    ROCPRIM_DEVICE
+    auto invoke_warp_sort(Key (&keys)[items_per_thread],
+                          Value (&values)[items_per_thread],
+                          storage_type& storage,
+                          unsigned int  begin_bit,
+                          unsigned int  end_bit) -> std::enable_if_t<!is_integral<K>::value>
     {
         (void)begin_bit;
         (void)end_bit;
@@ -580,12 +595,12 @@ private:
     }
 
     template<class K = Key>
-    ROCPRIM_DEVICE auto invoke_warp_sort(Key (&keys)[items_per_thread],
-                                         Value (&values)[items_per_thread],
-                                         storage_type& storage,
-                                         unsigned int  begin_bit,
-                                         unsigned int  end_bit)
-        -> std::enable_if_t<is_integral<K>::value>
+    ROCPRIM_DEVICE
+    auto invoke_warp_sort(Key (&keys)[items_per_thread],
+                          Value (&values)[items_per_thread],
+                          storage_type& storage,
+                          unsigned int  begin_bit,
+                          unsigned int  end_bit) -> std::enable_if_t<is_integral<K>::value>
     {
         if(begin_bit == 0 && end_bit == 8 * sizeof(Key))
         {
@@ -617,9 +632,9 @@ public:
               storage_type& storage)
     {
         const unsigned int num_items = end_offset - begin_offset;
-        const Key out_of_bounds = key_codec::get_out_of_bounds_key();
+        const Key          out_of_bounds = key_codec::get_out_of_bounds_key();
 
-        Key keys[items_per_thread];
+        Key   keys[items_per_thread];
         Value values[items_per_thread];
         keys_load_type().load(keys_input + begin_offset, keys, num_items, out_of_bounds, storage.keys_load);
 
@@ -642,25 +657,23 @@ public:
         }
     }
 
-    template<
-        class KeysInputIterator,
-        class KeysOutputIterator,
-        class ValuesInputIterator,
-        class ValuesOutputIterator
-    >
+    template<class KeysInputIterator,
+             class KeysOutputIterator,
+             class ValuesInputIterator,
+             class ValuesOutputIterator>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    void sort(KeysInputIterator keys_input,
-              Key* keys_tmp,
-              KeysOutputIterator keys_output,
-              ValuesInputIterator values_input,
-              Value* values_tmp,
+    void sort(KeysInputIterator    keys_input,
+              Key*                 keys_tmp,
+              KeysOutputIterator   keys_output,
+              ValuesInputIterator  values_input,
+              Value*               values_tmp,
               ValuesOutputIterator values_output,
-              bool to_output,
-              unsigned int begin_offset,
-              unsigned int end_offset,
-              unsigned int begin_bit,
-              unsigned int end_bit,
-              storage_type& storage)
+              bool                 to_output,
+              unsigned int         begin_offset,
+              unsigned int         end_offset,
+              unsigned int         begin_bit,
+              unsigned int         end_bit,
+              storage_type&        storage)
     {
         if(to_output)
         {
@@ -722,12 +735,14 @@ void segmented_sort(KeysInputIterator keys_input,
         block_size, items_per_thread,
         Descending
     >;
-    using long_radix_helper_type = segmented_radix_sort_helper<
-        key_type, value_type,
-        ::rocprim::device_warp_size(), block_size, items_per_thread,
-        long_radix_bits, Descending
-    >;
-    using warp_sort_helper_type = segmented_warp_sort_helper<
+    using long_radix_helper_type = segmented_radix_sort_helper<key_type,
+                                                               value_type,
+                                                               ::rocprim::device_warp_size(),
+                                                               block_size,
+                                                               items_per_thread,
+                                                               long_radix_bits,
+                                                               Descending>;
+    using warp_sort_helper_type  = segmented_warp_sort_helper<
         select_warp_sort_helper_config_t<params.warp_sort_config.partitioning_allowed,
                                          params.warp_sort_config.logical_warp_size_small,
                                          params.warp_sort_config.items_per_thread_small,
@@ -742,7 +757,7 @@ void segmented_sort(KeysInputIterator keys_input,
     ROCPRIM_SHARED_MEMORY union
     {
         typename single_block_helper_type::storage_type single_block_helper;
-        typename long_radix_helper_type::storage_type long_radix_helper;
+        typename long_radix_helper_type::storage_type   long_radix_helper;
         typename warp_sort_helper_type::storage_type warp_sort_helper;
     } storage;
 
@@ -760,7 +775,7 @@ void segmented_sort(KeysInputIterator keys_input,
     if(end_offset - begin_offset > items_per_block)
     {
         // Large segment
-        for (unsigned int bit = begin_bit; bit < end_bit; bit += long_radix_bits)
+        for(unsigned int bit = begin_bit; bit < end_bit; bit += long_radix_bits)
         {
             long_radix_helper_type().sort(
                 keys_input, keys_tmp, keys_output, values_input, values_tmp, values_output,
@@ -776,24 +791,34 @@ void segmented_sort(KeysInputIterator keys_input,
     else if(!warp_sort_enabled || end_offset - begin_offset > items_per_warp)
     {
         // Small segment
-        single_block_helper_type().sort(
-            keys_input, keys_tmp, keys_output, values_input, values_tmp, values_output,
-            (iterations % 2 == 0) != to_output,
-            begin_offset, end_offset,
-            begin_bit, end_bit,
-            storage.single_block_helper
-        );
+        single_block_helper_type().sort(keys_input,
+                                        keys_tmp,
+                                        keys_output,
+                                        values_input,
+                                        values_tmp,
+                                        values_output,
+                                        (iterations % 2 == 0) != to_output,
+                                        begin_offset,
+                                        end_offset,
+                                        begin_bit,
+                                        end_bit,
+                                        storage.single_block_helper);
     }
     else if(::rocprim::flat_block_thread_id() < params.warp_sort_config.logical_warp_size_small)
     {
         // Single warp segment
-        warp_sort_helper_type().sort(
-            keys_input, keys_tmp, keys_output,
-            values_input, values_tmp, values_output,
-            (iterations % 2 == 0) != to_output,
-            begin_offset, end_offset,
-            begin_bit, end_bit, storage.warp_sort_helper
-        );
+        warp_sort_helper_type().sort(keys_input,
+                                     keys_tmp,
+                                     keys_output,
+                                     values_input,
+                                     values_tmp,
+                                     values_output,
+                                     (iterations % 2 == 0) != to_output,
+                                     begin_offset,
+                                     end_offset,
+                                     begin_bit,
+                                     end_bit,
+                                     storage.warp_sort_helper);
     }
 }
 
@@ -837,16 +862,18 @@ void segmented_sort_large(KeysInputIterator keys_input,
         block_size, items_per_thread,
         Descending
     >;
-    using long_radix_helper_type = segmented_radix_sort_helper<
-        key_type, value_type,
-        ::rocprim::device_warp_size(), block_size, items_per_thread,
-        long_radix_bits, Descending
-    >;
+    using long_radix_helper_type = segmented_radix_sort_helper<key_type,
+                                                               value_type,
+                                                               ::rocprim::device_warp_size(),
+                                                               block_size,
+                                                               items_per_thread,
+                                                               long_radix_bits,
+                                                               Descending>;
 
     ROCPRIM_SHARED_MEMORY union
     {
         typename single_block_helper_type::storage_type single_block_helper;
-        typename long_radix_helper_type::storage_type long_radix_helper;
+        typename long_radix_helper_type::storage_type   long_radix_helper;
     } storage;
 
     const unsigned int block_id = ::rocprim::detail::block_id<0>();
@@ -861,7 +888,7 @@ void segmented_sort_large(KeysInputIterator keys_input,
 
     if(end_offset - begin_offset > items_per_block)
     {
-        for (unsigned int bit = begin_bit; bit < end_bit; bit += long_radix_bits)
+        for(unsigned int bit = begin_bit; bit < end_bit; bit += long_radix_bits)
         {
             long_radix_helper_type().sort(
                 keys_input, keys_tmp, keys_output, values_input, values_tmp, values_output,
@@ -876,13 +903,18 @@ void segmented_sort_large(KeysInputIterator keys_input,
     }
     else
     {
-        single_block_helper_type().sort(
-            keys_input, keys_tmp, keys_output, values_input, values_tmp, values_output,
-            (iterations % 2 == 0) != to_output,
-            begin_offset, end_offset,
-            begin_bit, end_bit,
-            storage.single_block_helper
-        );
+        single_block_helper_type().sort(keys_input,
+                                        keys_tmp,
+                                        keys_output,
+                                        values_input,
+                                        values_tmp,
+                                        values_output,
+                                        (iterations % 2 == 0) != to_output,
+                                        begin_offset,
+                                        end_offset,
+                                        begin_bit,
+                                        end_bit,
+                                        storage.single_block_helper);
     }
 }
 

--- a/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
@@ -69,8 +69,7 @@ ROCPRIM_KERNEL
         bool                                                            to_output,
         OffsetIterator                                                  begin_offsets,
         OffsetIterator                                                  end_offsets,
-        unsigned int                                                    long_iterations,
-        unsigned int                                                    short_iterations,
+        unsigned int                                                    iterations,
         unsigned int                                                    begin_bit,
         unsigned int                                                    end_bit)
 {
@@ -78,7 +77,7 @@ ROCPRIM_KERNEL
         keys_input, keys_tmp, keys_output, values_input, values_tmp, values_output,
         to_output,
         begin_offsets, end_offsets,
-        long_iterations, short_iterations,
+        iterations,
         begin_bit, end_bit
     );
 }
@@ -107,8 +106,7 @@ ROCPRIM_KERNEL __launch_bounds__(
                                                       SegmentIndexIterator segment_indices,
                                                       OffsetIterator       begin_offsets,
                                                       OffsetIterator       end_offsets,
-                                                      unsigned int         long_iterations,
-                                                      unsigned int         short_iterations,
+                                                      unsigned int         iterations,
                                                       unsigned int         begin_bit,
                                                       unsigned int         end_bit)
 {
@@ -116,7 +114,7 @@ ROCPRIM_KERNEL __launch_bounds__(
         keys_input, keys_tmp, keys_output, values_input, values_tmp, values_output,
         to_output, segment_indices,
         begin_offsets, end_offsets,
-        long_iterations, short_iterations,
+        iterations,
         begin_bit, end_bit
     );
 }
@@ -363,13 +361,6 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
     const unsigned int iterations = ::rocprim::detail::ceiling_div(bits, params.long_radix_bits);
     const bool to_output = with_double_buffer || (iterations - 1) % 2 == 0;
     is_result_in_output = (iterations % 2 == 0) != to_output;
-    const unsigned int radix_bits_diff = params.long_radix_bits - params.short_radix_bits;
-    const unsigned int short_iterations
-        = radix_bits_diff != 0
-              ? ::rocprim::min(iterations,
-                               (params.long_radix_bits * iterations - bits) / radix_bits_diff)
-              : 0;
-    const unsigned int long_iterations = iterations - short_iterations;
     const bool         do_partitioning
         = partitioning_allowed && segments >= params.warp_sort_config.partitioning_threshold;
 
@@ -443,11 +434,8 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
         std::cout << "end_bit " << end_bit << '\n';
         std::cout << "bits " << bits << '\n';
         std::cout << "segments " << segments << '\n';
-        std::cout << "radix_bits_diff " << radix_bits_diff << '\n';
         std::cout << "storage_size " << storage_size << '\n';
         std::cout << "iterations " << iterations << '\n';
-        std::cout << "long_iterations " << long_iterations << '\n';
-        std::cout << "short_iterations " << short_iterations << '\n';
         std::cout << "do_partitioning " << do_partitioning << '\n';
         std::cout << "params.kernel_config.block_size: " << params.kernel_config.block_size << '\n';
         std::cout << "params.kernel_config.items_per_thread: "
@@ -523,8 +511,7 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
                                large_segment_indices_output,
                                begin_offsets,
                                end_offsets,
-                               long_iterations,
-                               short_iterations,
+                               iterations,
                                begin_bit,
                                end_bit);
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_sort:large_segments",
@@ -607,8 +594,7 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
                            to_output,
                            begin_offsets,
                            end_offsets,
-                           long_iterations,
-                           short_iterations,
+                           iterations,
                            begin_bit,
                            end_bit);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_sort", segments, start)

--- a/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
@@ -59,27 +59,33 @@ template<class Config,
          class ValuesOutputIterator,
          class OffsetIterator>
 ROCPRIM_KERNEL
-    __launch_bounds__(device_params<Config>().kernel_config.block_size) void segmented_sort_kernel(
-        KeysInputIterator                                               keys_input,
-        typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
-        KeysOutputIterator                                              keys_output,
-        ValuesInputIterator                                             values_input,
-        typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
-        ValuesOutputIterator                                            values_output,
-        bool                                                            to_output,
-        OffsetIterator                                                  begin_offsets,
-        OffsetIterator                                                  end_offsets,
-        unsigned int                                                    iterations,
-        unsigned int                                                    begin_bit,
-        unsigned int                                                    end_bit)
+    __launch_bounds__(device_params<Config>().kernel_config.block_size)
+void segmented_sort_kernel(
+    KeysInputIterator                                               keys_input,
+    typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
+    KeysOutputIterator                                              keys_output,
+    ValuesInputIterator                                             values_input,
+    typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
+    ValuesOutputIterator                                            values_output,
+    bool                                                            to_output,
+    OffsetIterator                                                  begin_offsets,
+    OffsetIterator                                                  end_offsets,
+    unsigned int                                                    iterations,
+    unsigned int                                                    begin_bit,
+    unsigned int                                                    end_bit)
 {
-    segmented_sort<Config, Descending>(
-        keys_input, keys_tmp, keys_output, values_input, values_tmp, values_output,
-        to_output,
-        begin_offsets, end_offsets,
-        iterations,
-        begin_bit, end_bit
-    );
+    segmented_sort<Config, Descending>(keys_input,
+                                       keys_tmp,
+                                       keys_output,
+                                       values_input,
+                                       values_tmp,
+                                       values_output,
+                                       to_output,
+                                       begin_offsets,
+                                       end_offsets,
+                                       iterations,
+                                       begin_bit,
+                                       end_bit);
 }
 
 template<class Config,
@@ -93,30 +99,35 @@ template<class Config,
 ROCPRIM_KERNEL __launch_bounds__(
     device_params<Config>()
         .kernel_config
-        .block_size) void segmented_sort_large_kernel(KeysInputIterator keys_input,
-                                                      typename std::iterator_traits<
-                                                          KeysInputIterator>::value_type* keys_tmp,
-                                                      KeysOutputIterator  keys_output,
-                                                      ValuesInputIterator values_input,
-                                                      typename std::iterator_traits<
-                                                          ValuesInputIterator>::value_type*
-                                                                           values_tmp,
-                                                      ValuesOutputIterator values_output,
-                                                      bool                 to_output,
-                                                      SegmentIndexIterator segment_indices,
-                                                      OffsetIterator       begin_offsets,
-                                                      OffsetIterator       end_offsets,
-                                                      unsigned int         iterations,
-                                                      unsigned int         begin_bit,
-                                                      unsigned int         end_bit)
+        .block_size)
+void segmented_sort_large_kernel(
+    KeysInputIterator                                               keys_input,
+    typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
+    KeysOutputIterator                                              keys_output,
+    ValuesInputIterator                                             values_input,
+    typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
+    ValuesOutputIterator                                            values_output,
+    bool                                                            to_output,
+    SegmentIndexIterator                                            segment_indices,
+    OffsetIterator                                                  begin_offsets,
+    OffsetIterator                                                  end_offsets,
+    unsigned int                                                    iterations,
+    unsigned int                                                    begin_bit,
+    unsigned int                                                    end_bit)
 {
-    segmented_sort_large<Config, Descending>(
-        keys_input, keys_tmp, keys_output, values_input, values_tmp, values_output,
-        to_output, segment_indices,
-        begin_offsets, end_offsets,
-        iterations,
-        begin_bit, end_bit
-    );
+    segmented_sort_large<Config, Descending>(keys_input,
+                                             keys_tmp,
+                                             keys_output,
+                                             values_input,
+                                             values_tmp,
+                                             values_output,
+                                             to_output,
+                                             segment_indices,
+                                             begin_offsets,
+                                             end_offsets,
+                                             iterations,
+                                             begin_bit,
+                                             end_bit);
 }
 
 template<class Config,
@@ -360,7 +371,7 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
     const unsigned int bits = end_bit - begin_bit;
     const unsigned int iterations = ::rocprim::detail::ceiling_div(bits, params.long_radix_bits);
     const bool to_output = with_double_buffer || (iterations - 1) % 2 == 0;
-    is_result_in_output = (iterations % 2 == 0) != to_output;
+    is_result_in_output           = (iterations % 2 == 0) != to_output;
     const bool         do_partitioning
         = partitioning_allowed && segments >= params.warp_sort_config.partitioning_threshold;
 

--- a/rocprim/include/rocprim/rocprim.hpp
+++ b/rocprim/include/rocprim/rocprim.hpp
@@ -57,6 +57,7 @@
 #include "block/block_scan.hpp"
 #include "block/block_sort.hpp"
 #include "block/block_store.hpp"
+#include "block/config.hpp"
 
 #include "device/device_adjacent_difference.hpp"
 #include "device/device_binary_search.hpp"

--- a/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
@@ -30,6 +30,8 @@
 #include "../../functional.hpp"
 #include "../../intrinsics.hpp"
 
+#include "../../detail/merge_path.hpp"
+
 BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail

--- a/scripts/autotune-search/.gitignore
+++ b/scripts/autotune-search/.gitignore
@@ -1,0 +1,1 @@
+artifacts

--- a/scripts/autotune-search/main.py
+++ b/scripts/autotune-search/main.py
@@ -57,6 +57,9 @@ parameter_spaces = {
             ],
             "ValueType": [
                 "int64_t",
+                "int",
+                "short",
+                "int8_t",
             ],
         },
         "params": {

--- a/scripts/autotune-search/main.py
+++ b/scripts/autotune-search/main.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+
+from typing import Union, List
+import argparse
+import glob
+import itertools
+import json
+import logging
+import multiprocessing as mp
+import os
+import pathos.multiprocessing as pamp
+import rich.logging
+import rich.progress
+import scipy.optimize
+import shutil
+import subprocess
+
+parameter_spaces = {
+    "device_segmented_radix_sort_keys": {
+        "benchmark": "benchmark_device_segmented_radix_sort_keys",
+        "types": {
+            "KeyType": [
+                "int64_t",
+                "int",
+                "short",
+                "int8_t",
+                "double",
+                "float",
+                "rocprim::half",
+            ],
+        },
+        "params": {
+            "LongBits": [7, 8],
+            "ShortBits": [4, 5, 6],
+            "BlockSize": [256],
+            "ItemsPerThread": [7, 8, 13, 16, 17],
+            "WarpSmallLWS": [8, 16, 32],
+            "WarpSmallIPT": [4, 8],
+            "WarpSmallBS": [256],
+            "WarpPartition": [4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096],
+            "WarpMediumLWS": [16, 32],
+            "WarpMediumIPT": [4, 16],
+            "WarpMediumBS": [256],
+        },
+    },
+    "device_segmented_radix_sort_pairs": {
+        "benchmark": "benchmark_device_segmented_radix_sort_pairs",
+        "types": {
+            "KeyType": [
+                "int64_t",
+                "int",
+                "short",
+                "int8_t",
+                "double",
+                "float",
+                "rocprim::half",
+            ],
+            "ValueType": [
+                "int64_t",
+            ],
+        },
+        "params": {
+            "LongBits": [7, 8],
+            "ShortBits": [4, 5, 6],
+            "BlockSize": [256],
+            "ItemsPerThread": [7, 8, 13, 16, 17],
+            "WarpSmallLWS": [8, 16, 32],
+            "WarpSmallIPT": [4, 8],
+            "WarpSmallBS": [256],
+            "WarpPartition": [4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096],
+            "WarpMediumLWS": [16, 32],
+            "WarpMediumIPT": [4, 16],
+            "WarpMediumBS": [256],
+        },
+    },
+}
+
+def get_result_from_json(filename: os.PathLike) -> Union[float, int]:
+    '''
+    Get the result from the benchmark json.
+    '''
+    with open(filename, 'r') as file:
+        data = json.load(file)
+        try:
+            return float(data['benchmarks'][0]['bytes_per_second'])
+        except Exception as e:
+            log.error('Could not extract \'bytes_per_second\' from JSON!')
+            raise e
+
+def merge_jsons(source_filenames: List[os.PathLike], target_filename: os.PathLike) -> None:
+    '''
+    Merges benchmark JSONs. This is used to collect the singular results generated from the various
+    benchmark runs.
+    '''
+    merged = {
+        'context': {},
+        'benchmarks': [],
+    }
+
+    # collect jsons
+    for filename in source_filenames:
+        with open(filename, 'r') as file:
+            try:
+                data = json.load(file)
+            except json.decoder.JSONDecodeError as e:
+                log.warning(f'Skipping file \'{filename}\' because of error: {e}')
+
+            # HACK: we reuse the last context since we can only have one
+            merged['context'] = data['context']
+            # append benchmark data
+            merged['benchmarks'].extend(data['benchmarks'])
+
+    # write out file
+    with open(target_filename, 'w') as file:
+        json.dump(merged, file, indent=2)
+
+def combine(alg_name: str, arch: str):
+    '''
+    combine()
+    '''
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    result_dir = os.path.join(script_dir, 'artifacts')
+
+    alg_space = parameter_spaces[alg_name]
+    build_target = alg_space['benchmark']
+
+    merge_jsons(
+        glob.glob(os.path.join(result_dir, f'{arch}_{build_target}_*.json')),
+        os.path.join(result_dir, f'{arch}_{build_target}.json'),
+    )
+
+def tune_alg(alg_name: str, arch: str, max_samples: int, num_workers: int, size: int, trials: int) -> None:
+    '''
+    The core tuning procedure. This tunes a single algorithm for multiple types.
+    '''
+
+    # get the context of the tuning run
+    alg_space = parameter_spaces[alg_name]
+    build_target = alg_space['benchmark']
+
+    # types to tune, this can be a product of multiple types
+    types = [
+        dict(zip(alg_space['types'], ts))
+        for ts in itertools.product(
+            *[alg_space['types'][type] for type in alg_space['types']]
+        )
+    ]
+
+    # generate bounds by normalizing the parameter space from discrete to real numbers (relaxation)
+    bounds = dict(zip(alg_space['params'], ((0, 1) for _ in alg_space['params'])))
+
+    # define a utility function to access parameters in 'alg_space'
+    def param_from_normalized(name: str, value: float) -> str:
+        '''
+        Internal which maps a continious named parameter in [0; 1] to it's discrete value.
+        '''
+
+        # get the list of discrete values
+        params = alg_space['params'][name]
+
+        # get the index, make sure we're not out-of-bounds when value is 1.0
+        index = min(int(value * len(params)), len(params) - 1)
+
+        try:
+            return str(params[index])
+        except IndexError as e:
+            log.error(
+                f"Could not find parameter '{name}' at '{index}' derived from value '{value}' in {params}."
+            )
+            raise e
+
+    def tune_type(type: str) -> None:
+        cache = {}
+
+        def sample(xs: List[float]) -> Union[float, int]:
+            # each worker should get their own build dir
+            build_dir = os.path.join(source_dir, f'build/tune-{worker_id}')
+
+            # delete *.parallel folder
+            try:
+                # HACK: we just delete the benchmark folder because it's easier
+                shutil.rmtree(os.path.join(build_dir, 'benchmark'))
+            except FileNotFoundError:
+                # if the tree doesn't exist we don't have to remove it :)
+                pass
+
+            tune_param_names = list(type.keys()) + list(alg_space['params'])
+            tune_param_vals = list(type.values()) + [
+                param_from_normalized(name, value)
+                for (name, value) in zip(alg_space['params'].keys(), xs)
+            ]
+
+            result_id = '_'.join(tune_param_vals)
+            if result_id in cache:
+                log.info(f'[{worker_id}] Skipped already computed result!')
+                return cache[result_id]
+
+            result_filename = f'{arch}_{build_target}_{result_id}.json'
+
+            tune_param_names = ';'.join(tune_param_names)
+            tune_param_vals = ';'.join(tune_param_vals)
+
+            # CMake configure
+            log.info(f'[{worker_id}] Configuring: {result_id}')
+            configure = subprocess.call(
+                [
+                    'cmake',
+                    '-S',
+                    '.',
+                    '-B',
+                    build_dir,
+                    '-GNinja',
+                    '-DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++',
+                    '-DBUILD_BENCHMARK=ON',
+                    '-DBENCHMARK_CONFIG_TUNING=ON',
+                    f'-DAMDGPU_TARGETS={arch}',
+                    f'-DBENCHMARK_TUNE_PARAM_NAMES={tune_param_names}',
+                    f'-DBENCHMARK_TUNE_PARAMS={tune_param_vals}',
+                ],
+                cwd=source_dir,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+            if configure != 0:
+                cache[result_id] = 0.0
+                return 0.0
+
+            # Build target
+            log.info(f'[{worker_id}] Building: {result_id}')
+            build = subprocess.call(
+                ['cmake', '--build', '.', '--target', build_target],
+                cwd=build_dir,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+            if build != 0:
+                cache[result_id] = 0.0
+                result_context = {
+                    'config': dict(
+                        (
+                            (name, param_from_normalized(name, val))
+                            for name, val in zip(alg_space['params'], xs)
+                        )
+                    )
+                }
+                log.debug(json.dumps(result_context, indent=2))
+                return 0.0
+
+            # Run benchmark
+            gpu_lock.acquire()
+            try:
+                log.info(f'[{worker_id}] Benchmarking: {result_id}')
+                bench = subprocess.call(
+                    [
+                        os.path.join(build_dir, 'benchmark', build_target),
+                        '--name_format',
+                        'json',
+                        '--seed',
+                        'random',  # Random is better... I think? Otherwise we might overfit.
+                        '--size',
+                        f'{size}',
+                        '--trials',
+                        f'{trials}',  # 8 seems to be a fair balance between benchmarking and compile time. Needs verification though.
+                        '--benchmark_out_format=json',
+                        f'--benchmark_out={result_filename}',
+                    ],
+                    cwd=result_dir,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=120,
+                )
+
+                if bench != 0:
+                    cache[result_id] = 0.0
+                    return 0.0
+                result_value = get_result_from_json(
+                    os.path.join(result_dir, result_filename)
+                )
+                log.info(f'[{worker_id}] Completed: {result_id} @ {result_value / 1e9:.3f} GB/s')
+            finally:
+                gpu_lock.release()
+
+            result_context = {
+                'config': dict(
+                    (
+                        (name, param_from_normalized(name, val))
+                        for name, val in zip(alg_space['params'], xs)
+                    )
+                ),
+                'bytes_per_second': result_value,
+            }
+            log.debug(json.dumps(result_context, indent=2))
+
+            cache[result_id] = -result_value
+
+            # scipy.optimize does minimization, negate result for maximize
+            return -result_value
+
+        # Dual annealing is very good for tuning. See:
+        # - 'Benchmarking optimization algorithms for auto-tuning GPU kernels' by Schoonhoven et al, 2022.
+        # - 'A methodology for comparing optimization algorithms for auto-tuning' by Willemsen et al, 2024.
+        scipy.optimize.dual_annealing(
+            sample, bounds=bounds.values(), maxfun=max_samples
+        )
+
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    source_dir = os.path.join(script_dir, '../..')
+    result_dir = os.path.join(script_dir, 'artifacts')
+
+    os.makedirs(result_dir, exist_ok=True)
+
+    def pool_init(worker_ids, lock):
+        global worker_id, gpu_lock
+        gpu_lock = lock
+        worker_id = worker_ids.get(False)
+
+    man = mp.Manager()
+
+    # create queue to distrubute worker ids
+    worker_ids = man.Queue(num_workers)
+    for i in range(num_workers):
+        worker_ids.put(i)
+
+    # 'pathos' is needed to pickle local scopes to workers
+    with pamp.Pool(
+        processes=num_workers,
+        initializer=pool_init,
+        initargs=[worker_ids, mp.Lock()],
+    ) as pool:
+        pool.map(tune_type, types)
+
+    # We're done with tuning this entire algorithm, collect them into a single file!
+    merge_jsons(
+        glob.glob(os.path.join(result_dir, f'{arch}_{build_target}_*.json')),
+        os.path.join(result_dir, f'{arch}_{build_target}.json'),
+    )
+
+parser = argparse.ArgumentParser(
+    prog='autotune-search',
+    description='config tuning using local search',
+)
+
+parser.add_argument('targets',metavar='TARGETS', nargs='*', help='target(s) to optimize, seperated by comma')
+parser.add_argument('-a', '--arch', default='gfx942', help='architecture to target, e.g. gfx908')
+parser.add_argument('-n', '--evals', default=200, help='maximum number of configs being evaluated per type per target')
+parser.add_argument('-v', '--verbose', action='store_true', help='clear the output folder')
+parser.add_argument('-w', '--workers', default=8, help='number of workers')
+parser.add_argument('-s', '--size', default=33554432, help='input size to use for tuning')
+parser.add_argument('-t', '--trials', default=8, help='number of trials per config to test')
+parser.add_argument('-c', '--combine', action='store_true', help='skip tuning and combine the results of a previous run for the given targets and architecture')
+parser.add_argument('-l', '--list', action='store_true', help='list available targets')
+
+args = parser.parse_args()
+
+if not args.targets:
+    args.targets = list(parameter_spaces.keys())
+
+if args.list:
+    for target in parameter_spaces.keys():
+        print(target)
+    quit()
+
+log_level = logging.INFO
+if args.verbose:
+    log_level = logging.DEBUG
+
+logging.basicConfig(format='%(message)s', handlers=[rich.logging.RichHandler(rich_tracebacks=True, markup=True)], level=log_level)
+log = logging.getLogger('rich')
+
+if args.combine:
+    for target in args.targets:
+        combine(alg_name=target, arch=args.arch)
+    quit()
+
+for target in args.targets:
+    log.info(f'Tuning {target} for {args.arch} with {int(args.evals)} max evaluations')
+    tune_alg(
+        alg_name=target,
+        arch=args.arch,
+        max_samples=int(args.evals),
+        num_workers=int(args.workers),
+        size=int(args.size),
+        trials=int(args.trials)
+    )

--- a/scripts/autotune-search/main.py
+++ b/scripts/autotune-search/main.py
@@ -30,16 +30,15 @@ parameter_spaces = {
             ],
         },
         "params": {
-            "LongBits": [7, 8],
-            "ShortBits": [4, 5, 6],
+            "LongBits": [6, 7, 8],
             "BlockSize": [256],
             "ItemsPerThread": [7, 8, 13, 16, 17],
-            "WarpSmallLWS": [8, 16, 32],
-            "WarpSmallIPT": [4, 8],
+            "WarpSmallLWS": [8, 16, 32, 64],
+            "WarpSmallIPT": [2, 4, 8],
             "WarpSmallBS": [256],
             "WarpPartition": [4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096],
-            "WarpMediumLWS": [16, 32],
-            "WarpMediumIPT": [4, 16],
+            "WarpMediumLWS": [16, 32, 64],
+            "WarpMediumIPT": [4, 8, 16],
             "WarpMediumBS": [256],
         },
     },
@@ -63,16 +62,15 @@ parameter_spaces = {
             ],
         },
         "params": {
-            "LongBits": [7, 8],
-            "ShortBits": [4, 5, 6],
+            "LongBits": [6, 7, 8],
             "BlockSize": [256],
             "ItemsPerThread": [7, 8, 13, 16, 17],
-            "WarpSmallLWS": [8, 16, 32],
-            "WarpSmallIPT": [4, 8],
+            "WarpSmallLWS": [8, 16, 32, 64],
+            "WarpSmallIPT": [2, 4, 8],
             "WarpSmallBS": [256],
             "WarpPartition": [4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096],
-            "WarpMediumLWS": [16, 32],
-            "WarpMediumIPT": [4, 16],
+            "WarpMediumLWS": [16, 32, 64],
+            "WarpMediumIPT": [4, 8, 16],
             "WarpMediumBS": [256],
         },
     },
@@ -265,7 +263,7 @@ def tune_alg(alg_name: str, arch: str, max_samples: int, num_workers: int, size:
                         '--size',
                         f'{size}',
                         '--trials',
-                        f'{trials}',  # 8 seems to be a fair balance between benchmarking and compile time. Needs verification though.
+                        f'{trials}',
                         '--benchmark_out_format=json',
                         f'--benchmark_out={result_filename}',
                     ],
@@ -348,10 +346,10 @@ parser = argparse.ArgumentParser(
 parser.add_argument('targets',metavar='TARGETS', nargs='*', help='target(s) to optimize, seperated by comma')
 parser.add_argument('-a', '--arch', default='gfx942', help='architecture to target, e.g. gfx908')
 parser.add_argument('-n', '--evals', default=200, help='maximum number of configs being evaluated per type per target')
-parser.add_argument('-v', '--verbose', action='store_true', help='clear the output folder')
+parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
 parser.add_argument('-w', '--workers', default=8, help='number of workers')
 parser.add_argument('-s', '--size', default=33554432, help='input size to use for tuning')
-parser.add_argument('-t', '--trials', default=8, help='number of trials per config to test')
+parser.add_argument('-t', '--trials', default=3, help='number of trials per config to test')
 parser.add_argument('-c', '--combine', action='store_true', help='skip tuning and combine the results of a previous run for the given targets and architecture')
 parser.add_argument('-l', '--list', action='store_true', help='list available targets')
 

--- a/scripts/autotune-search/requirements.txt
+++ b/scripts/autotune-search/requirements.txt
@@ -1,0 +1,3 @@
+scipy
+pathos
+rich

--- a/scripts/autotune/create_optimization.py
+++ b/scripts/autotune/create_optimization.py
@@ -41,7 +41,7 @@ from collections import defaultdict
 from typing import Dict, List, Callable, Optional, Tuple
 from jinja2 import Environment, PackageLoader, select_autoescape
 
-TARGET_ARCHITECTURES = ['gfx803', 'gfx900', 'gfx906', 'gfx908', 'gfx90a', 'gfx1030', 'gfx1100', 'gfx1102']
+TARGET_ARCHITECTURES = ['gfx803', 'gfx900', 'gfx906', 'gfx908', 'gfx90a', 'gfx942', 'gfx1030', 'gfx1100', 'gfx1102']
 # C++ typename used for optional types
 EMPTY_TYPENAME = "empty_type"
 


### PR DESCRIPTION
This PR is aimed to improve performance on gfx942-based GPUs. As a side effect performance on other architectures is also impacted.

Please check the commit history for a more detailed breakdown of the changes. The most notable changes are:
- Implemented a hacky way to use local search for tuning to explore configurations with many parameters.
  - The tuning benchmark of device segmented radix has also been changed to make use of more parameters.
- Use radix rank match sub-algorithm instead of the basic one.
  - Change by @Snektron, I just cleaned up a bit.
- Pre-exchange blocked layout to warp striped layout as this is faster than working on blocked layout.
  - This is required for radix rank match.
- Maximise theoretical LDS-bound occupancy for different configs.
  - This brings our occupancy and LDS usage on-par with other libraries.
- Various micro-optimizations.
