### PR TITLE
Support getting device ID from stream hipStreamLegacy

### DIFF
--- a/rocprim/include/rocprim/device/config_types.hpp
+++ b/rocprim/include/rocprim/device/config_types.hpp
@@ -350,7 +350,7 @@ inline hipError_t get_device_arch(int device_id, target_arch& arch)
 inline hipError_t get_device_from_stream(const hipStream_t stream, int& device_id)
 {
     static constexpr hipStream_t default_stream = 0;
-    if(stream == default_stream || stream == hipStreamPerThread)
+    if(stream == default_stream || stream == hipStreamPerThread || stream == hipStreamLegacy)
     {
         const hipError_t result = hipGetDevice(&device_id);
         if(result != hipSuccess)


### PR DESCRIPTION
rocprim::get_device_from_stream must retreive the device ID in different ways depending on whether a user-created stream or a built-in stream type is being used.

This change modifies the check for built-in stream types so that it includes hipStreamLegacy. This prevents the function from calling `hipGetStreamDeviceId(hipStreamLegacy)`, which currently causes a segmentation fault.

It also allows hipStreamLegacy to be used in rocThrust API calls that require retrieving the device ID.