### PR TITLE
enable legacy stream

### DIFF
--- a/rocprim/include/rocprim/device/config_types.hpp
+++ b/rocprim/include/rocprim/device/config_types.hpp
@@ -340,7 +340,7 @@ inline hipError_t get_device_arch(int device_id, target_arch& arch)
 inline hipError_t get_device_from_stream(const hipStream_t stream, int& device_id)
 {
     static constexpr hipStream_t default_stream = 0;
-    if(stream == default_stream || stream == hipStreamPerThread)
+    if(stream == default_stream || stream == hipStreamPerThread || stream == hipStreamLegacy)
     {
         const hipError_t result = hipGetDevice(&device_id);
         if(result != hipSuccess)


### PR DESCRIPTION
Starting from ROCm 6.3, we have a special stream, hipStreamLegacy, which needs to handle. Otherwise, we will see crash for some applications that uses **hipGetStreamDeviceId**.