### PR TITLE
Add macros for 128-bit atomic loads/stores on gfx950

### DIFF
--- a/rocprim/include/rocprim/config.hpp
+++ b/rocprim/include/rocprim/config.hpp
@@ -103,9 +103,12 @@
 #undef ROCPRIM_TARGET_CDNA1
 #undef ROCPRIM_TARGET_CDNA2
 #undef ROCPRIM_TARGET_CDNA3
+#undef ROCPRIM_TARGET_CDNA4
 
 // See https://llvm.org/docs/AMDGPUUsage.html#instructions
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+#if defined(__gfx950__)
+    #define ROCPRIM_TARGET_CDNA4 1
+#elif defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     #define ROCPRIM_TARGET_CDNA3 1
 #elif defined(__gfx90a__)
     #define ROCPRIM_TARGET_CDNA2 1

--- a/rocprim/include/rocprim/intrinsics/atomic.hpp
+++ b/rocprim/include/rocprim/intrinsics/atomic.hpp
@@ -170,7 +170,7 @@ namespace detail
 #define ROCPRIM_ATOMIC_LOAD(inst, mod, wait, ptr) \
     asm volatile(inst " %0, %1 " mod "\t\n" wait : "=v"(result) : "v"(ptr) : "memory")
 
-#if ROCPRIM_TARGET_CDNA3
+#if ROCPRIM_TARGET_CDNA4 || ROCPRIM_TARGET_CDNA3
     #define ROCPRIM_ATOMIC_LOAD_FLAT(ptr) \
         ROCPRIM_ATOMIC_LOAD("flat_load_dwordx4", "sc1", "s_waitcnt vmcnt(0)", ptr)
     #define ROCPRIM_ATOMIC_LOAD_SHARED(ptr) \
@@ -280,7 +280,7 @@ namespace detail
 #define ROCPRIM_ATOMIC_STORE(inst, mod, wait, ptr) \
     asm volatile(inst " %0, %1 " mod "\t\n" wait : : "v"(ptr), "v"(value) : "memory")
 
-#if ROCPRIM_TARGET_CDNA3
+#if ROCPRIM_TARGET_CDNA4 || ROCPRIM_TARGET_CDNA3
     #define ROCPRIM_ATOMIC_STORE_FLAT(ptr) \
         ROCPRIM_ATOMIC_STORE("flat_store_dwordx4", "sc1", "s_waitcnt vmcnt(0)", ptr)
     #define ROCPRIM_ATOMIC_STORE_SHARED(ptr) \


### PR DESCRIPTION
This change adds an architecture macro for gfx950 in rocprim/config.hpp, then uses it to define ROCPRIM_ATOMIC_LOAD/STORE macros for 128-bit atomic loads on gfx950.