### PR TITLE
Warn about upcoming scan accumulator default type change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,28 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Fixed device radix sort not returning the correct required temporary storage when a double buffer contains `nullptr`.
 * Fixed constness of equality operators (`==` and `!=`) in `rocprim::key_value_pair`.
 
+### Upcoming changes
+
+* The default scan accumulator types for device-level scan algorithms will be changed. This is a breaking change.
+
+Previously, the default accumulator type was set to the input type for inclusive scans and to the initial value type for exclusive scans. These default types could cause unexpected overflow in situations where the input or initial type is smaller than the output type when the user doesn't explicitly set an accumulator type using the `AccType` template parameter.
+
+The new default types will be set to the type that results when the input or initial value type is applied to the scan operator. 
+
+The following is the complete list of affected functions and how their default accumulator types are changing:
+  * `rocprim::inclusive_scan`
+    * current default: `class AccType = typename std::iterator_traits<InputIterator>::value_type>`
+    * future default: `class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>`
+  * `rocprim::deterministic_inclusive_scan`
+    * current default: `class AccType = typename std::iterator_traits<InputIterator>::value_type>`
+    * future default: `class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>`
+  * `rocprim::exclusive_scan`
+    * current default: `class AccType = detail::input_type_t<InitValueType>>`
+    * future default: `class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>`
+  * `rocprim::deterministic_exclusive_scan`
+    * current default: `class AccType = detail::input_type_t<InitValueType>>`
+    * future default: `class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>`
+
 ### Deprecations
 
 * `rocprim::load_cs` and `rocprim::store_cs` are deprecated. Use `rocprim::load_nontemporal` and `rocprim::store_nontemporal` now.


### PR DESCRIPTION
In the next major release, we'll be modifying the default scan accumulator type for device-level scan algorithms.

Add a note to the changelog to warn users that this change will be coming soon, and describe how the default type will be changed.