### PR TITLE
Increase static build pkging stage timeout by 60min to 120min

### DIFF
--- a/.jenkins/static.groovy
+++ b/.jenkins/static.groovy
@@ -11,6 +11,7 @@ def runCI =
     def prj = new rocProject('rocPRIM', 'static')
     prj.paths.build_command = './install -c -s'
     prj.timeout.compile = 600
+    prj.timeout.packaging = 120
 
     def nodes = new dockerNodes(nodeDetails, jobName, prj)
 


### PR DESCRIPTION
passing run http://math-ci.amd.com/job/static-libraries/job/static-build/job/rocPRIM/view/change-requests/job/PR-643/1/pipeline-graph/