### PR TITLE
Remove gfx940 / gfx941 code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 
 ## rocPRIM 3.5.0 for ROCm 6.5.0
 
+### Removed
+* This release removes support for custom builds on gfx940 and gfx941.
+
 ### Added
 
 * Added gfx950 support.

--- a/rocprim/include/rocprim/config.hpp
+++ b/rocprim/include/rocprim/config.hpp
@@ -108,7 +108,7 @@
 // See https://llvm.org/docs/AMDGPUUsage.html#instructions
 #if defined(__gfx950__)
     #define ROCPRIM_TARGET_CDNA4 1
-#elif defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+#elif defined(__gfx942__)
     #define ROCPRIM_TARGET_CDNA3 1
 #elif defined(__gfx90a__)
     #define ROCPRIM_TARGET_CDNA2 1

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -47,7 +47,7 @@
 // cache.
 #ifndef ROCPRIM_DETAIL_LOOKBACK_SCAN_STATE_WITHOUT_SLOW_FENCES
     #if defined(__HIP_DEVICE_COMPILE__) \
-        && (defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__))
+        && (defined(__gfx942__) || defined(__gfx950__))
         #define ROCPRIM_DETAIL_LOOKBACK_SCAN_STATE_WITHOUT_SLOW_FENCES 1
     #else
         #define ROCPRIM_DETAIL_LOOKBACK_SCAN_STATE_WITHOUT_SLOW_FENCES 0

--- a/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -218,7 +218,7 @@ public:
         #else
         texture_type words[multiple];
 
-        #if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__)
+        #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__)
         #pragma message "Texture cache iterator is not supported on gfx94x, gfx120x or gfx95x as the texture fetch functions in HIP are not available."
         ROCPRIM_PRINT_ERROR_ONCE("WARNING: Usage of texture_cache_iterator on gfx94x, gfx120x or gfx95x devices is not supported and will not produce valid results.")
         #else

--- a/rocprim/include/rocprim/thread/thread_load.hpp
+++ b/rocprim/include/rocprim/thread/thread_load.hpp
@@ -109,9 +109,7 @@ T asm_thread_load(void* ptr)
     ROCPRIM_ASM_THREAD_LOAD(cache_modifier, llvm_cache_modifier, double, uint64_t, flat_load_dwordx2, v, wait_inst, wait_cmd);
     // clang-format on
 
-    #if defined(__gfx940__) || defined(__gfx941__)
-ROCPRIM_ASM_THREAD_LOAD_GROUP(load_cg, "sc1", "s_waitcnt", "");
-    #elif defined(__gfx942__) || defined(__gfx950__)
+    #if defined(__gfx942__) || defined(__gfx950__)
 ROCPRIM_ASM_THREAD_LOAD_GROUP(load_cg, "sc0 nt", "s_waitcnt", "");
     #elif defined(__gfx1200__) || defined(__gfx1201__)
 ROCPRIM_ASM_THREAD_LOAD_GROUP(load_cg, "th:TH_DEFAULT scope:SCOPE_DEV", "s_wait_loadcnt_dscnt", "");

--- a/rocprim/include/rocprim/thread/thread_store.hpp
+++ b/rocprim/include/rocprim/thread/thread_store.hpp
@@ -107,9 +107,7 @@ void asm_thread_store(void* ptr, T val)
     ROCPRIM_ASM_THREAD_STORE(cache_modifier, llvm_cache_modifier, double, uint64_t, flat_store_dwordx2, v, wait_inst, wait_cmd);
     // clang-format on
 
-    #if defined(__gfx940__) || defined(__gfx941__)
-ROCPRIM_ASM_THREAD_STORE_GROUP(store_cg, "sc0 sc1", "s_waitcnt", "");
-    #elif defined(__gfx942__) || defined(__gfx950__)
+    #if defined(__gfx942__) || defined(__gfx950__)
 ROCPRIM_ASM_THREAD_STORE_GROUP(store_cg, "sc0 nt", "s_waitcnt", "");
     #elif defined(__gfx1200__) || defined(__gfx1201__)
 ROCPRIM_ASM_THREAD_STORE_GROUP(store_cg,


### PR DESCRIPTION
Moving forward we will no longer support custom builds for gfx940 and gfx941. This change removes code that references those architectures.