### PR TITLE
Fix static assertion for int128 in ONNX Runtime with GNU extensions

### DIFF
--- a/test/rocprim/CMakeLists.txt
+++ b/test/rocprim/CMakeLists.txt
@@ -214,20 +214,26 @@ ${TEST_TYPE_SLICE_COUNT} test type slice(s) for test target ${TEST_TARGET}")
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${SOURCES})
 endfunction()
 
-function(add_rocprim_cpp17_test TEST_NAME TEST_SOURCES)
-  add_rocprim_test(${TEST_NAME} ${TEST_SOURCES})
+function(add_rocprim_cpp_standard_test STANDARD EXTENSIONS TARGET_SUFFIX TEST_NAME TEST_SOURCES)
   get_rocprim_test_target(${TEST_SOURCES} TEST_TARGET)
+  set(TEST_TARGET ${TEST_TARGET}${TARGET_SUFFIX})
+  add_rocprim_test_internal(${TEST_NAME}${TARGET_SUFFIX} "${TEST_SOURCES}" ${TEST_TARGET})
   # Request C++ standard 17, but decay to a previous version if not available:
   set_target_properties(${TEST_TARGET}
     PROPERTIES
-    CXX_STANDARD 17)
+    CXX_STANDARD ${STANDARD}
+    CXX_EXTENSIONS ${EXTENSIONS})
   if(USE_HIPCXX)
     set_target_properties(${TEST_TARGET}
       PROPERTIES
-      HIP_STANDARD 17)
+      HIP_STANDARD ${STANDARD}
+      HIP_EXTENSIONS ${EXTENSIONS})
   endif()
 endfunction()
 
+function(add_rocprim_cpp17_test TEST_NAME TEST_SOURCES)
+  add_rocprim_cpp_standard_test(17 OFF "" ${TEST_NAME} ${TEST_SOURCES})
+endfunction()
 
 # ****************************************************************************
 # Tests
@@ -294,7 +300,12 @@ add_rocprim_test("rocprim.texture_cache_iterator" test_texture_cache_iterator.cp
 add_rocprim_test("rocprim.thread" test_thread.cpp)
 add_rocprim_test("rocprim.thread_algos" test_thread_algos.cpp)
 add_rocprim_test("rocprim.transform_iterator" test_transform_iterator.cpp)
-add_rocprim_test("rocprim.type_traits_interface" test_type_traits_interface.cpp)
+add_rocprim_cpp_standard_test(14 OFF "_cpp14" "rocprim.type_traits_interface" test_type_traits_interface.cpp)
+add_rocprim_cpp_standard_test(14 ON "_gnupp14" "rocprim.type_traits_interface" test_type_traits_interface.cpp)
+add_rocprim_cpp_standard_test(17 OFF "_cpp17" "rocprim.type_traits_interface" test_type_traits_interface.cpp)
+add_rocprim_cpp_standard_test(17 ON "_gnupp17" "rocprim.type_traits_interface" test_type_traits_interface.cpp)
+add_rocprim_cpp_standard_test(20 OFF "_cpp20" "rocprim.type_traits_interface" test_type_traits_interface.cpp)
+add_rocprim_cpp_standard_test(20 ON "_gnupp20" "rocprim.type_traits_interface" test_type_traits_interface.cpp)
 add_rocprim_test("rocprim.no_half_operators" test_no_half_operators.cpp)
 add_rocprim_test("rocprim.intrinsics" test_intrinsics.cpp)
 add_rocprim_test("rocprim.intrinsics_atomic" test_intrinsics_atomic.cpp)


### PR DESCRIPTION
This is a cherry-pick of a StreamHPC [commit](https://github.com/ROCm/rocPRIM/pull/678/commits/b241d4099112bb402b251c4855d217febcd6b4e2) in #678 that resolves a compile-time issue encountered when building ONNX Runtime with GNU extensions. It works around the fact that `std::is_arithmetic<rocprim::int128_t>` returns different results in different compilation environments.