### PR TITLE
Fix Windows CMake link issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,15 @@ find_package(rocprim REQUIRED CONFIG PATHS "/opt/rocm/rocprim")
 # to be linked manually by user
 target_link_libraries(<your_target> roc::rocprim)
 
-# Includes rocPRIM headers and required HIP dependencies
-target_link_libraries(<your_target> roc::rocprim_hip)
+# Include rocPRIM headers and required HIP dependencies
+# - If using HIP language support (USE_HIPCXX=ON):
+target_link_libraries(<your_target> hip::host)
+
+# - Otherwise:
+target_link_libraries(<your_target> hip::device)
 ```
+
+For more information on `hip::host` and `hip::device`, please see the [ROCm documentation](https://rocm.docs.amd.com/en/latest/conceptual/cmake-packages.html#consuming-the-hip-api-in-c-code).
 
 ## Running unit tests
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -87,6 +87,10 @@ function(add_rocprim_benchmark BENCHMARK_SOURCE)
       PRIVATE
       $<IF:$<LINK_LANGUAGE:HIP>,hip::host,hip::device>
     )
+  else()
+    target_link_libraries(${BENCHMARK_TARGET}
+      PRIVATE
+      hip::device)
   endif()
 
   target_compile_options(${BENCHMARK_TARGET}

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -38,6 +38,10 @@ function(add_rocprim_example EXAMPLE_SOURCE)
       PRIVATE
       $<IF:$<LINK_LANGUAGE:HIP>,hip::host,hip::device>
     )
+  else()
+    target_link_libraries(${EXAMPLE_TARGET}
+      PRIVATE
+      hip::device)
   endif()
   set_target_properties(${EXAMPLE_TARGET}
     PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,6 +81,10 @@ function(add_hip_test TEST_NAME TEST_SOURCES)
       PRIVATE
       $<IF:$<LINK_LANGUAGE:HIP>,hip::host,hip::device>
     )
+  else()
+    target_link_libraries(${TEST_TARGET}
+      PRIVATE
+      hip::device)
   endif()
 
   target_compile_options(${TEST_TARGET}

--- a/test/rocprim/CMakeLists.txt
+++ b/test/rocprim/CMakeLists.txt
@@ -60,6 +60,10 @@ function(add_rocprim_test_internal TEST_NAME TEST_SOURCES TEST_TARGET)
       PRIVATE
       $<IF:$<LINK_LANGUAGE:HIP>,hip::host,hip::device>
     )
+  else()
+    target_link_libraries(${TEST_TARGET}
+      PRIVATE
+      hip::device)
   endif()
 
   target_compile_options(${TEST_TARGET}


### PR DESCRIPTION
A recent cmake change added a condition check that avoids evaluating a LINK_LANGUAGE generator expression if HIP_USECXX is OFF (since LINK_LANGUAGE is unsupported in CMake < 3.18). However, it didn't account for the fact that the LINK_LANGUAGE expression is embedded in a conditional generator expression.

This change adds an "else" block that ensures the "false" side of the conditional generator expression is still evaluated when the LINK_LANGUAGE code is skipped. This fixes some build issues on Windows.