### PR TITLE
Change device scan default accumulator type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,23 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 
 ### Changed
 
-* The default scan accumulator types for device-level scan algorithms has be changed. This is a breaking change.
-The previous default accumulator types could lead to situations in which unexpected overflow occured (for example,
-if the input or inital type were smaller than the output type).
+* The default scan accumulator types for device-level scan algorithms have changed. This is a breaking change.
+The previous default accumulator types could lead to situations in which unexpected overflow occured, such as
+when the input or inital type was smaller than the output type.
 
-The following is the complete list of affected functions and how their default accumulator types are changing:
+This is a complete list of affected functions and how their default accumulator types are changing:
   * `rocprim::inclusive_scan`
-    * current default: `class AccType = typename std::iterator_traits<InputIterator>::value_type>`
-    * future default: `class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>`
+    * past default: `class AccType = typename std::iterator_traits<InputIterator>::value_type>`
+    * new default: `class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>`
   * `rocprim::deterministic_inclusive_scan`
-    * current default: `class AccType = typename std::iterator_traits<InputIterator>::value_type>`
-    * future default: `class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>`
+    * past default: `class AccType = typename std::iterator_traits<InputIterator>::value_type>`
+    * new default: `class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>`
   * `rocprim::exclusive_scan`
-    * current default: `class AccType = detail::input_type_t<InitValueType>>`
-    * future default: `class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>`
+    * past default: `class AccType = detail::input_type_t<InitValueType>>`
+    * new default: `class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>`
   * `rocprim::deterministic_exclusive_scan`
-    * current default: `class AccType = detail::input_type_t<InitValueType>>`
-    * future default: `class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>`
+    * past default: `class AccType = detail::input_type_t<InitValueType>>`
+    * new default: `class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>`
 
 ## rocPRIM 3.5.0 for ROCm 6.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projects/rocPRIM/en/latest/](https://rocm.docs.amd.com/projects/rocPRIM/en/latest/).
 
+## rocPRIM 3.6.0 for ROCm 7.0
+
+### Changed
+
+* The default scan accumulator types for device-level scan algorithms has be changed. This is a breaking change.
+The previous default accumulator types could lead to situations in which unexpected overflow occured (for example,
+if the input or inital type were smaller than the output type).
+
+The following is the complete list of affected functions and how their default accumulator types are changing:
+  * `rocprim::inclusive_scan`
+    * current default: `class AccType = typename std::iterator_traits<InputIterator>::value_type>`
+    * future default: `class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>`
+  * `rocprim::deterministic_inclusive_scan`
+    * current default: `class AccType = typename std::iterator_traits<InputIterator>::value_type>`
+    * future default: `class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>`
+  * `rocprim::exclusive_scan`
+    * current default: `class AccType = detail::input_type_t<InitValueType>>`
+    * future default: `class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>`
+  * `rocprim::deterministic_exclusive_scan`
+    * current default: `class AccType = detail::input_type_t<InitValueType>>`
+    * future default: `class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>`
+
 ## rocPRIM 3.5.0 for ROCm 6.5.0
 
 ### Removed

--- a/rocprim/include/rocprim/device/device_scan.hpp
+++ b/rocprim/include/rocprim/device/device_scan.hpp
@@ -403,8 +403,8 @@ inline auto scan_impl(void*               temporary_storage,
 /// requirements of a C++ OutputIterator concept. It can be a simple pointer type.
 /// \tparam BinaryFunction type of binary function used for scan. Default type
 /// is \p rocprim::plus<T>, where \p T is a \p value_type of \p InputIterator.
-/// \tparam AccType accumulator type used to propagate the scanned values. Default type
-/// is value type of the input iterator.
+/// \tparam AccType accumulator type used to propagate the scanned values. The default is the type that
+/// is returned by a function of type BinaryFunction when it's is passed an InputIterator value.
 ///
 /// \param [in] temporary_storage pointer to a device-accessible temporary storage. When
 /// a null pointer is passed, the required allocation size (in bytes) is written to
@@ -495,7 +495,7 @@ template<class Config = default_config,
          class OutputIterator,
          class BinaryFunction
          = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>,
-         class AccType = typename std::iterator_traits<InputIterator>::value_type>
+         class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>>
 inline hipError_t inclusive_scan(void*             temporary_storage,
                                  size_t&           storage_size,
                                  InputIterator     input,
@@ -536,7 +536,7 @@ template<class Config = default_config,
          class OutputIterator,
          class BinaryFunction
          = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>,
-         class AccType = typename std::iterator_traits<InputIterator>::value_type>
+         class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>>
 inline hipError_t deterministic_inclusive_scan(void*             temporary_storage,
                                                size_t&           storage_size,
                                                InputIterator     input,
@@ -590,8 +590,8 @@ inline hipError_t deterministic_inclusive_scan(void*             temporary_stora
 /// \tparam InitValueType type of the initial value.
 /// \tparam BinaryFunction type of binary function used for scan. Default type
 /// is \p rocprim::plus<T>, where \p T is a \p value_type of \p InputIterator.
-/// \tparam AccType accumulator type used to propagate the scanned values. Default type
-/// is 'InitValueType', unless it's 'rocprim::future_value'. Then it will be the wrapped input type.
+/// \tparam AccType accumulator type used to propagate the scanned values. The default is the type that
+/// is returned by a function of type BinaryFunction when it's is passed a value of type InitValueType.
 ///
 /// \param [in] temporary_storage pointer to a device-accessible temporary storage. When
 /// a null pointer is passed, the required allocation size (in bytes) is written to
@@ -661,7 +661,7 @@ template<class Config = default_config,
          class InitValueType,
          class BinaryFunction
          = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>,
-         class AccType = detail::input_type_t<InitValueType>>
+         class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>>
 inline hipError_t exclusive_scan(void*               temporary_storage,
                                  size_t&             storage_size,
                                  InputIterator       input,
@@ -703,7 +703,7 @@ template<class Config = default_config,
          class InitValueType,
          class BinaryFunction
          = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>,
-         class AccType = detail::input_type_t<InitValueType>>
+         class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>>
 inline hipError_t deterministic_exclusive_scan(void*               temporary_storage,
                                                size_t&             storage_size,
                                                InputIterator       input,

--- a/test/rocprim/test_utils.hpp
+++ b/test/rocprim/test_utils.hpp
@@ -273,7 +273,7 @@ template<class InputIt, class OutputIt, class BinaryOperation>
 OutputIt host_inclusive_scan(InputIt first, InputIt last,
                              OutputIt d_first, BinaryOperation op)
 {
-    using acc_type = typename std::iterator_traits<InputIt>::value_type;
+    using acc_type = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIt>::value_type, BinaryOperation>;
     return host_inclusive_scan_impl(first, last, d_first, op, acc_type{});
 }
 
@@ -313,7 +313,7 @@ OutputIt host_exclusive_scan(InputIt first, InputIt last,
                              T initial_value, OutputIt d_first,
                              BinaryOperation op)
 {
-    using acc_type = typename std::iterator_traits<InputIt>::value_type;
+    using acc_type = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<T>, BinaryOperation>;
     return host_exclusive_scan_impl(first, last, initial_value, d_first, op, acc_type{});
 }
 


### PR DESCRIPTION
The default accumulator types are changing for ROCm 7.0 as described below. Note that this is a breaking change.
  * rocprim::inclusive_scan
    * previous default: class AccType = typename std::iterator_traits<InputIterator>::value_type>
    * new default: class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>`
  * `rocprim::deterministic_inclusive_scan
    * previous default: class AccType = typename std::iterator_traits<InputIterator>::value_type>`
    * new default: class AccType = rocprim::invoke_result_binary_op_t<typename std::iterator_traits<InputIterator>::value_type, BinaryFunction>`
  * `rocprim::exclusive_scan
    * previous default: class AccType = detail::input_type_t<InitValueType>>
    * new default: class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>
  * `rocprim::deterministic_exclusive_scan
    * previous default: class AccType = detail::input_type_t<InitValueType>>
    * new default: class AccType = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueType>, BinaryFunction>