### PR TITLE
Fix linking issue in thread_load

### DIFF
--- a/rocprim/include/rocprim/thread/thread_load.hpp
+++ b/rocprim/include/rocprim/thread/thread_load.hpp
@@ -69,7 +69,7 @@ namespace detail
 {
 
 template<cache_load_modifier CacheLoadModifier = load_default, typename T>
-ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+ROCPRIM_DEVICE ROCPRIM_INLINE
 T asm_thread_load(void* ptr)
 {
     T retval{};
@@ -81,23 +81,23 @@ T asm_thread_load(void* ptr)
 
     // Important for syncing. Check section 9.2.2 or 7.3 in the following document
     // http://developer.amd.com/wordpress/media/2013/12/AMD_GCN3_Instruction_Set_Architecture_rev1.1.pdf
-    #define ROCPRIM_ASM_THREAD_LOAD(cache_modifier,                                               \
-                                    llvm_cache_modifier,                                          \
-                                    type,                                                         \
-                                    interim_type,                                                 \
-                                    asm_operator,                                                 \
-                                    output_modifier,                                              \
-                                    wait_inst,                                                    \
-                                    wait_cmd)                                                     \
-        template<>                                                                                \
-        ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE type asm_thread_load<cache_modifier, type>(void* ptr) \
-        {                                                                                         \
-            interim_type retval;                                                                  \
-            asm volatile(#asm_operator " %0, %1 " llvm_cache_modifier "\n\t" wait_inst wait_cmd   \
-                                       "(%2)"                                                     \
-                         : "=" #output_modifier(retval)                                           \
-                         : "v"(ptr), "I"(0x00));                                                  \
-            return *bit_cast<type*>(&retval);                                                     \
+    #define ROCPRIM_ASM_THREAD_LOAD(cache_modifier,                                             \
+                                    llvm_cache_modifier,                                        \
+                                    type,                                                       \
+                                    interim_type,                                               \
+                                    asm_operator,                                               \
+                                    output_modifier,                                            \
+                                    wait_inst,                                                  \
+                                    wait_cmd)                                                   \
+        template<>                                                                              \
+        ROCPRIM_DEVICE ROCPRIM_INLINE type asm_thread_load<cache_modifier, type>(void* ptr)     \
+        {                                                                                       \
+            interim_type retval;                                                                \
+            asm volatile(#asm_operator " %0, %1 " llvm_cache_modifier "\n\t" wait_inst wait_cmd \
+                                       "(%2)"                                                   \
+                         : "=" #output_modifier(retval)                                         \
+                         : "v"(ptr), "I"(0x00));                                                \
+            return *bit_cast<type*>(&retval);                                                   \
         }
 
     // TODO Add specialization for custom larger data types


### PR DESCRIPTION
The `ROCPRIM_FORCE_INLINE` is not necessary and gives some linking issues.