### PR TITLE
Develop Stream: fix warp dpp reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Fixed an issue where `rocprim::partial_sort_copy` would yield a compile error if the input iterator is const.
 * Fixed incorrect 128-bit signed and unsigned integers type traits.
 * Fixed compilation issue when `rocprim::radix_key_codec<...>` is specialized with a 128-bit integer.
+* Fixed the warp-level reduction `rocprim::warp_reduce.reduce` DPP implementation to avoid undefined intermediate values during the reduction.
 
 ### Upcoming changes
 * Using the initialisation constructor of `rocprim::reverse_iterator` will throw a deprecation warning. It will be marked as explicit in the next major release.

--- a/rocprim/include/rocprim/block/detail/block_reduce_warp_reduce.hpp
+++ b/rocprim/include/rocprim/block/detail/block_reduce_warp_reduce.hpp
@@ -190,14 +190,15 @@ private:
             }
             ::rocprim::syncthreads();
 
-            if(flat_tid < warps_no_)
+            if(warp_id == 0)
             {
                 // Use warp partial to calculate the final reduce results for every thread
-                auto warp_partial = storage_.warp_partials[lane_id];
+                auto warp_partial = storage_.warp_partials[lane_id % warps_no_];
 
-                warp_reduce<!warps_no_is_pow_of_two_, warp_reduce_output_type>(
-                    warp_partial, output, warps_no_, reduce_op
-                );
+                warp_reduce<!warps_no_is_pow_of_two_, warp_reduce_output_type>(warp_partial,
+                                                                               output,
+                                                                               warps_no_,
+                                                                               reduce_op);
             }
         }
     }


### PR DESCRIPTION
1. **Fix intra-warp reduction**. By using rotations instead of shifts in [warp_reduce_dpp.hpp](https://github.com/ROCm/rocPRIM/blob/develop/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp#L66-L75) we make sure that no registers are left with invalid values. We thus substitute the `dpp_ctrl` values of `0x114` and `0x118` for `0x124` and `0x128`, respectively.
2. **Fix inter-warp reduction**. After performing the intra-warp reduction, a second round of reduction is done to reduce the warps' results. In this case, we still may have some threads reading invalid values because currently there is divergence in this reduction (only the first `warps_no_` threads will participate in the final reduction). So potentially many threads will be disabled and then the dpp instruction will resort to what `bound_ctrl` dictates just like described before. Thus, to ensure that all threads read and write valid values, we remove this divergence from [block_reduce_warp_reduce.hpp](https://github.com/ROCm/rocPRIM/blob/develop/rocprim/include/rocprim/block/detail/block_reduce_warp_reduce.hpp#L193).
3. Additionally, to prevent the same segfaults happening when the  `BlockSize` used is less than the hardware warp size, we added a fallback to the `warp_shuffle` in that case.