### PR TITLE
[rocPRIM] Disable int tests in `test_lookback_reproducibility.cpp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,8 @@ The following is the complete list of affected functions and how their default a
   * `ROCPRIM_WAVEFRONT_SIZE`
 
 ### Known issues
-* When using `rocprim::deterministic_inclusive_scan_by_key` the intermediate values can change order on Navi3x
+* When using `rocprim::deterministic_inclusive_scan_by_key` and `rocprim::deterministic_exclusive_scan_by_key` the intermediate values can change order on Navi3x
+  * However if a commutative scan operator is used then the final scan value (output array) will still always be consistent between runs
 
 ## rocPRIM 3.4.0 for ROCm 6.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ The following is the complete list of affected functions and how their default a
   * `rocprim::warp_size()`
   * `ROCPRIM_WAVEFRONT_SIZE`
 
+### Known issues
+* When using `rocprim::deterministic_inclusive_scan_by_key` the intermediate values can change order on Navi3x
+
 ## rocPRIM 3.4.0 for ROCm 6.4.0
 
 ### Added

--- a/test/rocprim/test_lookback_reproducibility.cpp
+++ b/test/rocprim/test_lookback_reproducibility.cpp
@@ -83,7 +83,7 @@ struct RocprimLookbackReproducibilityTests : public testing::Test
 };
 
 using Suite = testing::Types<
-    TestParams<int>,// Temporary disable int tests on Navi3X due to known error
+    TestParams<int>,
     TestParams<rocprim::bfloat16>,
     TestParams<rocprim::half>,
     TestParams<float>,

--- a/test/rocprim/test_lookback_reproducibility.cpp
+++ b/test/rocprim/test_lookback_reproducibility.cpp
@@ -83,9 +83,7 @@ struct RocprimLookbackReproducibilityTests : public testing::Test
 };
 
 using Suite = testing::Types<
-    #if !defined(__GFX11__)                       
-        TestParams<int>,// Temporary disable int tests on Navi3X due to known error
-    #endif
+    TestParams<int>,// Temporary disable int tests on Navi3X due to known error
     TestParams<rocprim::bfloat16>,
     TestParams<rocprim::half>,
     TestParams<float>,
@@ -223,6 +221,14 @@ TYPED_TEST(RocprimLookbackReproducibilityTests, ScanByKey)
     using compare_op_type = rocprim::equal_to<K>;
     using Config          = rocprim::default_config;
 
+    hipDeviceProp_t attributes;
+    HIP_CHECK(hipGetDeviceProperties(&attributes, 0));
+
+    // Disable int test case for Navi3X because of known issue
+    if (std::is_same_v<V, int> && attributes.major == 11){
+        GTEST_SKIP();
+    }
+    
     const size_t min_segment_length = 1000;
     const size_t max_segment_length = 10000;
 

--- a/test/rocprim/test_lookback_reproducibility.cpp
+++ b/test/rocprim/test_lookback_reproducibility.cpp
@@ -82,12 +82,13 @@ struct RocprimLookbackReproducibilityTests : public testing::Test
     const bool debug_synchronous = false;
 };
 
-using Suite = testing::Types<TestParams<int>, // Sanity check
-                             TestParams<rocprim::bfloat16>,
-                             TestParams<rocprim::half>,
-                             TestParams<float>,
-                             TestParams<double>,
-                             TestParams<common::custom_type<double, double, true>>>;
+using Suite = testing::Types<
+                            // TestParams<int>, // Sanity check ### Temporary disable int tests due to known error
+                            TestParams<rocprim::bfloat16>,
+                            TestParams<rocprim::half>,
+                            TestParams<float>,
+                            TestParams<double>,
+                            TestParams<common::custom_type<double, double, true>>>;
 
 TYPED_TEST_SUITE(RocprimLookbackReproducibilityTests, Suite);
 

--- a/test/rocprim/test_lookback_reproducibility.cpp
+++ b/test/rocprim/test_lookback_reproducibility.cpp
@@ -83,12 +83,15 @@ struct RocprimLookbackReproducibilityTests : public testing::Test
 };
 
 using Suite = testing::Types<
-                            // TestParams<int>, // Sanity check ### Temporary disable int tests due to known error
-                            TestParams<rocprim::bfloat16>,
-                            TestParams<rocprim::half>,
-                            TestParams<float>,
-                            TestParams<double>,
-                            TestParams<common::custom_type<double, double, true>>>;
+    #if !defined(__GFX11__)                       
+        TestParams<int>,// Temporary disable int tests on Navi3X due to known error
+    #endif
+    TestParams<rocprim::bfloat16>,
+    TestParams<rocprim::half>,
+    TestParams<float>,
+    TestParams<double>,
+    TestParams<common::custom_type<double, double, true>>
+>;
 
 TYPED_TEST_SUITE(RocprimLookbackReproducibilityTests, Suite);
 


### PR DESCRIPTION
There is a current issue with integers case on NAVI3X machines where when using rocprim::deterministic_inclusive_scan_by_key the intermediate values can change value.