### PR TITLE
Add atomic_add overload for type double

### DIFF
--- a/rocprim/include/rocprim/intrinsics/atomic.hpp
+++ b/rocprim/include/rocprim/intrinsics/atomic.hpp
@@ -45,6 +45,12 @@ namespace detail
         return ::atomicAdd(address, value);
     }
 
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    double atomic_add(double * address, double value)
+    {
+        return ::atomicAdd(address, value);
+    }
+
     ROCPRIM_DEVICE ROCPRIM_INLINE unsigned long atomic_add(unsigned long* address,
                                                            unsigned long  value)
     {

--- a/test/rocprim/test_device_histogram.cpp
+++ b/test/rocprim/test_device_histogram.cpp
@@ -132,6 +132,7 @@ using custom_config1 = rocprim::histogram_config<rocprim::kernel_config<128, 5>>
 
 typedef ::testing::Types<params1<int, 10, 0, 10>,
                          params1<float, 10, 0, 10>,
+                         params1<float, 10, 0, 10, float, float>,
                          params1<rocprim::half, 10, 0, 10>,
                          params1<rocprim::bfloat16, 10, 0, 10>,
                          params1<int8_t, 10, 0, 10>,
@@ -140,8 +141,8 @@ typedef ::testing::Types<params1<int, 10, 0, 10>,
                          params1<unsigned short, 65536, 0, 65536, int>,
                          params1<unsigned char, 10, 20, 240, unsigned char, unsigned int>,
                          params1<unsigned char, 256, 0, 256, short>,
-
                          params1<double, 10, 0, 1000, double, int>,
+                         params1<double, 10, 0, 1000, double, double>,
                          params1<int, 123, 100, 5635, int>,
                          params1<double, 55, -123, +123, double, unsigned int, custom_config1>,
                          params1<int, 10, 0, 10, int, int, rocprim::default_config, true>>


### PR DESCRIPTION
The rocprim::histogram_even algorithm uses rocprim::atomic_add. There are atomic_add overloads for all of the non-half-type primitive data types we support, with the exception of double.

Because of this, if you called rocprim::histogram_even and used double as the counter type, you'd get a compilation error.

This changes just adds an atomic_add overload that accepts double, and tacks on a few unit test cases that exercise histogram_even with float and double counters.