### PR TITLE
The assert fix for block_radix_sort <cherry-picked from develop> (#714)

### DIFF
--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -164,7 +164,7 @@ public:
         ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     block_radix_sort()
     {
-        assert(BlockSize % ::rocprim::arch::wavefront::size() == 0);
+        assert(!warp_striped || BlockSize % ::rocprim::arch::wavefront::size() == 0);
     }
 
     /// \brief Performs ascending radix sort over keys partitioned across threads in a block.


### PR DESCRIPTION
Fix for an unnecessary triggering assert. The assert is necessary, but only for block_radix_rank_algorithm::match, the same as the static_assert.