### PR TITLE
Temporary workaround for shared memory write ordering compiler issue

### DIFF
--- a/rocprim/include/rocprim/block/detail/block_adjacent_difference_impl.hpp
+++ b/rocprim/include/rocprim/block/detail/block_adjacent_difference_impl.hpp
@@ -119,8 +119,12 @@ public:
         // Save the last item of each thread
         storage.items[flat_id] = input[ItemsPerThread - 1];
 
+        // Temporary workaround to deal with a compiler bug: count up instead of down.
+        // TODO: Restore this after the bug is addressed.
+        // ROCPRIM_UNROLL
+        // for(unsigned int i = ItemsPerThread - 1; i > 0; --i)
         ROCPRIM_UNROLL
-        for(unsigned int i = ItemsPerThread - 1; i > 0; --i)
+        for (unsigned int i = 1; i < ItemsPerThread; i++)
         {
             output[i] = detail::apply(
                 op, input[i - 1], input[i], flat_id * ItemsPerThread + i, as_flags, reversed);


### PR DESCRIPTION
This change implements a temporary workaround to fix block_histogram while we wait for a compiler fix.

Changing the direction of the for loop in block_adjacent_difference_impl::apply_left prevents the optimizer from generating an out-of-order write to shared memory in this case.

This is not an optimal solution to the problem, but if we need to we could use it while we wait for the compiler issue to be resolved.