### PR TITLE
Add workaround for printing 128-bit types in gtest for windows

### DIFF
--- a/test/common_test_header.hpp
+++ b/test/common_test_header.hpp
@@ -62,7 +62,7 @@
     }
 
 #ifndef ROCPRIM_HAS_INT128_SUPPORT
-    //#define ROCPRIM_HAS_INT128_SUPPORT 1
+    #define ROCPRIM_HAS_INT128_SUPPORT 1
 #endif
 
 #define INSTANTIATE_TYPED_TEST_EXPANDED_1(line, test_suite_name, ...)         \

--- a/test/common_test_header.hpp
+++ b/test/common_test_header.hpp
@@ -62,7 +62,7 @@
     }
 
 #ifndef ROCPRIM_HAS_INT128_SUPPORT
-    #define ROCPRIM_HAS_INT128_SUPPORT 1
+    //#define ROCPRIM_HAS_INT128_SUPPORT 1
 #endif
 
 #define INSTANTIATE_TYPED_TEST_EXPANDED_1(line, test_suite_name, ...)         \

--- a/test/rocprim/test_utils_assertions.hpp
+++ b/test/rocprim/test_utils_assertions.hpp
@@ -155,7 +155,22 @@ void assert_eq(const T& result, const T& expected)
 {
     if(bit_equal(result, expected))
         return; // Check bitwise equality for +NaN, -NaN, +0.0, -0.0, +inf, -inf.
+#if defined(_WIN32)
+	// GTest's ASSERT_EQ prints the values if the test fails. On Windows, the version of GTest provided by vcpkg doesn't
+	// provide overloads for printing 128 bit types, resulting in linker errors.
+	// Check if we're testing with 128 bit types. If so, test using bools so GTest doesn't try to print them on failure.
+	if (test_utils::is_int128<T>::value || test_utils::is_uint128<T>::value)
+	{
+		const bool values_equal = (result == expected);
+		ASSERT_EQ(values_equal, true);
+	}
+	else
+	{
+		ASSERT_EQ(result, expected);
+	}
+#else		
     ASSERT_EQ(result, expected);
+#endif
 }
 
 template<class T>

--- a/test/rocprim/test_utils_assertions.hpp
+++ b/test/rocprim/test_utils_assertions.hpp
@@ -73,7 +73,22 @@ void assert_eq(const std::vector<T>& result,
     {
         if(bit_equal(result[i], expected[i]))
             continue; // Check bitwise equality for +NaN, -NaN, +0.0, -0.0, +inf, -inf.
+#if defined(_WIN32)
+        // GTest's ASSERT_EQ prints the values if the test fails. On Windows, the version of GTest provided by vcpkg doesn't
+        // provide overloads for printing 128 bit types, resulting in linker errors.
+        // Check if we're testing with 128 bit types. If so, test using bools so GTest doesn't try to print them on failure.
+        if (test_utils::is_int128<T>::value || test_utils::is_uint128<T>::value)
+        {
+            const bool values_equal = (result[i] == expected[i]);
+            ASSERT_EQ(values_equal, true) << "where index = " << i;
+        }
+        else
+        {
+            ASSERT_EQ(result[i], expected[i]) << "where index = " << i;
+        }
+#else
         ASSERT_EQ(result[i], expected[i]) << "where index = " << i;
+#endif		
     }
 }
 
@@ -90,7 +105,22 @@ void assert_eq(const std::vector<common::custom_type<T, T, true>>& result,
     {
         if(bit_equal(result[i].x, expected[i].x) && bit_equal(result[i].y, expected[i].y))
             continue; // Check bitwise equality for +NaN, -NaN, +0.0, -0.0, +inf, -inf.
+#if defined(_WIN32)
+        // GTest's ASSERT_EQ prints the values if the test fails. On Windows, the version of GTest provided by vcpkg doesn't
+        // provide overloads for printing 128 bit types, resulting in linker errors.
+        // Check if we're testing with 128 bit types. If so, test using bools so GTest doesn't try to print them on failure.
+        if (sizeof(T) >= 8)
+        {
+            const bool values_equal = (result[i] == expected[i]);
+            ASSERT_EQ(values_equal, true) << "where index = " << i;
+        }
+        else
+        {
+            ASSERT_EQ(result[i], expected[i]) << "where index = " << i;
+        }
+#else
         ASSERT_EQ(result[i], expected[i]) << "where index = " << i;
+#endif		
     }
 }
 

--- a/test/rocprim/test_utils_assertions.hpp
+++ b/test/rocprim/test_utils_assertions.hpp
@@ -68,7 +68,9 @@ void assert_eq(const std::vector<T>& result,
                const size_t          max_length = SIZE_MAX)
 {
     if(max_length == SIZE_MAX || max_length > expected.size())
+    {
         ASSERT_EQ(result.size(), expected.size());
+    }
     for(size_t i = 0; i < std::min(result.size(), max_length); i++)
     {
         if(bit_equal(result[i], expected[i]))
@@ -77,7 +79,7 @@ void assert_eq(const std::vector<T>& result,
         // GTest's ASSERT_EQ prints the values if the test fails. On Windows, the version of GTest provided by vcpkg doesn't
         // provide overloads for printing 128 bit types, resulting in linker errors.
         // Check if we're testing with 128 bit types. If so, test using bools so GTest doesn't try to print them on failure.
-        if (test_utils::is_int128<T>::value || test_utils::is_uint128<T>::value)
+        if (test_utils::is_int128<T>::value || test_utils::is_uint128<T>::value || (typeid(T) == typeid(common::custom_type<double,double,1>)))
         {
             const bool values_equal = (result[i] == expected[i]);
             ASSERT_EQ(values_equal, true) << "where index = " << i;
@@ -109,15 +111,8 @@ void assert_eq(const std::vector<common::custom_type<T, T, true>>& result,
         // GTest's ASSERT_EQ prints the values if the test fails. On Windows, the version of GTest provided by vcpkg doesn't
         // provide overloads for printing 128 bit types, resulting in linker errors.
         // Check if we're testing with 128 bit types. If so, test using bools so GTest doesn't try to print them on failure.
-        if (sizeof(T) >= 8)
-        {
-            const bool values_equal = (result[i] == expected[i]);
-            ASSERT_EQ(values_equal, true) << "where index = " << i;
-        }
-        else
-        {
-            ASSERT_EQ(result[i], expected[i]) << "where index = " << i;
-        }
+		const bool values_equal = (result[i] == expected[i]);
+		ASSERT_EQ(values_equal, true) << "where index = " << i;
 #else
         ASSERT_EQ(result[i], expected[i]) << "where index = " << i;
 #endif		

--- a/test/rocprim/test_utils_assertions.hpp
+++ b/test/rocprim/test_utils_assertions.hpp
@@ -111,8 +111,8 @@ void assert_eq(const std::vector<common::custom_type<T, T, true>>& result,
         // GTest's ASSERT_EQ prints the values if the test fails. On Windows, the version of GTest provided by vcpkg doesn't
         // provide overloads for printing 128 bit types, resulting in linker errors.
         // Check if we're testing with 128 bit types. If so, test using bools so GTest doesn't try to print them on failure.
-		const bool values_equal = (result[i] == expected[i]);
-		ASSERT_EQ(values_equal, true) << "where index = " << i;
+        const bool values_equal = (result[i] == expected[i]);
+        ASSERT_EQ(values_equal, true) << "where index = " << i;
 #else
         ASSERT_EQ(result[i], expected[i]) << "where index = " << i;
 #endif		
@@ -156,18 +156,18 @@ void assert_eq(const T& result, const T& expected)
     if(bit_equal(result, expected))
         return; // Check bitwise equality for +NaN, -NaN, +0.0, -0.0, +inf, -inf.
 #if defined(_WIN32)
-	// GTest's ASSERT_EQ prints the values if the test fails. On Windows, the version of GTest provided by vcpkg doesn't
-	// provide overloads for printing 128 bit types, resulting in linker errors.
-	// Check if we're testing with 128 bit types. If so, test using bools so GTest doesn't try to print them on failure.
-	if (test_utils::is_int128<T>::value || test_utils::is_uint128<T>::value)
-	{
-		const bool values_equal = (result == expected);
-		ASSERT_EQ(values_equal, true);
+    // GTest's ASSERT_EQ prints the values if the test fails. On Windows, the version of GTest provided by vcpkg doesn't
+    // provide overloads for printing 128 bit types, resulting in linker errors.
+    // Check if we're testing with 128 bit types. If so, test using bools so GTest doesn't try to print them on failure.
+    if (test_utils::is_int128<T>::value || test_utils::is_uint128<T>::value)
+    {
+        const bool values_equal = (result == expected);
+        ASSERT_EQ(values_equal, true);
 	}
-	else
-	{
-		ASSERT_EQ(result, expected);
-	}
+    else
+    {
+        ASSERT_EQ(result, expected);
+    }
 #else		
     ASSERT_EQ(result, expected);
 #endif

--- a/test/rocprim/test_utils_data_generation.hpp
+++ b/test/rocprim/test_utils_data_generation.hpp
@@ -25,6 +25,8 @@
 #include "../../common/utils_custom_type.hpp"
 #include "../../common/utils_data_generation.hpp"
 
+#include "../common_test_header.hpp"
+
 #include "test_seed.hpp"
 #include "test_utils_custom_float_traits_type.hpp"
 #include "test_utils_custom_float_type.hpp"
@@ -579,6 +581,18 @@ std::vector<size_t> get_block_size_multiples(T seed_value, const unsigned int bl
     std::set<size_t> unique_sizes(sizes.begin(), sizes.end());
     return std::vector<size_t>(unique_sizes.begin(), unique_sizes.end());
 }
+
+#if ROCPRIM_HAS_INT128_SUPPORT
+template<class T>
+using is_int128 = std::is_same<__int128_t, typename std::remove_cv<T>::type>;
+template<class T>
+using is_uint128 = std::is_same<__uint128_t, typename std::remove_cv<T>::type>;
+#else
+template<class T>
+using is_int128 = std::false_type;
+template<class T>
+using is_uint128 = std::false_type;
+#endif // ROCPRIM_HAS_INT128_SUPPORT
 
 } // namespace test_utils
 

--- a/test/rocprim/test_utils_data_generation.hpp
+++ b/test/rocprim/test_utils_data_generation.hpp
@@ -584,9 +584,9 @@ std::vector<size_t> get_block_size_multiples(T seed_value, const unsigned int bl
 
 #if ROCPRIM_HAS_INT128_SUPPORT
 template<class T>
-using is_int128 = std::is_same<__int128_t, typename std::remove_cv<T>::type>;
+using is_int128 = std::is_same<rocprim::int128_t, typename std::remove_cv<T>::type>;
 template<class T>
-using is_uint128 = std::is_same<__uint128_t, typename std::remove_cv<T>::type>;
+using is_uint128 = std::is_same<rocprim::uint128_t, typename std::remove_cv<T>::type>;
 #else
 template<class T>
 using is_int128 = std::false_type;


### PR DESCRIPTION
See https://github.com/ROCm/hipCUB/pull/462.