### PR TITLE
Device reduce optimization

### DIFF
--- a/rocprim/include/rocprim/device/config_types.hpp
+++ b/rocprim/include/rocprim/device/config_types.hpp
@@ -169,6 +169,7 @@ enum class target_arch : unsigned int
     gfx906  = 906,
     gfx908  = 908,
     gfx90a  = 910,
+    gfx942  = 942,
     gfx1030 = 1030,
     gfx1100 = 1100,
     gfx1102 = 1102,
@@ -203,14 +204,22 @@ constexpr bool prefix_equals(const char* lhs, const char* rhs, std::size_t n)
 
 constexpr target_arch get_target_arch_from_name(const char* const arch_name, const std::size_t n)
 {
-    constexpr const char* target_names[]
-        = {"gfx803", "gfx900", "gfx906", "gfx908", "gfx90a", "gfx1030", "gfx1100", "gfx1102"};
+    constexpr const char* target_names[]         = {"gfx803",
+                                                    "gfx900",
+                                                    "gfx906",
+                                                    "gfx908",
+                                                    "gfx90a",
+                                                    "gfx942",
+                                                    "gfx1030",
+                                                    "gfx1100",
+                                                    "gfx1102"};
     constexpr target_arch target_architectures[] = {
         target_arch::gfx803,
         target_arch::gfx900,
         target_arch::gfx906,
         target_arch::gfx908,
         target_arch::gfx90a,
+        target_arch::gfx942,
         target_arch::gfx1030,
         target_arch::gfx1100,
         target_arch::gfx1102,
@@ -266,6 +275,8 @@ auto dispatch_target_arch(const target_arch target_arch)
             return Config::template architecture_config<target_arch::gfx908>::params;
         case target_arch::gfx90a:
             return Config::template architecture_config<target_arch::gfx90a>::params;
+        case target_arch::gfx942:
+            return Config::template architecture_config<target_arch::gfx942>::params;
         case target_arch::gfx1030:
             return Config::template architecture_config<target_arch::gfx1030>::params;
         case target_arch::gfx1100:

--- a/rocprim/include/rocprim/device/detail/config/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/detail/config/device_reduce.hpp
@@ -518,6 +518,74 @@ struct default_reduce_config<static_cast<unsigned int>(target_arch::gfx90a),
     : reduce_config<256, 16, ::rocprim::block_reduce_algorithm::using_warp_reduce>
 {};
 
+// Based on key_type = double
+template<class key_type>
+struct default_reduce_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4))>>
+    : reduce_config<256, 16, ::rocprim::block_reduce_algorithm::using_warp_reduce>
+{};
+
+// Based on key_type = float
+template<class key_type>
+struct default_reduce_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2))>>
+    : reduce_config<256, 8, ::rocprim::block_reduce_algorithm::using_warp_reduce>
+{};
+
+// Based on key_type = rocprim::half
+template<class key_type>
+struct default_reduce_config<static_cast<unsigned int>(target_arch::gfx942),
+                             key_type,
+                             std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value)
+                                               && (sizeof(key_type) <= 2))>>
+    : reduce_config<128, 16, ::rocprim::block_reduce_algorithm::using_warp_reduce>
+{};
+
+// Based on key_type = int64_t
+template<class key_type>
+struct default_reduce_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4))>>
+    : reduce_config<256, 2, ::rocprim::block_reduce_algorithm::using_warp_reduce>
+{};
+
+// Based on key_type = int
+template<class key_type>
+struct default_reduce_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2))>>
+    : reduce_config<256, 4, ::rocprim::block_reduce_algorithm::using_warp_reduce>
+{};
+
+// Based on key_type = short
+template<class key_type>
+struct default_reduce_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    key_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1))>>
+    : reduce_config<128, 16, ::rocprim::block_reduce_algorithm::using_warp_reduce>
+{};
+
+// Based on key_type = int8_t
+template<class key_type>
+struct default_reduce_config<static_cast<unsigned int>(target_arch::gfx942),
+                             key_type,
+                             std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value)
+                                               && (sizeof(key_type) <= 1))>>
+    : reduce_config<256, 16, ::rocprim::block_reduce_algorithm::using_warp_reduce>
+{};
+
 } // end namespace detail
 
 END_ROCPRIM_NAMESPACE

--- a/rocprim/include/rocprim/device/detail/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/detail/device_reduce.hpp
@@ -64,7 +64,8 @@ auto reduce_with_initial(T output, T initial_value, BinaryFunction reduce_op) ->
 
 template<
     bool WithInitialValue,
-    unsigned int LimitItems,
+    bool         FitLarger,
+    unsigned int FitItems,
     class Config,
     class ResultType,
     class InputIterator,
@@ -83,7 +84,7 @@ void block_reduce_kernel_impl(InputIterator input,
 
     constexpr unsigned int block_size = params.reduce_config.block_size;
     constexpr unsigned int items_per_thread
-        = ceiling_div(params.reduce_config.items_per_thread, LimitItems);
+        = FitLarger ? params.reduce_config.items_per_thread * FitItems: ceiling_div(params.reduce_config.items_per_thread, FitItems);
 
     using result_type = ResultType;
 

--- a/rocprim/include/rocprim/device/detail/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/detail/device_reduce.hpp
@@ -21,8 +21,8 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_DEVICE_REDUCE_HPP_
 #define ROCPRIM_DEVICE_DETAIL_DEVICE_REDUCE_HPP_
 
-#include <type_traits>
 #include <iterator>
+#include <type_traits>
 
 #include "../../config.hpp"
 #include "../../detail/temp_storage.hpp"
@@ -30,8 +30,8 @@
 #include "../config_types.hpp"
 #include "../device_reduce_config.hpp"
 
-#include "../../intrinsics.hpp"
 #include "../../functional.hpp"
+#include "../../intrinsics.hpp"
 #include "../../types.hpp"
 
 #include "../../block/block_load.hpp"
@@ -44,38 +44,27 @@ namespace detail
 
 // Helper functions for reducing final value with
 // initial value.
-template<
-    bool WithInitialValue,
-    class T,
-    class BinaryFunction
->
+template<bool WithInitialValue, class T, class BinaryFunction>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-auto reduce_with_initial(T output,
-                         T initial_value,
-                         BinaryFunction reduce_op)
-    -> typename std::enable_if<WithInitialValue, T>::type
+auto reduce_with_initial(T output, T initial_value, BinaryFunction reduce_op) ->
+    typename std::enable_if<WithInitialValue, T>::type
 {
     return reduce_op(initial_value, output);
 }
 
-template<
-    bool WithInitialValue,
-    class T,
-    class BinaryFunction
->
+template<bool WithInitialValue, class T, class BinaryFunction>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-auto reduce_with_initial(T output,
-                         T initial_value,
-                         BinaryFunction reduce_op)
-    -> typename std::enable_if<!WithInitialValue, T>::type
+auto reduce_with_initial(T output, T initial_value, BinaryFunction reduce_op) ->
+    typename std::enable_if<!WithInitialValue, T>::type
 {
-    (void) initial_value;
-    (void) reduce_op;
+    (void)initial_value;
+    (void)reduce_op;
     return output;
 }
 
 template<
     bool WithInitialValue,
+    unsigned int LimitItems,
     class Config,
     class ResultType,
     class InputIterator,
@@ -92,8 +81,9 @@ void block_reduce_kernel_impl(InputIterator input,
 {
     static constexpr reduce_config_params params = device_params<Config>();
 
-    constexpr unsigned int block_size       = params.reduce_config.block_size;
-    constexpr unsigned int items_per_thread = params.reduce_config.items_per_thread;
+    constexpr unsigned int block_size = params.reduce_config.block_size;
+    constexpr unsigned int items_per_thread
+        = ceiling_div(params.reduce_config.items_per_thread, LimitItems);
 
     using result_type = ResultType;
 
@@ -111,12 +101,10 @@ void block_reduce_kernel_impl(InputIterator input,
     // last incomplete block
     if(flat_block_id == (input_size / items_per_block))
     {
-        block_load_direct_striped<block_size>(
-            flat_id,
-            input + block_offset,
-            values,
-            valid_in_last_block
-        );
+        block_load_direct_striped<block_size>(flat_id,
+                                              input + block_offset,
+                                              values,
+                                              valid_in_last_block);
 
         output_value = values[0];
         ROCPRIM_UNROLL
@@ -136,34 +124,26 @@ void block_reduce_kernel_impl(InputIterator input,
     }
     else
     {
-        block_load_direct_striped<block_size>(
-            flat_id,
-            input + block_offset,
-            values
-        );
+        block_load_direct_striped<block_size>(flat_id, input + block_offset, values);
 
         // load input values into values
-        block_reduce_type()
-            .reduce(
-                values, // input
-                output_value, // output
-                reduce_op
-            );
+        block_reduce_type().reduce(values, // input
+                                   output_value, // output
+                                   reduce_op);
     }
 
     // Save value into output
     if(flat_id == 0)
     {
-        output[flat_block_id] = input_size == 0
-            ? static_cast<result_type>(initial_value)
-            : reduce_with_initial<WithInitialValue>(
-                output_value,
-                static_cast<result_type>(initial_value),
-                reduce_op
-            );
+        output[flat_block_id]
+            = input_size == 0
+                  ? static_cast<result_type>(initial_value)
+                  : reduce_with_initial<WithInitialValue>(output_value,
+                                                          static_cast<result_type>(initial_value),
+                                                          reduce_op);
     }
 }
-} // end of detail namespace
+} // namespace detail
 
 END_ROCPRIM_NAMESPACE
 

--- a/rocprim/include/rocprim/device/detail/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/detail/device_reduce.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,9 +21,6 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_DEVICE_REDUCE_HPP_
 #define ROCPRIM_DEVICE_DETAIL_DEVICE_REDUCE_HPP_
 
-#include <iterator>
-#include <type_traits>
-
 #include "../../config.hpp"
 #include "../../detail/temp_storage.hpp"
 #include "../../detail/various.hpp"
@@ -36,6 +33,9 @@
 
 #include "../../block/block_load.hpp"
 #include "../../block/block_reduce.hpp"
+
+#include <iterator>
+#include <type_traits>
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -84,7 +84,8 @@ void block_reduce_kernel_impl(InputIterator input,
 
     constexpr unsigned int block_size = params.reduce_config.block_size;
     constexpr unsigned int items_per_thread
-        = FitLarger ? params.reduce_config.items_per_thread * FitItems: ceiling_div(params.reduce_config.items_per_thread, FitItems);
+        = FitLarger ? params.reduce_config.items_per_thread * FitItems
+                    : ceiling_div(params.reduce_config.items_per_thread, FitItems);
 
     using result_type = ResultType;
 

--- a/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/device_reduce.hpp
@@ -44,7 +44,8 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<bool WithInitialValue,
+template<bool         WithInitialValue,
+         unsigned int LimitItems,
          class Config,
          class ResultType,
          class InputIterator,
@@ -52,16 +53,18 @@ template<bool WithInitialValue,
          class InitValueType,
          class BinaryFunction>
 ROCPRIM_KERNEL
-    __launch_bounds__(device_params<Config>().reduce_config.block_size) void block_reduce_kernel(
-        InputIterator  input,
-        const size_t   size,
-        OutputIterator output,
-        InitValueType  initial_value,
-        BinaryFunction reduce_op)
+    __launch_bounds__(device_params<Config>().reduce_config.block_size)
+void block_reduce_kernel(InputIterator  input,
+                         const size_t   size,
+                         OutputIterator output,
+                         InitValueType  initial_value,
+                         BinaryFunction reduce_op)
 {
-    block_reduce_kernel_impl<WithInitialValue, Config, ResultType>(
-        input, size, output, initial_value, reduce_op
-    );
+    block_reduce_kernel_impl<WithInitialValue, LimitItems, Config, ResultType>(input,
+                                                                               size,
+                                                                               output,
+                                                                               initial_value,
+                                                                               reduce_op);
 }
 
 #define ROCPRIM_DETAIL_HIP_SYNC(name, size, start) \
@@ -183,17 +186,19 @@ hipError_t reduce_impl(void * temporary_storage,
 
     if(number_of_blocks > 1)
     {
-        const auto    aligned_size_limit = number_of_blocks_limit * items_per_block;
+        const auto aligned_size_limit = number_of_blocks_limit * items_per_block;
 
         // Launch number_of_blocks_limit blocks while there is still at least as many blocks left as the limit
         const auto number_of_launch = (size + aligned_size_limit - 1) / aligned_size_limit;
-        for(size_t i = 0, offset = 0; i < number_of_launch; ++i, offset += aligned_size_limit) {
-            const auto current_size = std::min<size_t>(size - offset, aligned_size_limit);
+        for(size_t i = 0, offset = 0; i < number_of_launch; ++i, offset += aligned_size_limit)
+        {
+            const auto current_size   = std::min<size_t>(size - offset, aligned_size_limit);
             const auto current_blocks = (current_size + items_per_block - 1) / items_per_block;
 
-            if(debug_synchronous) start = std::chrono::high_resolution_clock::now();
+            if(debug_synchronous)
+                start = std::chrono::steady_clock::now();
             hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(detail::block_reduce_kernel<false, config, result_type>),
+                HIP_KERNEL_NAME(detail::block_reduce_kernel<false, 1, config, result_type>),
                 dim3(current_blocks),
                 dim3(block_size),
                 0,
@@ -206,7 +211,8 @@ hipError_t reduce_impl(void * temporary_storage,
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", current_size, start);
         }
 
-        if(debug_synchronous) start = std::chrono::high_resolution_clock::now();
+        if(debug_synchronous)
+            start = std::chrono::steady_clock::now();
         auto error = reduce_impl<WithInitialValue, Config>(nested_temp_storage,
                                                            nested_temp_storage_size,
                                                            block_prefixes, // input
@@ -216,17 +222,61 @@ hipError_t reduce_impl(void * temporary_storage,
                                                            reduce_op,
                                                            stream,
                                                            debug_synchronous);
-        if(error != hipSuccess) return error;
+        if(error != hipSuccess)
+            return error;
         ROCPRIM_DETAIL_HIP_SYNC("nested_device_reduce", number_of_blocks, start);
     }
     else
     {
-        if(debug_synchronous) start = std::chrono::high_resolution_clock::now();
-        hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(detail::block_reduce_kernel<WithInitialValue, config, result_type>),
-            dim3(1), dim3(block_size), 0, stream,
-            input, size, output, initial_value, reduce_op
-        );
+        const unsigned int to_large = size > 0 ? items_per_block / size : 0;
+        if(debug_synchronous)
+            start = std::chrono::steady_clock::now();
+        if(to_large >= 16)
+        {
+            detail::block_reduce_kernel<WithInitialValue, 16, config, result_type>
+                <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                           size,
+                                                           output,
+                                                           initial_value,
+                                                           reduce_op);
+        }
+        else if(to_large >= 8)
+        {
+            detail::block_reduce_kernel<WithInitialValue, 8, config, result_type>
+                <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                           size,
+                                                           output,
+                                                           initial_value,
+                                                           reduce_op);
+        }
+        else if(to_large >= 4)
+        {
+            detail::block_reduce_kernel<WithInitialValue, 4, config, result_type>
+                <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                           size,
+                                                           output,
+                                                           initial_value,
+                                                           reduce_op);
+        }
+        else if(to_large >= 2)
+        {
+            detail::block_reduce_kernel<WithInitialValue, 2, config, result_type>
+                <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                           size,
+                                                           output,
+                                                           initial_value,
+                                                           reduce_op);
+        }
+        else
+        {
+            detail::block_reduce_kernel<WithInitialValue, 1, config, result_type>
+                <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                           size,
+                                                           output,
+                                                           initial_value,
+                                                           reduce_op);
+        }
+
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);
     }
 
@@ -236,7 +286,7 @@ hipError_t reduce_impl(void * temporary_storage,
 #undef ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR
 #undef ROCPRIM_DETAIL_HIP_SYNC
 
-} // end of detail namespace
+} // namespace detail
 
 /// \brief Parallel reduction primitive for device level.
 ///
@@ -360,29 +410,31 @@ hipError_t reduce_impl(void * temporary_storage,
 /// );
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class InitValueType,
-    class BinaryFunction = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>
->
-inline
-hipError_t reduce(void * temporary_storage,
-                 size_t& storage_size,
-                 InputIterator input,
-                 OutputIterator output,
-                 const InitValueType initial_value,
-                 const size_t size,
-                 BinaryFunction reduce_op = BinaryFunction(),
-                 const hipStream_t stream = 0,
-                 bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class InitValueType,
+         class BinaryFunction
+         = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>>
+inline hipError_t reduce(void*               temporary_storage,
+                         size_t&             storage_size,
+                         InputIterator       input,
+                         OutputIterator      output,
+                         const InitValueType initial_value,
+                         const size_t        size,
+                         BinaryFunction      reduce_op         = BinaryFunction(),
+                         const hipStream_t   stream            = 0,
+                         bool                debug_synchronous = false)
 {
-    return detail::reduce_impl<true, Config>(
-        temporary_storage, storage_size,
-        input, output, initial_value, size,
-        reduce_op, stream, debug_synchronous
-    );
+    return detail::reduce_impl<true, Config>(temporary_storage,
+                                             storage_size,
+                                             input,
+                                             output,
+                                             initial_value,
+                                             size,
+                                             reduce_op,
+                                             stream,
+                                             debug_synchronous);
 }
 
 /// \brief Parallel reduce primitive for device level.
@@ -490,29 +542,31 @@ hipError_t reduce(void * temporary_storage,
 /// );
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class BinaryFunction = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>
->
-inline
-hipError_t reduce(void * temporary_storage,
-                  size_t& storage_size,
-                  InputIterator input,
-                  OutputIterator output,
-                  const size_t size,
-                  BinaryFunction reduce_op = BinaryFunction(),
-                  const hipStream_t stream = 0,
-                  bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class BinaryFunction
+         = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>>
+inline hipError_t reduce(void*             temporary_storage,
+                         size_t&           storage_size,
+                         InputIterator     input,
+                         OutputIterator    output,
+                         const size_t      size,
+                         BinaryFunction    reduce_op         = BinaryFunction(),
+                         const hipStream_t stream            = 0,
+                         bool              debug_synchronous = false)
 {
     using input_type = typename std::iterator_traits<InputIterator>::value_type;
 
-    return detail::reduce_impl<false, Config>(
-        temporary_storage, storage_size,
-        input, output, input_type(), size,
-        reduce_op, stream, debug_synchronous
-    );
+    return detail::reduce_impl<false, Config>(temporary_storage,
+                                              storage_size,
+                                              input,
+                                              output,
+                                              input_type(),
+                                              size,
+                                              reduce_op,
+                                              stream,
+                                              debug_synchronous);
 }
 
 /// @}

--- a/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/device_reduce.hpp
@@ -61,11 +61,12 @@ void block_reduce_kernel(InputIterator  input,
                          InitValueType  initial_value,
                          BinaryFunction reduce_op)
 {
-    block_reduce_kernel_impl<WithInitialValue, FitLarger, FitItems, Config, ResultType>(input,
-                                                                                      size,
-                                                                                      output,
-                                                                                      initial_value,
-                                                                                      reduce_op);
+    block_reduce_kernel_impl<WithInitialValue, FitLarger, FitItems, Config, ResultType>(
+        input,
+        size,
+        output,
+        initial_value,
+        reduce_op);
 }
 
 #define ROCPRIM_DETAIL_HIP_SYNC(name, size, start) \
@@ -94,6 +95,24 @@ void block_reduce_kernel(InputIterator  input,
         } \
     }
 
+#define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                       \
+    do                                                                                    \
+    {                                                                                     \
+        if(debug_synchronous)                                                             \
+        {                                                                                 \
+            start = std::chrono::steady_clock::now();                                     \
+        }                                                                                 \
+                                                                                          \
+        block_reduce_kernel<WithInitialValue, fit_larger, fit_items, config, result_type> \
+            <<<dim3(1), dim3(block_size), 0, stream>>>(input,                             \
+                                                       size,                              \
+                                                       output,                            \
+                                                       initial_value,                     \
+                                                       reduce_op);                        \
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);  \
+    }                                                                                     \
+    while(0)
+
 
 template<
     bool WithInitialValue, // true when inital_value should be used in reduction
@@ -121,11 +140,8 @@ hipError_t reduce_impl(void * temporary_storage,
     using config = wrapped_reduce_config<Config, result_type>;
 
     detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
+    ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+
     const reduce_config_params params = dispatch_target_arch<config>(target_arch);
 
     const unsigned int block_size       = params.reduce_config.block_size;
@@ -142,20 +158,16 @@ hipError_t reduce_impl(void * temporary_storage,
     size_t nested_temp_storage_size = 0;
     if(number_of_blocks > 1)
     {
-        const hipError_t nested_result
-            = reduce_impl<WithInitialValue, Config>(nullptr,
-                                                    nested_temp_storage_size,
-                                                    block_prefixes, // input
-                                                    output, // output
-                                                    initial_value,
-                                                    number_of_blocks, // input size
-                                                    reduce_op,
-                                                    stream,
-                                                    debug_synchronous);
-        if(nested_result != hipSuccess)
-        {
-            return nested_result;
-        }
+        ROCPRIM_RETURN_ON_ERROR(
+            reduce_impl<WithInitialValue, Config>(nullptr,
+                                                  nested_temp_storage_size,
+                                                  block_prefixes, // input
+                                                  output, // output
+                                                  initial_value,
+                                                  number_of_blocks, // input size
+                                                  reduce_op,
+                                                  stream,
+                                                  debug_synchronous));
     }
 
     const hipError_t partition_result = detail::temp_storage::partition(
@@ -197,137 +209,90 @@ hipError_t reduce_impl(void * temporary_storage,
             const auto current_blocks = (current_size + items_per_block - 1) / items_per_block;
 
             if(debug_synchronous)
+            {
                 start = std::chrono::steady_clock::now();
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(detail::block_reduce_kernel<false, true, 1, config, result_type>),
-                dim3(current_blocks),
-                dim3(block_size),
-                0,
-                stream,
-                input + offset,
-                current_size,
-                block_prefixes + i * number_of_blocks_limit,
-                initial_value,
-                reduce_op);
+            }
+            block_reduce_kernel<false, true, 1, config, result_type>
+                <<<dim3(current_blocks), dim3(block_size), 0, stream>>>(
+                    input + offset,
+                    current_size,
+                    block_prefixes + i * number_of_blocks_limit,
+                    initial_value,
+                    reduce_op);
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", current_size, start);
         }
 
         if(debug_synchronous)
+        {
             start = std::chrono::steady_clock::now();
-        auto error = reduce_impl<WithInitialValue, Config>(nested_temp_storage,
-                                                           nested_temp_storage_size,
-                                                           block_prefixes, // input
-                                                           output, // output
-                                                           initial_value,
-                                                           number_of_blocks, // input size
-                                                           reduce_op,
-                                                           stream,
-                                                           debug_synchronous);
-        if(error != hipSuccess)
-            return error;
+        }
+
+        ROCPRIM_RETURN_ON_ERROR(
+            reduce_impl<WithInitialValue, Config>(nested_temp_storage,
+                                                  nested_temp_storage_size,
+                                                  block_prefixes, // input
+                                                  output, // output
+                                                  initial_value,
+                                                  number_of_blocks, // input size
+                                                  reduce_op,
+                                                  stream,
+                                                  debug_synchronous));
+
         ROCPRIM_DETAIL_HIP_SYNC("nested_device_reduce", number_of_blocks, start);
     }
     else
     {
-        const unsigned int to_large = size > 0 ? items_per_block / size : 0;
-        const unsigned int to_small = number_of_blocks;
+        const unsigned int too_large = size > 0 ? items_per_block / size : 0;
+        const unsigned int too_small = number_of_blocks;
 
-        if(debug_synchronous)
-            start = std::chrono::steady_clock::now();
-        if(to_small > 1)
+        if(too_small > 1)
         {
-            if(to_small <= 2)
+            if(too_small <= 2)
             {
-                detail::block_reduce_kernel<WithInitialValue, true, 2, config, result_type>
-                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
+                SINGLE_REDUCE_KERNEL(true, 2);
             }
-            else if (to_small <= 4)
+            else if(too_small <= 4)
             {
-                detail::block_reduce_kernel<WithInitialValue, true, 4, config, result_type>
-                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
+                SINGLE_REDUCE_KERNEL(true, 4);
             }
-            else if (to_small <= 8)
+            else if(too_small <= 8)
             {
-                detail::block_reduce_kernel<WithInitialValue, true, 8, config, result_type>
-                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
+                SINGLE_REDUCE_KERNEL(true, 8);
             }
-            else if (to_small <= 16)
+            else if(too_small <= 16)
             {
-                detail::block_reduce_kernel<WithInitialValue, true, 16, config, result_type>
-                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
+                SINGLE_REDUCE_KERNEL(true, 16);
             }
         }
         else
         {
-            if(to_large >= 16)
+            if(too_large >= 16)
             {
-                detail::block_reduce_kernel<WithInitialValue, false, 16, config, result_type>
-                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
+                SINGLE_REDUCE_KERNEL(false, 16);
             }
-            else if(to_large >= 8)
+            else if(too_large >= 8)
             {
-                detail::block_reduce_kernel<WithInitialValue, false, 8, config, result_type>
-                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
+                SINGLE_REDUCE_KERNEL(false, 8);
             }
-            else if(to_large >= 4)
+            else if(too_large >= 4)
             {
-                detail::block_reduce_kernel<WithInitialValue, false, 4, config, result_type>
-                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
+                SINGLE_REDUCE_KERNEL(false, 4);
             }
-            else if(to_large >= 2)
+            else if(too_large >= 2)
             {
-                detail::block_reduce_kernel<WithInitialValue, false, 2, config, result_type>
-                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
+                SINGLE_REDUCE_KERNEL(false, 2);
             }
             else
             {
-                detail::block_reduce_kernel<WithInitialValue, false, 1, config, result_type>
-                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
+                SINGLE_REDUCE_KERNEL(false, 1);
             }
         }
-
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);
     }
 
     return hipSuccess;
 }
 
+#undef SINGLE_REDUCE_KERNEL
 #undef ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR
 #undef ROCPRIM_DETAIL_HIP_SYNC
 

--- a/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/device_reduce.hpp
@@ -197,6 +197,9 @@ hipError_t reduce_impl(void * temporary_storage,
         std::cout << "items_per_block " << items_per_block << '\n';
     }
 
+    // We increase the items per thread with a maximum of 16.
+    // This means if the number_of_blocks is larger than 16 it
+    // will not fit in one kernel.
     if(number_of_blocks > 16)
     {
         const auto aligned_size_limit = number_of_blocks_limit * items_per_block;
@@ -242,11 +245,16 @@ hipError_t reduce_impl(void * temporary_storage,
     }
     else
     {
+        // Modify the items per thread to both better utilise the available
+        // compute units and avoid launching more kernels than necessary.
+        // That is, if we can double the items per thread to prevent an extra
+        // kernel launch, we should probably do that.
         const unsigned int too_large = size > 0 ? items_per_block / size : 0;
         const unsigned int too_small = number_of_blocks;
 
         if(too_small > 1)
         {
+            // Decrease IPT for better utilisation
             if(too_small <= 2)
             {
                 SINGLE_REDUCE_KERNEL(true, 2);
@@ -266,6 +274,7 @@ hipError_t reduce_impl(void * temporary_storage,
         }
         else
         {
+            // Increase IPT to prevent kernel launch
             if(too_large >= 16)
             {
                 SINGLE_REDUCE_KERNEL(false, 16);

--- a/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/device_reduce.hpp
@@ -75,7 +75,7 @@ void block_reduce_kernel(InputIterator  input,
         std::cout << name << "(" << size << ")"; \
         auto _error = hipStreamSynchronize(stream); \
         if(_error != hipSuccess) return _error; \
-        auto _end = std::chrono::high_resolution_clock::now(); \
+        auto _end = std::chrono::steady_clock::now(); \
         auto _d = std::chrono::duration_cast<std::chrono::duration<double>>(_end - start); \
         std::cout << " " << _d.count() * 1000 << " ms" << '\n'; \
     }
@@ -89,11 +89,22 @@ void block_reduce_kernel(InputIterator  input,
             std::cout << name << "(" << size << ")"; \
             auto __error = hipStreamSynchronize(stream); \
             if(__error != hipSuccess) return __error; \
-            auto _end = std::chrono::high_resolution_clock::now(); \
+            auto _end = std::chrono::steady_clock::now(); \
             auto _d = std::chrono::duration_cast<std::chrono::duration<double>>(_end - start); \
             std::cout << " " << _d.count() * 1000 << " ms" << '\n'; \
         } \
     }
+
+#define ROCPRIM_RETURN_ON_ERROR(...)      \
+    do                                    \
+    {                                     \
+        hipError_t error = (__VA_ARGS__); \
+        if(error != hipSuccess)           \
+        {                                 \
+            return error;                 \
+        }                                 \
+    }                                     \
+    while(0)
 
 #define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                       \
     do                                                                                    \
@@ -184,7 +195,7 @@ hipError_t reduce_impl(void * temporary_storage,
     }
 
     // Start point for time measurements
-    std::chrono::high_resolution_clock::time_point start;
+    std::chrono::steady_clock::time_point start;
 
     const auto size_limit             = params.reduce_config.size_limit;
     const auto number_of_blocks_limit = ::rocprim::max<size_t>(size_limit / items_per_block, 1);
@@ -302,6 +313,7 @@ hipError_t reduce_impl(void * temporary_storage,
 }
 
 #undef SINGLE_REDUCE_KERNEL
+#undef ROCPRIM_RETURN_ON_ERROR
 #undef ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR
 #undef ROCPRIM_DETAIL_HIP_SYNC
 

--- a/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/device_reduce.hpp
@@ -45,7 +45,8 @@ namespace detail
 {
 
 template<bool         WithInitialValue,
-         unsigned int LimitItems,
+         bool         FitLarger,
+         unsigned int FitItems,
          class Config,
          class ResultType,
          class InputIterator,
@@ -60,11 +61,11 @@ void block_reduce_kernel(InputIterator  input,
                          InitValueType  initial_value,
                          BinaryFunction reduce_op)
 {
-    block_reduce_kernel_impl<WithInitialValue, LimitItems, Config, ResultType>(input,
-                                                                               size,
-                                                                               output,
-                                                                               initial_value,
-                                                                               reduce_op);
+    block_reduce_kernel_impl<WithInitialValue, FitLarger, FitItems, Config, ResultType>(input,
+                                                                                      size,
+                                                                                      output,
+                                                                                      initial_value,
+                                                                                      reduce_op);
 }
 
 #define ROCPRIM_DETAIL_HIP_SYNC(name, size, start) \
@@ -184,7 +185,7 @@ hipError_t reduce_impl(void * temporary_storage,
         std::cout << "items_per_block " << items_per_block << '\n';
     }
 
-    if(number_of_blocks > 1)
+    if(number_of_blocks > 16)
     {
         const auto aligned_size_limit = number_of_blocks_limit * items_per_block;
 
@@ -198,7 +199,7 @@ hipError_t reduce_impl(void * temporary_storage,
             if(debug_synchronous)
                 start = std::chrono::steady_clock::now();
             hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(detail::block_reduce_kernel<false, 1, config, result_type>),
+                HIP_KERNEL_NAME(detail::block_reduce_kernel<false, true, 1, config, result_type>),
                 dim3(current_blocks),
                 dim3(block_size),
                 0,
@@ -229,52 +230,96 @@ hipError_t reduce_impl(void * temporary_storage,
     else
     {
         const unsigned int to_large = size > 0 ? items_per_block / size : 0;
+        const unsigned int to_small = number_of_blocks;
+
         if(debug_synchronous)
             start = std::chrono::steady_clock::now();
-        if(to_large >= 16)
+        if(to_small > 1)
         {
-            detail::block_reduce_kernel<WithInitialValue, 16, config, result_type>
-                <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                           size,
-                                                           output,
-                                                           initial_value,
-                                                           reduce_op);
-        }
-        else if(to_large >= 8)
-        {
-            detail::block_reduce_kernel<WithInitialValue, 8, config, result_type>
-                <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                           size,
-                                                           output,
-                                                           initial_value,
-                                                           reduce_op);
-        }
-        else if(to_large >= 4)
-        {
-            detail::block_reduce_kernel<WithInitialValue, 4, config, result_type>
-                <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                           size,
-                                                           output,
-                                                           initial_value,
-                                                           reduce_op);
-        }
-        else if(to_large >= 2)
-        {
-            detail::block_reduce_kernel<WithInitialValue, 2, config, result_type>
-                <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                           size,
-                                                           output,
-                                                           initial_value,
-                                                           reduce_op);
+            if(to_small <= 2)
+            {
+                detail::block_reduce_kernel<WithInitialValue, true, 2, config, result_type>
+                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+            }
+            else if (to_small <= 4)
+            {
+                detail::block_reduce_kernel<WithInitialValue, true, 4, config, result_type>
+                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+            }
+            else if (to_small <= 8)
+            {
+                detail::block_reduce_kernel<WithInitialValue, true, 8, config, result_type>
+                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+            }
+            else if (to_small <= 16)
+            {
+                detail::block_reduce_kernel<WithInitialValue, true, 16, config, result_type>
+                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+            }
         }
         else
         {
-            detail::block_reduce_kernel<WithInitialValue, 1, config, result_type>
-                <<<dim3(1), dim3(block_size), 0, stream>>>(input,
-                                                           size,
-                                                           output,
-                                                           initial_value,
-                                                           reduce_op);
+            if(to_large >= 16)
+            {
+                detail::block_reduce_kernel<WithInitialValue, false, 16, config, result_type>
+                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+            }
+            else if(to_large >= 8)
+            {
+                detail::block_reduce_kernel<WithInitialValue, false, 8, config, result_type>
+                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+            }
+            else if(to_large >= 4)
+            {
+                detail::block_reduce_kernel<WithInitialValue, false, 4, config, result_type>
+                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+            }
+            else if(to_large >= 2)
+            {
+                detail::block_reduce_kernel<WithInitialValue, false, 2, config, result_type>
+                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+            }
+            else
+            {
+                detail::block_reduce_kernel<WithInitialValue, false, 1, config, result_type>
+                    <<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+            }
         }
 
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);


### PR DESCRIPTION
This PR includes tuning for the device_reduce for arch gfx942.
It also includes fitting for the last kernel launch of rocprim::device_reduce.
This fitting is done with the IPT and is based on the input size.
It decreases the IPT if the size is smaller than the items that will be executed in the kernel.
It increases the IPT if the amount of items are just to big for one kernel.