### PR TITLE
Accept hip stream legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Fixed incorrect 128-bit signed and unsigned integers type traits.
 * Fixed compilation issue when `rocprim::radix_key_codec<...>` is specialized with a 128-bit integer.
 * Fixed the warp-level reduction `rocprim::warp_reduce.reduce` DPP implementation to avoid undefined intermediate values during the reduction.
+* Fixed an issue that was causing a segmentation fault when hipStreamLegacy was passed to some API functions.
 
 ### Upcoming changes
 * Using the initialisation constructor of `rocprim::reverse_iterator` will throw a deprecation warning. It will be marked as explicit in the next major release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Fixed incorrect 128-bit signed and unsigned integers type traits.
 * Fixed compilation issue when `rocprim::radix_key_codec<...>` is specialized with a 128-bit integer.
 * Fixed the warp-level reduction `rocprim::warp_reduce.reduce` DPP implementation to avoid undefined intermediate values during the reduction.
-* Fixed an issue that was causing a segmentation fault when hipStreamLegacy was passed to some API functions.
+* Fixed an issue that caused a segmentation fault when `hipStreamLegacy` was passed to some API functions.
 
 ### Upcoming changes
 * Using the initialisation constructor of `rocprim::reverse_iterator` will throw a deprecation warning. It will be marked as explicit in the next major release.

--- a/rocprim/include/rocprim/device/config_types.hpp
+++ b/rocprim/include/rocprim/device/config_types.hpp
@@ -350,7 +350,7 @@ inline hipError_t get_device_arch(int device_id, target_arch& arch)
 inline hipError_t get_device_from_stream(const hipStream_t stream, int& device_id)
 {
     static constexpr hipStream_t default_stream = 0;
-    if(stream == default_stream || stream == hipStreamPerThread)
+    if(stream == default_stream || stream == hipStreamPerThread || stream == hipStreamLegacy)
     {
         const hipError_t result = hipGetDevice(&device_id);
         if(result != hipSuccess)

--- a/rocprim/include/rocprim/device/config_types.hpp
+++ b/rocprim/include/rocprim/device/config_types.hpp
@@ -350,7 +350,15 @@ inline hipError_t get_device_arch(int device_id, target_arch& arch)
 inline hipError_t get_device_from_stream(const hipStream_t stream, int& device_id)
 {
     static constexpr hipStream_t default_stream = 0;
-    if(stream == default_stream || stream == hipStreamPerThread || stream == hipStreamLegacy)
+
+    // hipStreamLegacy is supported in HIP >= 6.1.0
+#if (HIP_VERSION_MAJOR >= 6 && HIP_VERSION_MINOR >= 1)
+    const bool is_legacy_stream = (stream == hipStreamLegacy);
+#else
+    const bool is_legacy_stream = false;
+#endif
+
+    if (stream == default_stream || stream == hipStreamPerThread || is_legacy_stream);
     {
         const hipError_t result = hipGetDevice(&device_id);
         if(result != hipSuccess)

--- a/test/rocprim/test_config_dispatch.cpp
+++ b/test/rocprim/test_config_dispatch.cpp
@@ -98,6 +98,12 @@ TEST(RocprimConfigDispatchTests, DeviceIdFromStream)
     HIP_CHECK(get_device_from_stream(hipStreamPerThread, result));
     ASSERT_EQ(result, device_id);
 
+    // hipStreamLegacy support was added in ROCm 6.1.0
+#if (HIP_VERSION_MAJOR >= 6 && HIP_VERSION_MINOR >= 1)
+    HIP_CHECK(get_device_from_stream(hipStreamLegacy, result));
+    ASSERT_EQ(result, device_id);
+#endif
+
     hipStream_t stream;
     HIP_CHECK(hipStreamCreate(&stream));
     HIP_CHECK(get_device_from_stream(stream, result));


### PR DESCRIPTION
Support getting device ID from stream hipStreamLegacy

When you pass a stream handle to rocprim::get_device_from_stream,
it must check to see if it is a user-created or built-in stream. For user-created
streams, the device ID must be retrieved using hipGetStreamDeviceId.
For built-in stream handles, it can be retrieved using hipGetDevice.

This change modifies the check for built-in stream types so that
it includes hipStreamLegacy. This prevents the function from
calling hipGetStreamDeviceId(hipStreamLegacy), which currently
causes a segmentation fault.

The check for hipStreamLegacy is only compiled if we're running
HIP >= 6.1.0, since that's where the stream handle constant was added.

It also adds a test case for get_device_from_stream that exercises
this scenario.