### PR TITLE
Workaround for shared memory write ordering compiler issue

### DIFF
--- a/rocprim/include/rocprim/block/detail/block_histogram_sort.hpp
+++ b/rocprim/include/rocprim/block/detail/block_histogram_sort.hpp
@@ -103,14 +103,10 @@ public:
         ::rocprim::syncthreads(); // Fix race condition that appeared on Vega10 hardware, storage LDS is reused below.
 
         ROCPRIM_UNROLL
-        for(unsigned int offset = 0; offset < Bins; offset += BlockSize)
+        for(unsigned int offset = 0; offset + flat_tid < Bins; offset += BlockSize)
         {
-            const unsigned int offset_tid = offset + flat_tid;
-            if(offset_tid < Bins)
-            {
-                storage_.start[offset_tid] = tile_size;
-                storage_.end[offset_tid] = tile_size;
-            }
+            storage_.start[offset + flat_tid] = tile_size;
+            storage_.end[offset + flat_tid] = tile_size;
         }
         ::rocprim::syncthreads();
 


### PR DESCRIPTION
This change implements a workaround to fix block_histogram while we wait for a compiler fix.

The block_histogram_sort algorithm contains a loop that initializes values in a shared memory struct. Then it runs the flag_heads() algorithm using that struct. It appear that in some cases, the optimizer is reordering things such that shared memory writes in flag_heads() run before the loop initialization code completes.

Changing the loop condition and removing the inner "if" statement seems to prevent the optimizer from doing this. From an algorithmic standpoint, this should be functionally equivalent to the way the code was before the change.