### PR TITLE
Avoid evaluating CMake LINK_LANGUAGE generator expressions in CMake <3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 
 * Removed HIP-CPU support. HIP-CPU support was experimental and broken.
 * Changed the C++ version from 14 to 17. C++14 will be deprecated in the next major release.
+* You can use CMake HIP language support with CMake 3.18 and later. To use HIP language support, run `cmake` with `-DUSE_HIPCXX=ON` instead of setting the `CXX` variable to the path to a HIP-aware compiler.
 
 ### Resolved issues
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -82,10 +82,12 @@ function(add_rocprim_benchmark BENCHMARK_SOURCE)
       benchmark::benchmark
   )
 
-  target_link_libraries(${BENCHMARK_TARGET}
-    PRIVATE
+  if(USE_HIPCXX)
+    target_link_libraries(${BENCHMARK_TARGET}
+      PRIVATE
       $<IF:$<LINK_LANGUAGE:HIP>,hip::host,hip::device>
-  )
+    )
+  endif()
 
   target_compile_options(${BENCHMARK_TARGET}
     PRIVATE

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -33,10 +33,12 @@ function(add_rocprim_example EXAMPLE_SOURCE)
     PRIVATE
     rocprim
   )
-  target_link_libraries(${EXAMPLE_TARGET}
-    PRIVATE
+  if(USE_HIPCXX)
+    target_link_libraries(${EXAMPLE_TARGET}
+      PRIVATE
       $<IF:$<LINK_LANGUAGE:HIP>,hip::host,hip::device>
-  )
+    )
+  endif()
   set_target_properties(${EXAMPLE_TARGET}
     PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/example"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,10 +76,12 @@ function(add_hip_test TEST_NAME TEST_SOURCES)
     PRIVATE
       rocprim
   )
-  target_link_libraries(${TEST_TARGET}
-    PRIVATE
+  if(USE_HIPCXX)
+    target_link_libraries(${TEST_TARGET}
+      PRIVATE
       $<IF:$<LINK_LANGUAGE:HIP>,hip::host,hip::device>
-  )
+    )
+  endif()
 
   target_compile_options(${TEST_TARGET}
     PRIVATE

--- a/test/rocprim/CMakeLists.txt
+++ b/test/rocprim/CMakeLists.txt
@@ -55,10 +55,12 @@ function(add_rocprim_test_internal TEST_NAME TEST_SOURCES TEST_TARGET)
       GTest::Main
   )
 
-  target_link_libraries(${TEST_TARGET}
-    PRIVATE
+  if(USE_HIPCXX)
+    target_link_libraries(${TEST_TARGET}
+      PRIVATE
       $<IF:$<LINK_LANGUAGE:HIP>,hip::host,hip::device>
-  )
+    )
+  endif()
 
   target_compile_options(${TEST_TARGET}
     PRIVATE


### PR DESCRIPTION
Avoid evaluating CMake LINK_LANGUAGE generator expressions in CMake <3.18

Recently, we added CMake HIP Language support. That change introduced generator expressions that use the LINK_LANGUAGE keyword. This keyword is only supported in CMake 3.18+. The minimum CMake version we require is 3.16.

As a result, if you built with CMake 3.16 - 3.18, you'd get a build failure.

This change adds checks around all the spots where the LINK_LANGUAGE keyword is used to avoid this problem.

It also adds a description of the CMake HIP Language support to the changelog (previously overlooked).