### PR TITLE
fix: resolve out-of-memory in tests on rx9070

### DIFF
--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -1,0 +1,110 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef COMMON_UTILS_HPP_
+#define COMMON_UTILS_HPP_
+
+#include <rocprim/intrinsics/thread.hpp>
+
+#ifdef USE_GTEST
+    // GoogleTest-compatible HIP_CHECK macro. FAIL is called to log the Google Test trace.
+    // The lambda is invoked immediately as assertions that generate a fatal failure can
+    // only be used in void-returning functions.
+    #define HIP_CHECK(condition)                                                            \
+        {                                                                                   \
+            hipError_t error = condition;                                                   \
+            if(error != hipSuccess)                                                         \
+            {                                                                               \
+                [error]()                                                                   \
+                { FAIL() << "HIP error " << error << ": " << hipGetErrorString(error); }(); \
+                exit(error);                                                                \
+            }                                                                               \
+        }
+#else
+    #define HIP_CHECK(condition)                                                                \
+        {                                                                                       \
+            hipError_t error = condition;                                                       \
+            if(error != hipSuccess)                                                             \
+            {                                                                                   \
+                std::cout << "HIP error: " << hipGetErrorString(error) << " file: " << __FILE__ \
+                          << " line: " << __LINE__ << std::endl;                                \
+                exit(error);                                                                    \
+            }                                                                                   \
+        }
+#endif
+
+namespace common
+{
+template<unsigned int LogicalWarpSize>
+__device__ constexpr bool device_test_enabled_for_warp_size_v
+    = ::rocprim::arch::wavefront::max_size() >= LogicalWarpSize;
+
+inline char* __get_env(const char* name)
+{
+    char* env;
+#ifdef _MSC_VER
+    errno_t err = _dupenv_s(&env, nullptr, name);
+    if(err)
+    {
+        return nullptr;
+    }
+#else
+    env = std::getenv(name);
+#endif
+    return env;
+}
+
+inline void clean_env(char* env)
+{
+#ifdef _MSC_VER
+    free(env);
+#endif
+    (void)env;
+}
+
+inline bool use_hmm()
+{
+
+    char*      env = __get_env("ROCPRIM_USE_HMM");
+    const bool hmm = (env != nullptr) && (strcmp(env, "1") == 0);
+    clean_env(env);
+    return hmm;
+}
+
+// Helper for HMM allocations: HMM is requested through ROCPRIM_USE_HMM=1 environment variable
+template<class T>
+hipError_t hipMallocHelper(T** devPtr, size_t size)
+{
+    if(use_hmm())
+    {
+        return hipMallocManaged(reinterpret_cast<void**>(devPtr), size);
+    }
+    else
+    {
+        return hipMalloc(reinterpret_cast<void**>(devPtr), size);
+    }
+    return hipSuccess;
+}
+
+} // namespace common
+
+#endif // COMMON_UTILS_HPP_

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -54,9 +54,6 @@
 
 namespace common
 {
-template<unsigned int LogicalWarpSize>
-__device__ constexpr bool device_test_enabled_for_warp_size_v
-    = ::rocprim::arch::wavefront::max_size() >= LogicalWarpSize;
 
 inline char* __get_env(const char* name)
 {

--- a/common/utils_device_ptr.hpp
+++ b/common/utils_device_ptr.hpp
@@ -1,0 +1,614 @@
+// Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ROCPRIM_UTILS_DEVICE_PTR_HPP
+#define ROCPRIM_UTILS_DEVICE_PTR_HPP
+
+#include "utils.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace common
+{
+
+/// \brief An RAII friendly class to manage the memory allocated on device.
+///
+/// \tparam A Template type used by the class.
+template<typename ValueType = void>
+class device_ptr
+{
+public:
+    using decay_type = std::decay_t<ValueType>;
+    using size_type  = std::size_t;
+    using value_type = ValueType;
+
+private:
+    // If value_type is void we want to emulate allocating bytes (uchar).
+    using value_type_proxy
+        = std::conditional_t<std::is_same<decay_type, void>::value, unsigned char, ValueType>;
+
+public:
+    static constexpr size_t value_size = sizeof(value_type_proxy);
+
+    device_ptr() : device_raw_ptr_(nullptr), number_of_ele_(0){};
+
+    /// \brief Construct with a pre-allocated memory space.
+    device_ptr(size_type pre_alloc_number_of_ele)
+        : device_raw_ptr_(nullptr), number_of_ele_(pre_alloc_number_of_ele)
+    {
+        size_type storage_size = number_of_ele_ * value_size;
+        HIP_CHECK(common::hipMallocHelper(&device_raw_ptr_, storage_size));
+    };
+
+    device_ptr(device_ptr const&) = delete;
+
+    device_ptr(device_ptr&& other) noexcept
+        : device_raw_ptr_(other.device_raw_ptr_), number_of_ele_(other.number_of_ele_)
+    {
+        other.leak();
+    };
+
+    /// \brief Construct by host vectors with the same sized value_type
+    template<typename InValueType, typename Allocator>
+    explicit device_ptr(std::vector<InValueType, Allocator> const& data)
+        : device_raw_ptr_(nullptr), number_of_ele_(data.size())
+    {
+        static_assert(sizeof(InValueType) == value_size,
+                      "value_type of input must have the same size with device_ptr::value_type");
+
+        size_type storage_size = number_of_ele_ * value_size;
+        HIP_CHECK(common::hipMallocHelper(&device_raw_ptr_, storage_size));
+        HIP_CHECK(hipMemcpy(device_raw_ptr_, data.data(), storage_size, hipMemcpyHostToDevice));
+    }
+
+    template<typename InValueType>
+    explicit device_ptr(std::vector<InValueType> const& data, hipStream_t stream)
+        : device_raw_ptr_(nullptr), number_of_ele_(data.size())
+    {
+        static_assert(sizeof(InValueType) == value_size,
+                      "value_type of input must have the same size with device_ptr::value_type");
+
+        size_type storage_size = number_of_ele_ * value_size;
+        HIP_CHECK(common::hipMallocHelper(&device_raw_ptr_, storage_size));
+        HIP_CHECK(hipMemcpyAsync(device_raw_ptr_,
+                                 data.data(),
+                                 storage_size,
+                                 hipMemcpyHostToDevice,
+                                 stream));
+    }
+
+    template<typename InValueType, size_type Size>
+    explicit device_ptr(std::array<InValueType, Size> const& data)
+        : device_raw_ptr_(nullptr), number_of_ele_(Size)
+    {
+        static_assert(sizeof(InValueType) == value_size,
+                      "value_type of input must have the same size with device_ptr::value_type");
+
+        size_type storage_size = Size * value_size;
+        HIP_CHECK(common::hipMallocHelper(&device_raw_ptr_, storage_size));
+        HIP_CHECK(hipMemcpy(device_raw_ptr_, data.data(), storage_size, hipMemcpyHostToDevice));
+    }
+
+    template<typename InValueType, size_type Size>
+    explicit device_ptr(std::array<InValueType, Size> const& data, hipStream_t stream)
+        : device_raw_ptr_(nullptr), number_of_ele_(Size)
+    {
+        static_assert(sizeof(InValueType) == value_size,
+                      "value_type of input must have the same size with device_ptr::value_type");
+
+        size_type storage_size = Size * value_size;
+        HIP_CHECK(common::hipMallocHelper(&device_raw_ptr_, storage_size));
+        HIP_CHECK(hipMemcpyAsync(device_raw_ptr_,
+                                 data.data(),
+                                 storage_size,
+                                 hipMemcpyHostToDevice,
+                                 stream));
+    }
+
+    template<typename InValueType, typename DeleterType>
+    explicit device_ptr(std::unique_ptr<InValueType[], DeleterType> const& uptr, size_type size)
+        : device_raw_ptr_(nullptr), number_of_ele_(size)
+    {
+        static_assert(sizeof(InValueType) == value_size,
+                      "value_type of input must have the same size with device_ptr::value_type");
+
+        size_type storage_size = size * value_size;
+        HIP_CHECK(common::hipMallocHelper(&device_raw_ptr_, storage_size));
+        HIP_CHECK(hipMemcpy(device_raw_ptr_, uptr.get(), storage_size, hipMemcpyHostToDevice));
+    }
+
+    template<typename InValueType, typename DeleterType>
+    explicit device_ptr(std::unique_ptr<InValueType[], DeleterType> const& uptr,
+                        size_type                                          size,
+                        hipStream_t                                        stream)
+        : device_raw_ptr_(nullptr), number_of_ele_(size)
+    {
+        static_assert(sizeof(InValueType) == value_size,
+                      "value_type of input must have the same size with device_ptr::value_type");
+
+        size_type storage_size = size * value_size;
+        HIP_CHECK(common::hipMallocHelper(&device_raw_ptr_, storage_size));
+        HIP_CHECK(hipMemcpyAsync(device_raw_ptr_,
+                                 uptr.get(),
+                                 storage_size,
+                                 hipMemcpyHostToDevice,
+                                 stream));
+    }
+
+    ~device_ptr()
+    {
+        free_manually();
+    };
+
+    device_ptr& operator=(device_ptr const&) = delete;
+
+    device_ptr& operator=(device_ptr&& other) noexcept
+    {
+        free_manually();
+
+        device_raw_ptr_ = other.device_raw_ptr_;
+        number_of_ele_  = other.number_of_ele_;
+        other.leak();
+
+        return *this;
+    };
+
+    /// \brief Do copy on the device.
+    ///
+    /// \return A new `device_ptr` rvalue.
+    device_ptr duplicate() const
+    {
+        device_ptr ret;
+        ret.number_of_ele_     = number_of_ele_;
+        size_type storage_size = number_of_ele_ * value_size;
+        HIP_CHECK(common::hipMallocHelper(&ret.device_raw_ptr_, storage_size));
+        HIP_CHECK(
+            hipMemcpy(ret.device_raw_ptr_, device_raw_ptr_, storage_size, hipMemcpyDeviceToDevice));
+        return ret;
+    }
+
+    device_ptr duplicate_async(hipStream_t stream) const
+    {
+        device_ptr ret;
+        ret.number_of_ele_     = number_of_ele_;
+        size_type storage_size = number_of_ele_ * value_size;
+        HIP_CHECK(common::hipMallocHelper(&ret.device_raw_ptr_, storage_size));
+        HIP_CHECK(hipMemcpyAsync(ret.device_raw_ptr_,
+                                 device_raw_ptr_,
+                                 storage_size,
+                                 hipMemcpyDeviceToDevice,
+                                 stream));
+        return ret;
+    }
+
+    /// \brief Do type cast and move the ownership to the new `device_ptr<TargetPtrType>`.
+    ///
+    /// \return A new `device_ptr<TargetPtrType>` rvalue.
+    template<typename TargetPtrType>
+    device_ptr<TargetPtrType> move_cast() noexcept
+    {
+        using target_value_t = typename device_ptr<TargetPtrType>::value_type;
+
+        auto ret_deivce_raw_ptr_
+            = static_cast<target_value_t*>(static_cast<void*>(device_raw_ptr_));
+        auto ret_number_of_ele_ = value_size * number_of_ele_ / sizeof(target_value_t);
+        leak();
+        return {ret_deivce_raw_ptr_, ret_number_of_ele_};
+    }
+
+    /// \brief Get the device raw pointer
+    value_type* get() const noexcept
+    {
+        return device_raw_ptr_;
+    }
+
+    /// \brief Clean every thing on this instance, which could lead to memory leak. Should call `get()` and free the raw pointer manually
+    void leak() noexcept
+    {
+        device_raw_ptr_ = nullptr;
+        number_of_ele_  = 0;
+    }
+
+    /// \brief Call this function to garbage the memory in advance
+    void free_manually()
+    {
+        if(device_raw_ptr_ != nullptr)
+        {
+            HIP_CHECK(hipFree(device_raw_ptr_));
+        }
+        leak();
+    }
+
+    void resize(size_type new_number_of_ele)
+    {
+        if(new_number_of_ele == 0)
+        {
+            free_manually();
+        }
+        else
+        {
+            value_type* device_temp_ptr = nullptr;
+            HIP_CHECK(common::hipMallocHelper(&device_temp_ptr, new_number_of_ele * value_size));
+            HIP_CHECK(hipMemcpy(device_temp_ptr,
+                                device_raw_ptr_,
+                                std::min(new_number_of_ele, number_of_ele_) * value_size,
+                                hipMemcpyDeviceToDevice));
+            free_manually();
+            device_raw_ptr_ = device_temp_ptr;
+            number_of_ele_  = new_number_of_ele;
+        }
+    }
+
+    void resize_async(size_type new_number_of_ele, hipStream_t stream)
+    {
+        if(new_number_of_ele == 0)
+        {
+            free_manually();
+        }
+        else
+        {
+            value_type* device_temp_ptr = nullptr;
+            HIP_CHECK(common::hipMallocHelper(&device_temp_ptr, new_number_of_ele * value_size));
+            HIP_CHECK(hipMemcpyAsync(device_temp_ptr,
+                                     device_raw_ptr_,
+                                     std::min(new_number_of_ele, number_of_ele_) * value_size,
+                                     hipMemcpyDeviceToDevice,
+                                     stream));
+            free_manually();
+            device_raw_ptr_ = device_temp_ptr;
+            number_of_ele_  = new_number_of_ele;
+        }
+    }
+
+    // if got error hipErrorOutOfMemory` return false, else return `true`
+    bool resize_with_memory_check(size_type new_number_of_ele)
+    {
+        if(new_number_of_ele == 0)
+        {
+            free_manually();
+        }
+        else
+        {
+            value_type* device_temp_ptr = nullptr;
+            const auto  err
+                = common::hipMallocHelper(&device_temp_ptr, new_number_of_ele * value_size);
+            if(err == hipErrorOutOfMemory)
+            {
+                return false;
+            }
+            HIP_CHECK(err);
+            HIP_CHECK(hipMemcpy(device_temp_ptr,
+                                device_raw_ptr_,
+                                std::min(new_number_of_ele, number_of_ele_) * value_size,
+                                hipMemcpyDeviceToDevice));
+            free_manually();
+            device_raw_ptr_ = device_temp_ptr;
+            number_of_ele_  = new_number_of_ele;
+        }
+        return true;
+    }
+
+    bool resize_with_memory_check_async(size_type new_number_of_ele, hipStream_t stream)
+    {
+        if(new_number_of_ele == 0)
+        {
+            free_manually();
+        }
+        else
+        {
+            value_type* device_temp_ptr = nullptr;
+            const auto  err
+                = common::hipMallocHelper(&device_temp_ptr, new_number_of_ele * value_size);
+            if(err == hipErrorOutOfMemory)
+            {
+                return false;
+            }
+            HIP_CHECK(err);
+            HIP_CHECK(hipMemcpyAsync(device_temp_ptr,
+                                     device_raw_ptr_,
+                                     std::min(new_number_of_ele, number_of_ele_) * value_size,
+                                     hipMemcpyDeviceToDevice,
+                                     stream));
+            free_manually();
+            device_raw_ptr_ = device_temp_ptr;
+            number_of_ele_  = new_number_of_ele;
+        }
+        return true;
+    }
+
+    /// \brief Get the size of this memory space
+    size_type msize() const noexcept
+    {
+        return number_of_ele_ * value_size;
+    }
+
+    /// \brief Get the number of elements
+    size_type size() const noexcept
+    {
+        return number_of_ele_;
+    }
+
+    /// \brief Copy from host to device
+    template<typename InValueType, typename Allocator>
+    void store(std::vector<InValueType, Allocator> const& host_vec, size_type offset = 0)
+    {
+        static_assert(sizeof(InValueType) == value_size,
+                      "value_type of input must have the same size with device_ptr::value_type");
+
+        if(host_vec.size() + offset > number_of_ele_)
+        {
+            resize(host_vec.size() + offset);
+        }
+
+        HIP_CHECK(hipMemcpy(device_raw_ptr_ + offset,
+                            host_vec.data(),
+                            host_vec.size() * value_size,
+                            hipMemcpyHostToDevice));
+    }
+
+    template<typename InValueType, size_type Size>
+    void store(std::array<InValueType, Size> const& host_arr)
+    {
+        static_assert(sizeof(InValueType) == value_size,
+                      "value_type of input must have the same size with device_ptr::value_type");
+
+        if(Size > number_of_ele_)
+        {
+            resize(Size);
+        }
+
+        HIP_CHECK(
+            hipMemcpy(device_raw_ptr_, host_arr.data(), Size * value_size, hipMemcpyHostToDevice));
+    }
+
+    template<typename InValueType>
+    void
+        store(std::unique_ptr<InValueType[]> const& uptr, size_type offset, size_type number_of_ele)
+    {
+        static_assert(
+            sizeof(InValueType) == value_size,
+            "value_type of input unique_ptr must have the same size with device_ptr::value_type");
+
+        if(offset + number_of_ele > number_of_ele_)
+        {
+            resize(offset + number_of_ele);
+        }
+        HIP_CHECK(hipMemcpy(device_raw_ptr_ + offset,
+                            uptr.get(),
+                            number_of_ele * value_size,
+                            hipMemcpyHostToDevice));
+    }
+
+    template<typename InValueType>
+    void store_async(std::vector<InValueType> const& host_vec, hipStream_t stream)
+    {
+        static_assert(
+            sizeof(InValueType) == value_size,
+            "value_type of input vector must have the same size with device_ptr::value_type");
+
+        if(host_vec.size() > number_of_ele_)
+        {
+            resize(host_vec.size());
+        }
+
+        HIP_CHECK(hipMemcpyAsync(device_raw_ptr_,
+                                 host_vec.data(),
+                                 host_vec.size() * value_size,
+                                 hipMemcpyHostToDevice,
+                                 stream));
+    }
+
+    template<typename InValueType, size_type Size>
+    void store_async(std::array<InValueType, Size> const& host_arr, hipStream_t stream)
+    {
+        static_assert(sizeof(InValueType) == value_size,
+                      "value_type of input must have the same size with device_ptr::value_type");
+
+        if(Size > number_of_ele_)
+        {
+            resize(Size);
+        }
+
+        HIP_CHECK(hipMemcpyAsync(device_raw_ptr_,
+                                 host_arr.data(),
+                                 Size * value_size,
+                                 hipMemcpyHostToDevice,
+                                 stream));
+    }
+
+    template<typename InValueType>
+    void store_async(std::unique_ptr<InValueType[]> const& uptr,
+                     size_type                             offset,
+                     size_type                             number_of_ele,
+                     hipStream_t                           stream)
+    {
+        static_assert(
+            sizeof(InValueType) == value_size,
+            "value_type of input unique_ptr must have the same size with device_ptr::value_type");
+
+        if(offset + number_of_ele > number_of_ele_)
+        {
+            resize(offset + number_of_ele);
+        }
+        HIP_CHECK(hipMemcpyAsync(device_raw_ptr_ + offset,
+                                 uptr.get(),
+                                 number_of_ele * value_size,
+                                 hipMemcpyHostToDevice,
+                                 stream));
+    }
+
+    // will not check the boundary
+    void store_value_at(size_type pos, value_type_proxy const& value)
+    {
+        HIP_CHECK(hipMemcpy(device_raw_ptr_ + pos, &value, value_size, hipMemcpyHostToDevice));
+    }
+
+    // will not check the boundary
+    template<typename T = value_type>
+    void store_value_at_async(size_type pos, value_type_proxy const& value, hipStream_t stream)
+    {
+        HIP_CHECK(
+            hipMemcpy(device_raw_ptr_ + pos, &value, value_size, hipMemcpyHostToDevice, stream));
+    }
+
+    /// \brief Copy from device to device
+    template<typename InPtrValueType>
+    void replace(device_ptr<InPtrValueType> const& device_ptr)
+    {
+        static_assert(sizeof(InPtrValueType) == value_size,
+                      "sizeof(InPtrValueType) must equal to value_size");
+
+        if(device_ptr.number_of_ele_ > number_of_ele_)
+        {
+            resize(device_ptr.number_of_ele_);
+        }
+
+        HIP_CHECK(hipMemcpy(device_raw_ptr_,
+                            device_ptr.device_raw_ptr_,
+                            device_ptr.number_of_ele_ * value_size,
+                            hipMemcpyDeviceToDevice));
+    }
+
+    template<typename InPtrValueType>
+    void replace_async(device_ptr<InPtrValueType> const& device_ptr, hipStream_t stream)
+    {
+        static_assert(sizeof(InPtrValueType) == value_size,
+                      "sizeof(InPtrValueType) must equal to value_size");
+
+        if(device_ptr.number_of_ele_ > number_of_ele_)
+        {
+            resize(device_ptr.number_of_ele_);
+        }
+
+        HIP_CHECK(hipMemcpyAsync(device_raw_ptr_,
+                                 device_ptr.device_raw_ptr_,
+                                 device_ptr.number_of_ele_ * value_size,
+                                 hipMemcpyDeviceToDevice,
+                                 stream));
+    }
+
+    void memset(size_type offset, int value, size_type size_bytes)
+    {
+        HIP_CHECK(hipMemset(reinterpret_cast<char*>(device_raw_ptr_) + offset,
+                            value,
+                            static_cast<size_t>(size_bytes)));
+    }
+
+    void memset_async(size_type offset, int value, size_type size_bytes, hipStream_t stream)
+    {
+        HIP_CHECK(hipMemsetAsync(reinterpret_cast<char*>(device_raw_ptr_) + offset,
+                                 value,
+                                 static_cast<size_t>(size_bytes),
+                                 stream));
+    }
+
+    /// \brief Copy from device to host
+    /// This function will store loaded values into std::vector
+    auto load() const
+    {
+        std::vector<value_type> ret(number_of_ele_);
+        HIP_CHECK(hipMemcpy(ret.data(),
+                            device_raw_ptr_,
+                            number_of_ele_ * value_size,
+                            hipMemcpyDeviceToHost));
+        return ret;
+    }
+
+    auto load_async(hipStream_t stream) const
+    {
+        std::vector<value_type> ret(number_of_ele_);
+        HIP_CHECK(hipMemcpyAsync(ret.data(),
+                                 device_raw_ptr_,
+                                 number_of_ele_ * value_size,
+                                 hipMemcpyDeviceToHost,
+                                 stream));
+        return ret;
+    }
+
+    template<size_type Size>
+    auto load_to_array() const
+    {
+        std::array<value_type, Size> ret;
+        HIP_CHECK(hipMemcpy(ret.data(),
+                            device_raw_ptr_,
+                            std::min<size_type>(number_of_ele_, Size) * value_size,
+                            hipMemcpyDeviceToHost));
+        return ret;
+    }
+
+    template<size_type Size>
+    auto load_to_array_async(hipStream_t stream) const
+    {
+        std::array<value_type, Size> ret;
+        HIP_CHECK(hipMemcpyAsync(ret.data(),
+                                 device_raw_ptr_,
+                                 std::min<size_type>(number_of_ele_, Size) * value_size,
+                                 hipMemcpyDeviceToHost,
+                                 stream));
+        return ret;
+    }
+
+    auto load_to_unique_ptr() const
+    {
+        std::unique_ptr<value_type[]> ret(new value_type[number_of_ele_]);
+        HIP_CHECK(hipMemcpy(ret.get(),
+                            device_raw_ptr_,
+                            number_of_ele_ * value_size,
+                            hipMemcpyDeviceToHost));
+        return ret;
+    }
+
+    auto load_to_unique_ptr_async(hipStream_t stream) const
+    {
+        std::unique_ptr<value_type[]> ret(new value_type[number_of_ele_]);
+        HIP_CHECK(hipMemcpyAsync(ret.get(),
+                                 device_raw_ptr_,
+                                 number_of_ele_ * value_size,
+                                 hipMemcpyDeviceToHost,
+                                 stream));
+        return ret;
+    }
+
+    auto load_value_at(size_type pos) const
+    {
+        value_type ret;
+        HIP_CHECK(hipMemcpy(&ret, device_raw_ptr_ + pos, value_size, hipMemcpyDeviceToHost));
+        return ret;
+    }
+
+    auto load_value_at_async(size_type pos, hipStream_t stream) const
+    {
+        value_type ret;
+        HIP_CHECK(
+            hipMemcpyAsync(&ret, device_raw_ptr_ + pos, value_size, hipMemcpyDeviceToHost, stream));
+        return ret;
+    }
+
+private:
+    value_type* device_raw_ptr_;
+    size_type   number_of_ele_;
+};
+
+} // namespace common
+
+#endif

--- a/test/rocprim/test_device_merge.cpp
+++ b/test/rocprim/test_device_merge.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,9 @@
 #include "../common_test_header.hpp"
 #include "test_utils_types.hpp"
 
+#include "../../common/utils.hpp"
+#include "../../common/utils_device_ptr.hpp"
+
 // required rocprim headers
 #include <rocprim/device/device_merge.hpp>
 #include <rocprim/functional.hpp>
@@ -35,9 +38,7 @@
 #include <hip/hip_runtime.h>
 
 #include <algorithm>
-#include <fstream>
 #include <numeric>
-#include <vector>
 
 using DefaultConfig = rocprim::default_config;
 
@@ -129,11 +130,19 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
 
     for(auto sizes : get_sizes())
     {
-        if ((std::get<0>(sizes) == 0 || std::get<1>(sizes) == 0) && test_common_utils::use_hmm())
+        if((std::get<0>(sizes) == 0 || std::get<1>(sizes) == 0) && test_common_utils::use_hmm())
         {
             // hipMallocManaged() currently doesnt support zero byte allocation
             continue;
         }
+
+        if((std::get<0>(sizes) + std::get<1>(sizes) >= 100000
+            && sizeof(key_type) > sizeof(size_t) * 16))
+        {
+            // Huge types are slow
+            continue;
+        }
+
         SCOPED_TRACE(
             testing::Message() << "with sizes = {" <<
             std::get<0>(sizes) << ", " << std::get<1>(sizes) << "}"
@@ -145,7 +154,7 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
         // compare function
         compare_op_type compare_op;
 
-        for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
+        for(size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
         {
             unsigned int seed_value = seed_index < random_seeds_count  ? rand() : seeds[seed_index - random_seeds_count];
             SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
@@ -170,35 +179,21 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
 
             test_utils::out_of_bounds_flag out_of_bounds;
 
-            common::device_ptr<key_type> d_keys_input1;
-            common::device_ptr<key_type> d_keys_input2;
-            common::device_ptr<key_type> d_keys_output;
-
-            if(!d_keys_input1.resize_with_memory_check(keys_input1.size())
-               || !d_keys_input2.resize_with_memory_check(keys_input2.size())
-               || !d_keys_output.resize_with_memory_check(keys_output.size()))
-            {
-                std::cout << "Out of memory. Skipping test with sizes = {" << size1 << ", " << size2
-                          << "}" << std::endl;
-                break;
-            }
-
-            d_keys_input1.store(keys_input1);
-            d_keys_input2.store(keys_input2);
+            common::device_ptr<key_type> d_keys_input1(keys_input1);
+            common::device_ptr<key_type> d_keys_input2(keys_input2);
+            common::device_ptr<key_type> d_keys_output(keys_output.size());
 
             test_utils::bounds_checking_iterator<key_type> d_keys_checking_output(
-                d_keys_output,
+                d_keys_output.get(),
                 out_of_bounds.device_pointer(),
                 size1 + size2);
 
-            // temp storage
-            size_t temp_storage_size_bytes;
-            void * d_temp_storage = nullptr;
             // Get size of d_temp_storage
-            HIP_CHECK(rocprim::merge<config>(d_temp_storage,
+            size_t temp_storage_size_bytes;
+            HIP_CHECK(rocprim::merge<config>(nullptr,
                                              temp_storage_size_bytes,
-                                             d_keys_input1,
-                                             d_keys_input2,
+                                             d_keys_input1.get(),
+                                             d_keys_input2.get(),
                                              d_keys_checking_output,
                                              keys_input1.size(),
                                              keys_input2.size(),
@@ -210,14 +205,7 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            common::device_ptr<void> d_temp_storage;
-
-            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
-            {
-                std::cout << "Out of memory. Skipping test with sizes = {" << size1 << ", " << size2
-                          << "}" << std::endl;
-                break;
-            }
+            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
 
             test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
@@ -226,10 +214,10 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
             }
 
             // Run
-            HIP_CHECK(rocprim::merge<config>(d_temp_storage,
+            HIP_CHECK(rocprim::merge<config>(d_temp_storage.get(),
                                              temp_storage_size_bytes,
-                                             d_keys_input1,
-                                             d_keys_input2,
+                                             d_keys_input1.get(),
+                                             d_keys_input2.get(),
                                              d_keys_checking_output,
                                              keys_input1.size(),
                                              keys_input2.size(),
@@ -248,21 +236,10 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
             ASSERT_FALSE(out_of_bounds.get());
 
             // Copy keys_output to host
-            HIP_CHECK(
-                hipMemcpy(
-                    keys_output.data(), d_keys_output,
-                    keys_output.size() * sizeof(key_type),
-                    hipMemcpyDeviceToHost
-                )
-            );
+            keys_output = d_keys_output.load();
 
             // Check if keys_output values are as expected
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected));
-
-            HIP_CHECK(hipFree(d_keys_input1));
-            HIP_CHECK(hipFree(d_keys_input2));
-            HIP_CHECK(hipFree(d_keys_output));
-            HIP_CHECK(hipFree(d_temp_storage));
 
             if (TestFixture::use_graphs)
                 gHelper.cleanupGraphHelper();
@@ -295,11 +272,12 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
 
     for(auto sizes : get_sizes())
     {
-        if ((std::get<0>(sizes) == 0 || std::get<1>(sizes) == 0) && test_common_utils::use_hmm())
+        if((std::get<0>(sizes) == 0 || std::get<1>(sizes) == 0) && test_common_utils::use_hmm())
         {
             // hipMallocManaged() currently doesnt support zero byte allocation
             continue;
         }
+
         SCOPED_TRACE(
             testing::Message() << "with sizes = {" <<
             std::get<0>(sizes) << ", " << std::get<1>(sizes) << "}"
@@ -353,51 +331,31 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
 
             test_utils::out_of_bounds_flag out_of_bounds;
 
-            common::device_ptr<key_type>   d_keys_input1;
-            common::device_ptr<key_type>   d_keys_input2;
-            common::device_ptr<key_type>   d_keys_output;
-            common::device_ptr<value_type> d_values_input1;
-            common::device_ptr<value_type> d_values_input2;
-            common::device_ptr<value_type> d_values_output;
-
-            if(!d_keys_input1.resize_with_memory_check(keys_input1.size())
-               || !d_keys_input2.resize_with_memory_check(keys_input2.size())
-               || !d_keys_output.resize_with_memory_check(keys_output.size())
-               || !d_values_input1.resize_with_memory_check(values_input1.size())
-               || !d_values_input2.resize_with_memory_check(values_input1.size())
-               || !d_values_output.resize_with_memory_check(values_output.size()))
-            {
-                std::cout << "Out of memory. Skipping test with sizes = {" << size1 << ", " << size2
-                          << "}" << std::endl;
-                break;
-            }
-
-            d_keys_input1.store(keys_input1);
-            d_keys_input2.store(keys_input2);
-            d_values_input1.store(values_input1);
-            d_values_input2.store(values_input2);
+            common::device_ptr<key_type>   d_keys_input1(keys_input1);
+            common::device_ptr<key_type>   d_keys_input2(keys_input2);
+            common::device_ptr<key_type>   d_keys_output(keys_output.size());
+            common::device_ptr<value_type> d_values_input1(values_input1);
+            common::device_ptr<value_type> d_values_input2(values_input2);
+            common::device_ptr<value_type> d_values_output(values_output.size());
 
             test_utils::bounds_checking_iterator<key_type> d_keys_checking_output(
-                d_keys_output,
+                d_keys_output.get(),
                 out_of_bounds.device_pointer(),
-                size1 + size2
-            );
+                size1 + size2);
             test_utils::bounds_checking_iterator<value_type> d_values_checking_output(
-                d_values_output,
+                d_values_output.get(),
                 out_of_bounds.device_pointer(),
                 size1 + size2);
 
-            // temp storage
-            size_t temp_storage_size_bytes;
-            void * d_temp_storage = nullptr;
             // Get size of d_temp_storage
-            HIP_CHECK(rocprim::merge<config>(d_temp_storage,
+            size_t temp_storage_size_bytes;
+            HIP_CHECK(rocprim::merge<config>(nullptr,
                                              temp_storage_size_bytes,
-                                             d_keys_input1,
-                                             d_keys_input2,
+                                             d_keys_input1.get(),
+                                             d_keys_input2.get(),
                                              d_keys_checking_output,
-                                             d_values_input1,
-                                             d_values_input2,
+                                             d_values_input1.get(),
+                                             d_values_input2.get(),
                                              d_values_checking_output,
                                              keys_input1.size(),
                                              keys_input2.size(),
@@ -409,14 +367,7 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            common::device_ptr<void> d_temp_storage;
-
-            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
-            {
-                std::cout << "Out of memory. Skipping test with sizes = {" << size1 << ", " << size2
-                          << "}" << std::endl;
-                break;
-            }
+            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
 
             test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
@@ -425,13 +376,13 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
             }
 
             // Run
-            HIP_CHECK(rocprim::merge<config>(d_temp_storage,
+            HIP_CHECK(rocprim::merge<config>(d_temp_storage.get(),
                                              temp_storage_size_bytes,
-                                             d_keys_input1,
-                                             d_keys_input2,
+                                             d_keys_input1.get(),
+                                             d_keys_input2.get(),
                                              d_keys_checking_output,
-                                             d_values_input1,
-                                             d_values_input2,
+                                             d_values_input1.get(),
+                                             d_values_input2.get(),
                                              d_values_checking_output,
                                              keys_input1.size(),
                                              keys_input2.size(),
@@ -449,20 +400,8 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
 
             ASSERT_FALSE(out_of_bounds.get());
 
-            HIP_CHECK(
-                hipMemcpy(
-                    keys_output.data(), d_keys_output,
-                    keys_output.size() * sizeof(key_type),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(
-                hipMemcpy(
-                    values_output.data(), d_values_output,
-                    values_output.size() * sizeof(value_type),
-                    hipMemcpyDeviceToHost
-                )
-            );
+            keys_output   = d_keys_output.load();
+            values_output = d_values_output.load();
 
             // Check if keys_output values are as expected
             std::vector<key_type> expected_key(expected.size());
@@ -475,21 +414,15 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected_key));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, expected_value));
 
-            HIP_CHECK(hipFree(d_keys_input1));
-            HIP_CHECK(hipFree(d_keys_input2));
-            HIP_CHECK(hipFree(d_keys_output));
-            HIP_CHECK(hipFree(d_values_input1));
-            HIP_CHECK(hipFree(d_values_input2));
-            HIP_CHECK(hipFree(d_values_output));
-            HIP_CHECK(hipFree(d_temp_storage));
-
             if (TestFixture::use_graphs)
                 gHelper.cleanupGraphHelper();
         }
     }
 
     if (TestFixture::use_graphs)
+    {
         HIP_CHECK(hipStreamDestroy(stream));
+    }
 }
 
 template<bool UseGraphs = false, typename config = rocprim::default_config>
@@ -512,18 +445,8 @@ void testMergeMismatchedIteratorTypes()
     std::vector<int> expected_keys_output(2 * keys_input1.size());
     std::iota(expected_keys_output.begin(), expected_keys_output.end(), 0);
 
-    int* d_keys_input1 = nullptr;
-    int* d_keys_output = nullptr;
-    HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input1,
-                                                 keys_input1.size() * sizeof(keys_input1[0])));
-    HIP_CHECK(
-        test_common_utils::hipMallocHelper(&d_keys_output,
-                                           expected_keys_output.size() * sizeof(keys_input1[0])));
-
-    HIP_CHECK(hipMemcpy(d_keys_input1,
-                        keys_input1.data(),
-                        keys_input1.size() * sizeof(keys_input1[0]),
-                        hipMemcpyHostToDevice));
+    common::device_ptr<int> d_keys_input1(keys_input1);
+    common::device_ptr<int> d_keys_output(expected_keys_output.size());
 
     const auto d_keys_input2
         = rocprim::make_transform_iterator(rocprim::make_counting_iterator(0),
@@ -541,9 +464,9 @@ void testMergeMismatchedIteratorTypes()
     size_t temp_storage_size_bytes = 0;
     HIP_CHECK(rocprim::merge<config>(nullptr,
                                      temp_storage_size_bytes,
-                                     d_keys_input1,
+                                     d_keys_input1.get(),
                                      d_keys_input2,
-                                     d_keys_output,
+                                     d_keys_output.get(),
                                      keys_input1.size(),
                                      keys_input1.size(),
                                      rocprim::less<int>{},
@@ -552,8 +475,7 @@ void testMergeMismatchedIteratorTypes()
 
     ASSERT_GT(temp_storage_size_bytes, 0);
 
-    void* d_temp_storage = nullptr;
-    HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
+    common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
 
     test_utils::GraphHelper gHelper;
     if(UseGraphs)
@@ -561,11 +483,11 @@ void testMergeMismatchedIteratorTypes()
         gHelper.startStreamCapture(stream);
     }
 
-    HIP_CHECK(rocprim::merge<config>(d_temp_storage,
+    HIP_CHECK(rocprim::merge<config>(d_temp_storage.get(),
                                      temp_storage_size_bytes,
-                                     d_keys_input1,
+                                     d_keys_input1.get(),
                                      d_keys_input2,
-                                     d_keys_output,
+                                     d_keys_output.get(),
                                      keys_input1.size(),
                                      keys_input1.size(),
                                      rocprim::less<int>{},
@@ -577,17 +499,9 @@ void testMergeMismatchedIteratorTypes()
         gHelper.createAndLaunchGraph(stream);
     }
 
-    std::vector<int> keys_output(expected_keys_output.size());
-    HIP_CHECK(hipMemcpy(keys_output.data(),
-                        d_keys_output,
-                        keys_output.size() * sizeof(keys_output[0]),
-                        hipMemcpyDeviceToHost));
+    const auto keys_output = d_keys_output.load();
 
     ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected_keys_output));
-
-    HIP_CHECK(hipFree(d_temp_storage));
-    HIP_CHECK(hipFree(d_keys_output));
-    HIP_CHECK(hipFree(d_keys_input1));
 
     if (UseGraphs)
     {

--- a/test/rocprim/test_device_merge.cpp
+++ b/test/rocprim/test_device_merge.cpp
@@ -170,26 +170,21 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
 
             test_utils::out_of_bounds_flag out_of_bounds;
 
-            key_type * d_keys_input1;
-            key_type * d_keys_input2;
-            key_type * d_keys_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input1, keys_input1.size() * sizeof(key_type)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input2, keys_input2.size() * sizeof(key_type)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, keys_output.size() * sizeof(key_type)));
-            HIP_CHECK(
-                hipMemcpy(
-                    d_keys_input1, keys_input1.data(),
-                    keys_input1.size() * sizeof(key_type),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(
-                hipMemcpy(
-                    d_keys_input2, keys_input2.data(),
-                    keys_input2.size() * sizeof(key_type),
-                    hipMemcpyHostToDevice
-                )
-            );
+            common::device_ptr<key_type> d_keys_input1;
+            common::device_ptr<key_type> d_keys_input2;
+            common::device_ptr<key_type> d_keys_output;
+
+            if(!d_keys_input1.resize_with_memory_check(keys_input1.size())
+               || !d_keys_input2.resize_with_memory_check(keys_input2.size())
+               || !d_keys_output.resize_with_memory_check(keys_output.size()))
+            {
+                std::cout << "Out of memory. Skipping test with sizes = {" << size1 << ", " << size2
+                          << "}" << std::endl;
+                break;
+            }
+
+            d_keys_input1.store(keys_input1);
+            d_keys_input2.store(keys_input2);
 
             test_utils::bounds_checking_iterator<key_type> d_keys_checking_output(
                 d_keys_output,
@@ -215,7 +210,14 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKey)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test with sizes = {" << size1 << ", " << size2
+                          << "}" << std::endl;
+                break;
+            }
 
             test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
@@ -351,46 +353,29 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
 
             test_utils::out_of_bounds_flag out_of_bounds;
 
-            key_type * d_keys_input1;
-            key_type * d_keys_input2;
-            key_type * d_keys_output;
-            value_type * d_values_input1;
-            value_type * d_values_input2;
-            value_type * d_values_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input1, keys_input1.size() * sizeof(key_type)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input2, keys_input2.size() * sizeof(key_type)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, keys_output.size() * sizeof(key_type)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input1, values_input1.size() * sizeof(value_type)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input2, values_input2.size() * sizeof(value_type)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_output, values_output.size() * sizeof(value_type)));
-            HIP_CHECK(
-                hipMemcpy(
-                    d_keys_input1, keys_input1.data(),
-                    keys_input1.size() * sizeof(key_type),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(
-                hipMemcpy(
-                    d_keys_input2, keys_input2.data(),
-                    keys_input2.size() * sizeof(key_type),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(
-                hipMemcpy(
-                    d_values_input1, values_input1.data(),
-                    values_input1.size() * sizeof(value_type),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(
-                hipMemcpy(
-                    d_values_input2, values_input2.data(),
-                    values_input2.size() * sizeof(value_type),
-                    hipMemcpyHostToDevice
-                )
-            );
+            common::device_ptr<key_type>   d_keys_input1;
+            common::device_ptr<key_type>   d_keys_input2;
+            common::device_ptr<key_type>   d_keys_output;
+            common::device_ptr<value_type> d_values_input1;
+            common::device_ptr<value_type> d_values_input2;
+            common::device_ptr<value_type> d_values_output;
+
+            if(!d_keys_input1.resize_with_memory_check(keys_input1.size())
+               || !d_keys_input2.resize_with_memory_check(keys_input2.size())
+               || !d_keys_output.resize_with_memory_check(keys_output.size())
+               || !d_values_input1.resize_with_memory_check(values_input1.size())
+               || !d_values_input2.resize_with_memory_check(values_input1.size())
+               || !d_values_output.resize_with_memory_check(values_output.size()))
+            {
+                std::cout << "Out of memory. Skipping test with sizes = {" << size1 << ", " << size2
+                          << "}" << std::endl;
+                break;
+            }
+
+            d_keys_input1.store(keys_input1);
+            d_keys_input2.store(keys_input2);
+            d_values_input1.store(values_input1);
+            d_values_input2.store(values_input2);
 
             test_utils::bounds_checking_iterator<key_type> d_keys_checking_output(
                 d_keys_output,
@@ -424,7 +409,14 @@ TYPED_TEST(RocprimDeviceMergeTests, MergeKeyValue)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test with sizes = {" << size1 << ", " << size2
+                          << "}" << std::endl;
+                break;
+            }
 
             test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -80,7 +80,9 @@ using RocprimDeviceSortTestsParams = ::testing::Types<
     DeviceSortParams<test_utils::custom_test_type<float>, test_utils::custom_test_type<double>>,
     DeviceSortParams<int, test_utils::custom_float_type>,
     DeviceSortParams<test_utils::custom_test_array_type<int, 4>>,
-    DeviceSortParams<int, int, ::rocprim::less<int>, true>>;
+    DeviceSortParams<int, int, ::rocprim::less<int>, true>,
+    DeviceSortParams<int, common::custom_huge_type<2048, float>>,
+    DeviceSortParams<common::custom_huge_type<2048*8, long long>>>;
 
 static_assert(std::is_trivially_copyable<test_utils::custom_float_type>::value,
               "Type must be trivially copyable to cover merge sort specialized kernel");
@@ -118,28 +120,24 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             in_place = !in_place;
 
             // Generate data
-            std::vector<key_type> input = test_utils::get_random_data<key_type>(size, -100, 100, seed_value); // float16 can't exceed 65504
-            std::vector<key_type> output(size);
+            std::vector<key_type> input = test_utils::get_random_data_wrapped<key_type>(
+                size,
+                -100,
+                100,
+                seed_value); // float16 can't exceed 65504
 
-            key_type * d_input;
-            key_type * d_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(key_type)));
-            if(in_place)
+            common::device_ptr<key_type> d_input;
+            common::device_ptr<key_type> d_output_alloc;
+
+            if(!d_input.resize_with_memory_check(size)
+               || !d_output_alloc.resize_with_memory_check(in_place ? 0 : size))
             {
-                d_output = d_input;
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
             }
-            else
-            {
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(key_type)));
-            }
-            HIP_CHECK(
-                hipMemcpy(
-                    d_input, input.data(),
-                    input.size() * sizeof(key_type),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+
+            d_input.store(input);
+            common::device_ptr<key_type>& d_output = in_place ? d_input : d_output_alloc;
 
             // compare function
             compare_function compare_op;
@@ -164,8 +162,13 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
-            HIP_CHECK(hipDeviceSynchronize());
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
 
             test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
@@ -257,48 +260,27 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
             std::vector<value_type> values_input(size);
             test_utils::iota(values_input.begin(), values_input.end(), 0);
 
-            std::vector<key_type> keys_output(size);
-            std::vector<value_type> values_output(size);
+            common::device_ptr<key_type>   d_keys_input;
+            common::device_ptr<key_type>   d_keys_output_alloc;
+            common::device_ptr<value_type> d_values_input;
+            common::device_ptr<value_type> d_values_output_alloc;
 
-            key_type * d_keys_input;
-            key_type * d_keys_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, keys_input.size() * sizeof(key_type)));
-            if(in_place)
+            if(!d_keys_input.resize_with_memory_check(size)
+               || !d_keys_output_alloc.resize_with_memory_check(in_place ? 0 : size)
+               || !d_values_input.resize_with_memory_check(size)
+               || !d_values_output_alloc.resize_with_memory_check(in_place ? 0 : size))
             {
-                d_keys_output = d_keys_input;
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
             }
-            else
-            {
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, keys_output.size() * sizeof(key_type)));
-            }
-            HIP_CHECK(
-                hipMemcpy(
-                    d_keys_input, keys_input.data(),
-                    keys_input.size() * sizeof(key_type),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
 
-            value_type * d_values_input;
-            value_type * d_values_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input, values_input.size() * sizeof(value_type)));
-            if(in_place)
-            {
-                d_values_output = d_values_input;
-            }
-            else
-            {
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_output, values_output.size() * sizeof(value_type)));
-            }
-            HIP_CHECK(
-                hipMemcpy(
-                    d_values_input, values_input.data(),
-                    values_input.size() * sizeof(value_type),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+            d_keys_input.store(keys_input);
+            d_values_input.store(values_input);
+
+            common::device_ptr<key_type>& d_keys_output
+                = in_place ? d_keys_input : d_keys_output_alloc;
+            common::device_ptr<value_type>& d_values_output
+                = in_place ? d_values_input : d_values_output_alloc;
 
             // compare function
             compare_function compare_op;
@@ -334,8 +316,13 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
-            HIP_CHECK(hipDeviceSynchronize());
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
 
             test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -82,7 +82,7 @@ using RocprimDeviceSortTestsParams = ::testing::Types<
     DeviceSortParams<test_utils::custom_test_array_type<int, 4>>,
     DeviceSortParams<int, int, ::rocprim::less<int>, true>,
     DeviceSortParams<int, common::custom_huge_type<2048, float>>,
-    DeviceSortParams<common::custom_huge_type<2048*8, long long>>>;
+    DeviceSortParams<common::custom_huge_type<2048, float>>>;
 
 static_assert(std::is_trivially_copyable<test_utils::custom_float_type>::value,
               "Type must be trivially copyable to cover merge sort specialized kernel");

--- a/test/rocprim/test_device_merge_sort.cpp
+++ b/test/rocprim/test_device_merge_sort.cpp
@@ -1,6 +1,6 @@
 /// MIT License
 //
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,9 @@
 // SOFTWARE.
 
 #include "../common_test_header.hpp"
+
+#include "../../common/utils.hpp"
+#include "../../common/utils_device_ptr.hpp"
 
 // required rocprim headers
 #include <rocprim/device/device_merge_sort.hpp>
@@ -80,9 +83,7 @@ using RocprimDeviceSortTestsParams = ::testing::Types<
     DeviceSortParams<test_utils::custom_test_type<float>, test_utils::custom_test_type<double>>,
     DeviceSortParams<int, test_utils::custom_float_type>,
     DeviceSortParams<test_utils::custom_test_array_type<int, 4>>,
-    DeviceSortParams<int, int, ::rocprim::less<int>, true>,
-    DeviceSortParams<int, common::custom_huge_type<2048, float>>,
-    DeviceSortParams<common::custom_huge_type<2048, float>>>;
+    DeviceSortParams<int, int, ::rocprim::less<int>, true>>;
 
 static_assert(std::is_trivially_copyable<test_utils::custom_float_type>::value,
               "Type must be trivially copyable to cover merge sort specialized kernel");
@@ -120,23 +121,11 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             in_place = !in_place;
 
             // Generate data
-            std::vector<key_type> input = test_utils::get_random_data_wrapped<key_type>(
-                size,
-                -100,
-                100,
-                seed_value); // float16 can't exceed 65504
+            std::vector<key_type> input = test_utils::get_random_data<key_type>(size, -100, 100, seed_value); // float16 can't exceed 65504
 
-            common::device_ptr<key_type> d_input;
+            common::device_ptr<key_type> d_input(input);
             common::device_ptr<key_type> d_output_alloc;
-
-            if(!d_input.resize_with_memory_check(size)
-               || !d_output_alloc.resize_with_memory_check(in_place ? 0 : size))
-            {
-                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
-                break;
-            }
-
-            d_input.store(input);
+            d_output_alloc.resize(in_place ? 0 : size);
             common::device_ptr<key_type>& d_output = in_place ? d_input : d_output_alloc;
 
             // compare function
@@ -146,44 +135,38 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             std::vector<key_type> expected(input);
             std::stable_sort(expected.begin(), expected.end(), compare_op);
 
-            // temp storage
-            size_t temp_storage_size_bytes;
-            void * d_temp_storage = nullptr;
             // Get size of d_temp_storage
-            HIP_CHECK(
-                rocprim::merge_sort(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, input.size(),
-                    compare_op, stream, debug_synchronous
-                )
-            );
+            size_t temp_storage_size_bytes;
+            HIP_CHECK(rocprim::merge_sort(nullptr,
+                                          temp_storage_size_bytes,
+                                          d_input.get(),
+                                          d_output.get(),
+                                          input.size(),
+                                          compare_op,
+                                          stream,
+                                          debug_synchronous));
 
             // temp_storage_size_bytes must be >0
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            common::device_ptr<void> d_temp_storage;
-
-            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
-            {
-                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
-                break;
-            }
+            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
 
             test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                gHelper.startStreamCapture(stream);;
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
-            HIP_CHECK(
-                rocprim::merge_sort(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, input.size(),
-                    compare_op, stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(rocprim::merge_sort(d_temp_storage.get(),
+                                          temp_storage_size_bytes,
+                                          d_input.get(),
+                                          d_output.get(),
+                                          input.size(),
+                                          compare_op,
+                                          stream,
+                                          debug_synchronous));
 
             if(TestFixture::use_graphs)
             {
@@ -194,24 +177,10 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host
-            HIP_CHECK(
-                hipMemcpy(
-                    output.data(), d_output,
-                    output.size() * sizeof(key_type),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+            const auto output = d_output.load();
 
             // Check if output values are as expected
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
-
-            HIP_CHECK(hipFree(d_input));
-            if(!in_place)
-            {
-                HIP_CHECK(hipFree(d_output));
-            }
-            HIP_CHECK(hipFree(d_temp_storage));
 
             if (TestFixture::use_graphs)
             {
@@ -260,25 +229,15 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
             std::vector<value_type> values_input(size);
             test_utils::iota(values_input.begin(), values_input.end(), 0);
 
-            common::device_ptr<key_type>   d_keys_input;
-            common::device_ptr<key_type>   d_keys_output_alloc;
-            common::device_ptr<value_type> d_values_input;
-            common::device_ptr<value_type> d_values_output_alloc;
-
-            if(!d_keys_input.resize_with_memory_check(size)
-               || !d_keys_output_alloc.resize_with_memory_check(in_place ? 0 : size)
-               || !d_values_input.resize_with_memory_check(size)
-               || !d_values_output_alloc.resize_with_memory_check(in_place ? 0 : size))
-            {
-                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
-                break;
-            }
-
-            d_keys_input.store(keys_input);
-            d_values_input.store(values_input);
-
+            common::device_ptr<key_type> d_keys_input(keys_input);
+            common::device_ptr<key_type> d_keys_output_alloc;
+            d_keys_output_alloc.resize(in_place ? 0 : size);
             common::device_ptr<key_type>& d_keys_output
                 = in_place ? d_keys_input : d_keys_output_alloc;
+
+            common::device_ptr<value_type> d_values_input(values_input);
+            common::device_ptr<value_type> d_values_output_alloc;
+            d_values_output_alloc.resize(in_place ? 0 : size);
             common::device_ptr<value_type>& d_values_output
                 = in_place ? d_values_input : d_values_output_alloc;
 
@@ -297,16 +256,14 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
                              [compare_op](const key_value& a, const key_value& b)
                              { return compare_op(a.first, b.first); });
 
-            // temp storage
-            size_t temp_storage_size_bytes;
-            void * d_temp_storage = nullptr;
             // Get size of d_temp_storage
-            HIP_CHECK(rocprim::merge_sort(d_temp_storage,
+            size_t temp_storage_size_bytes;
+            HIP_CHECK(rocprim::merge_sort(nullptr,
                                           temp_storage_size_bytes,
-                                          d_keys_input,
-                                          d_keys_output,
-                                          d_values_input,
-                                          d_values_output,
+                                          d_keys_input.get(),
+                                          d_keys_output.get(),
+                                          d_values_input.get(),
+                                          d_values_output.get(),
                                           keys_input.size(),
                                           compare_op,
                                           stream,
@@ -316,29 +273,25 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            common::device_ptr<void> d_temp_storage;
-
-            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
-            {
-                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
-                break;
-            }
+            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
 
             test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
             {
-                gHelper.startStreamCapture(stream);;
+                gHelper.startStreamCapture(stream);
             }
 
             // Run
-            HIP_CHECK(
-                rocprim::merge_sort(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_keys_input, d_keys_output,
-                    d_values_input, d_values_output, keys_input.size(),
-                    compare_op, stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(rocprim::merge_sort(d_temp_storage.get(),
+                                          temp_storage_size_bytes,
+                                          d_keys_input.get(),
+                                          d_keys_output.get(),
+                                          d_values_input.get(),
+                                          d_values_output.get(),
+                                          keys_input.size(),
+                                          compare_op,
+                                          stream,
+                                          debug_synchronous));
 
             if(TestFixture::use_graphs)
             {
@@ -349,21 +302,8 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
             HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host
-            HIP_CHECK(
-                hipMemcpy(
-                    keys_output.data(), d_keys_output,
-                    keys_output.size() * sizeof(key_type),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(
-                hipMemcpy(
-                    values_output.data(), d_values_output,
-                    values_output.size() * sizeof(value_type),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+            const auto keys_output   = d_keys_output.load();
+            const auto values_output = d_values_output.load();
 
             // Check if output values are as expected
             std::vector<key_type> expected_key(expected.size());
@@ -376,15 +316,6 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected_key));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, expected_value));
-
-            HIP_CHECK(hipFree(d_keys_input));
-            HIP_CHECK(hipFree(d_values_input));
-            if(!in_place)
-            {
-                HIP_CHECK(hipFree(d_keys_output));
-                HIP_CHECK(hipFree(d_values_output));
-            }
-            HIP_CHECK(hipFree(d_temp_storage));
 
             if (TestFixture::use_graphs)
             {
@@ -427,8 +358,7 @@ void testLargeIndices()
                                                rocprim::identity<key_type>());
 
         key_type*  d_output;
-        hipError_t malloc_status
-            = test_common_utils::hipMallocHelper(&d_output, size * sizeof(*d_output));
+        hipError_t malloc_status = common::hipMallocHelper(&d_output, size * sizeof(*d_output));
         if(malloc_status == hipErrorOutOfMemory)
         {
             std::cout << "Out of memory. Skipping size = " << size << std::endl;
@@ -456,8 +386,7 @@ void testLargeIndices()
         ASSERT_GT(temp_storage_size_bytes, 0);
 
         // allocate temporary storage
-        malloc_status
-            = test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes);
+        malloc_status = common::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes);
         if(malloc_status == hipErrorOutOfMemory)
         {
             std::cout << "Out of memory. Skipping size = " << size << std::endl;
@@ -485,7 +414,7 @@ void testLargeIndices()
                             hipMemcpyDeviceToHost));
 
         // Check if output values are as expected
-        const size_t unique_keys    = size_t(test_utils::numeric_limits<key_type>::max()) + 1;
+        const size_t unique_keys = size_t(test_utils::numeric_limits<key_type>::max()) + 1;
         const size_t segment_length = rocprim::detail::ceiling_div(size, unique_keys);
         const size_t full_segments  = size % unique_keys == 0 ? unique_keys : size % unique_keys;
         for(size_t i = 0; i < size; i += 4321)

--- a/test/rocprim/test_device_partition.cpp
+++ b/test/rocprim/test_device_partition.cpp
@@ -117,18 +117,21 @@ TYPED_TEST(RocprimDevicePartitionTests, Flagged)
             std::vector<T> input = test_utils::get_random_data<T>(size, 1, 100, seed_value);
             std::vector<F> flags = test_utils::get_random_data01<F>(size, 0.25, seed_value);
 
-            T * d_input;
-            F * d_flags;
-            U * d_output;
-            unsigned int * d_selected_count_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_flags, flags.size() * sizeof(F)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, input.size() * sizeof(U)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
-            HIP_CHECK(
-                hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
-            HIP_CHECK(
-                hipMemcpy(d_flags, flags.data(), flags.size() * sizeof(F), hipMemcpyHostToDevice));
+            common::device_ptr<T>            d_input;
+            common::device_ptr<F>            d_flags;
+            common::device_ptr<U>            d_output;
+            common::device_ptr<unsigned int> d_selected_count_output;
+
+            if(!d_input.resize_with_memory_check(size) || !d_flags.resize_with_memory_check(size)
+               || !d_output.resize_with_memory_check(size)
+               || !d_selected_count_output.resize_with_memory_check(1))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
+
+            d_input.store(input);
+            d_flags.store(flags);
 
             // Calculate expected_selected and expected_rejected results on host
             std::vector<U> expected_selected;
@@ -167,8 +170,13 @@ TYPED_TEST(RocprimDevicePartitionTests, Flagged)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            void* d_temp_storage = nullptr;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
 
             test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
@@ -382,14 +390,19 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
             // Generate data
             std::vector<T> input = test_utils::get_random_data<T>(size, 1, 100, seed_value);
 
-            T * d_input;
-            U * d_output;
-            unsigned int * d_selected_count_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, input.size() * sizeof(U)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
-            HIP_CHECK(
-                hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
+            common::device_ptr<T>            d_input;
+            common::device_ptr<U>            d_output;
+            common::device_ptr<unsigned int> d_selected_count_output;
+
+            if(!d_input.resize_with_memory_check(size)
+               || !d_output.resize_with_memory_check(size)
+               || !d_selected_count_output.resize_with_memory_check(1))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
+
+            d_input.store(input);
 
             // Calculate expected_selected and expected_rejected results on host
             std::vector<U> expected_selected;
@@ -427,8 +440,13 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            void* d_temp_storage = nullptr;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
 
             test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
@@ -532,19 +550,20 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
             // Generate data
             std::vector<T> input = test_utils::get_random_data<T>(size, 1, 100, seed_value);
 
-            T* d_input;
-            U* d_selected;
-            U* d_rejected;
+            common::device_ptr<T>            d_input;
+            common::device_ptr<U>            d_selected;
+            common::device_ptr<U>            d_rejected;
+            common::device_ptr<unsigned int> d_selected_count_output;
 
-            unsigned int* d_selected_count_output;
+            if(!d_input.resize_with_memory_check(size) || !d_selected.resize_with_memory_check(size)
+               || !d_rejected.resize_with_memory_check(size)
+               || !d_selected_count_output.resize_with_memory_check(1))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
 
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected, input.size() * sizeof(U)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_rejected, input.size() * sizeof(U)));
-            HIP_CHECK(
-                test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
-            HIP_CHECK(
-                hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
+            d_input.store(input);
 
             // Calculate expected_selected and expected_rejected results on host
             std::vector<U> expected_selected;
@@ -582,8 +601,13 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            void* d_temp_storage = nullptr;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
 
             test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
@@ -710,28 +734,23 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
                 // Generate data
                 const auto input = test_utils::get_random_data<T>(size, 1, 100, seed_value);
 
-                // Output
-                auto selected_counts = std::array<unsigned int, 2>{};
+                common::device_ptr<T>            d_input;
+                common::device_ptr<U>            d_first_output;
+                common::device_ptr<U>            d_second_output;
+                common::device_ptr<U>            d_unselected_output;
+                common::device_ptr<unsigned int> d_selected_counts;
 
-                T* d_input                      = nullptr;
-                U* d_first_output               = nullptr;
-                U* d_second_output              = nullptr;
-                U* d_unselected_output          = nullptr;
-                unsigned int* d_selected_counts = nullptr;
+                if(!d_input.resize_with_memory_check(size)
+                   || !d_first_output.resize_with_memory_check(size)
+                   || !d_second_output.resize_with_memory_check(size)
+                   || !d_unselected_output.resize_with_memory_check(size)
+                   || !d_selected_counts.resize_with_memory_check(2))
+                {
+                    std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                    break;
+                }
 
-                HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
-                HIP_CHECK(hipMalloc(&d_first_output, input.size() * sizeof(U)));
-                HIP_CHECK(hipMalloc(&d_second_output, input.size() * sizeof(U)));
-                HIP_CHECK(hipMalloc(&d_unselected_output, input.size() * sizeof(U)));
-                HIP_CHECK(hipMalloc(&d_selected_counts, sizeof(selected_counts)));
-                HIP_CHECK(
-                    hipMemcpy(
-                        d_input, input.data(),
-                        input.size() * sizeof(T),
-                        hipMemcpyHostToDevice
-                    )
-                );
-
+                d_input.store(input);
 
                 const auto first_op = LessOp<T>{std::get<0>(limits)};
                 const auto second_op = LessOp<T>{std::get<1>(limits)};
@@ -776,8 +795,13 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
                 ASSERT_GT(temp_storage_size_bytes, 0);
 
                 // allocate temporary storage
-                void* d_temp_storage = nullptr;
-                HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
+                common::device_ptr<void> d_temp_storage;
+
+                if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+                {
+                    std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                    break;
+                }
 
                 test_utils::GraphHelper gHelper;;
                 if(TestFixture::use_graphs)

--- a/test/rocprim/test_device_partition.cpp
+++ b/test/rocprim/test_device_partition.cpp
@@ -22,6 +22,9 @@
 
 #include "../common_test_header.hpp"
 
+#include "../../common/utils.hpp"
+#include "../../common/utils_device_ptr.hpp"
+
 // required rocprim headers
 #include <rocprim/device/device_partition.hpp>
 #include <rocprim/iterator/constant_iterator.hpp>
@@ -158,10 +161,10 @@ TYPED_TEST(RocprimDevicePartitionTests, Flagged)
             HIP_CHECK(rocprim::partition<config>(
                 nullptr,
                 temp_storage_size_bytes,
-                d_input,
-                d_flags,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                d_selected_count_output,
+                d_input.get(),
+                d_flags.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                d_selected_count_output.get(),
                 input.size(),
                 stream,
                 debug_synchronous));
@@ -186,12 +189,12 @@ TYPED_TEST(RocprimDevicePartitionTests, Flagged)
 
             // Run
             HIP_CHECK(rocprim::partition<config>(
-                d_temp_storage,
+                d_temp_storage.get(),
                 temp_storage_size_bytes,
-                d_input,
-                d_flags,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                d_selected_count_output,
+                d_input.get(),
+                d_flags.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                d_selected_count_output.get(),
                 input.size(),
                 stream,
                 debug_synchronous));
@@ -202,19 +205,11 @@ TYPED_TEST(RocprimDevicePartitionTests, Flagged)
             }
 
             // Check if number of selected value is as expected_selected
-            unsigned int selected_count_output = 0;
-            HIP_CHECK(hipMemcpy(&selected_count_output,
-                                d_selected_count_output,
-                                sizeof(unsigned int),
-                                hipMemcpyDeviceToHost));
+            unsigned int selected_count_output = d_selected_count_output.load()[0];
             ASSERT_EQ(selected_count_output, expected_selected.size());
 
             // Check if output values are as expected_selected
-            std::vector<U> output(input.size());
-            HIP_CHECK(hipMemcpy(output.data(),
-                                d_output,
-                                output.size() * sizeof(U),
-                                hipMemcpyDeviceToHost));
+            auto output = d_output.load();
 
             std::vector<U> output_rejected;
             for(size_t i = 0; i < expected_rejected.size(); i++)
@@ -224,12 +219,6 @@ TYPED_TEST(RocprimDevicePartitionTests, Flagged)
             }
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected_selected, expected_selected.size()));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_rejected, expected_rejected, expected_rejected.size()));
-
-            HIP_CHECK(hipFree(d_input));
-            HIP_CHECK(hipFree(d_flags));
-            HIP_CHECK(hipFree(d_output));
-            HIP_CHECK(hipFree(d_selected_count_output));
-            HIP_CHECK(hipFree(d_temp_storage));
 
             if(TestFixture::use_graphs)
             {
@@ -427,9 +416,9 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
             HIP_CHECK(rocprim::partition<config>(
                 nullptr,
                 temp_storage_size_bytes,
-                d_input,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                d_selected_count_output,
+                d_input.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                d_selected_count_output.get(),
                 input.size(),
                 select_op,
                 stream,
@@ -455,11 +444,11 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
 
             // Run
             HIP_CHECK(rocprim::partition<config>(
-                d_temp_storage,
+                d_temp_storage.get(),
                 temp_storage_size_bytes,
-                d_input,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                d_selected_count_output,
+                d_input.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                d_selected_count_output.get(),
                 input.size(),
                 select_op,
                 stream,
@@ -474,19 +463,11 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
             HIP_CHECK(hipDeviceSynchronize());
 
             // Check if number of selected value is as expected_selected
-            unsigned int selected_count_output = 0;
-            HIP_CHECK(hipMemcpy(&selected_count_output,
-                                d_selected_count_output,
-                                sizeof(unsigned int),
-                                hipMemcpyDeviceToHost));
+            unsigned int selected_count_output = d_selected_count_output.load()[0];
             ASSERT_EQ(selected_count_output, expected_selected.size());
             
             // Check if output values are as expected_selected
-            std::vector<U> output(input.size());
-            HIP_CHECK(hipMemcpy(output.data(),
-                                d_output,
-                                output.size() * sizeof(U),
-                                hipMemcpyDeviceToHost));
+            const auto output = d_output.load();
 
             std::vector<U> output_rejected;
             for(size_t i = 0; i < expected_rejected.size(); i++)
@@ -496,11 +477,6 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
             }
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected_selected, expected_selected.size()));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_rejected, expected_rejected, expected_rejected.size()));
-
-            HIP_CHECK(hipFree(d_input));
-            HIP_CHECK(hipFree(d_output));
-            HIP_CHECK(hipFree(d_selected_count_output));
-            HIP_CHECK(hipFree(d_temp_storage));
 
             if(TestFixture::use_graphs)
             {
@@ -587,10 +563,10 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
             HIP_CHECK(rocprim::partition_two_way<config>(
                 nullptr,
                 temp_storage_size_bytes,
-                d_input,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_selected),
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_rejected),
-                d_selected_count_output,
+                d_input.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_selected.get()),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_rejected.get()),
+                d_selected_count_output.get(),
                 input.size(),
                 select_op,
                 stream,
@@ -616,12 +592,12 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
 
             // Run
             HIP_CHECK(rocprim::partition_two_way<config>(
-                d_temp_storage,
+                d_temp_storage.get(),
                 temp_storage_size_bytes,
-                d_input,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_selected),
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_rejected),
-                d_selected_count_output,
+                d_input.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_selected.get()),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_rejected.get()),
+                d_selected_count_output.get(),
                 input.size(),
                 select_op,
                 stream,
@@ -636,35 +612,17 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
             HIP_CHECK(hipDeviceSynchronize());
 
             // Check if number of selected value is as expected
-            unsigned int selected_count_output = 0;
-            HIP_CHECK(hipMemcpy(&selected_count_output,
-                                d_selected_count_output,
-                                sizeof(unsigned int),
-                                hipMemcpyDeviceToHost));
+            unsigned int selected_count_output = d_selected_count_output.load()[0];
             ASSERT_EQ(selected_count_output, expected_selected.size());
 
             // Check if output values are as expected
-            std::vector<U> selected(input.size());
-            std::vector<U> rejected(input.size());
-            HIP_CHECK(hipMemcpy(selected.data(),
-                                d_selected,
-                                selected.size() * sizeof(U),
-                                hipMemcpyDeviceToHost));
-            HIP_CHECK(hipMemcpy(rejected.data(),
-                                d_rejected,
-                                rejected.size() * sizeof(U),
-                                hipMemcpyDeviceToHost));
+            const auto selected = d_selected.load();
+            const auto rejected = d_rejected.load();
 
             ASSERT_NO_FATAL_FAILURE(
                 test_utils::assert_eq(selected, expected_selected, expected_selected.size()));
             ASSERT_NO_FATAL_FAILURE(
                 test_utils::assert_eq(rejected, expected_rejected, expected_rejected.size()));
-
-            HIP_CHECK(hipFree(d_input));
-            HIP_CHECK(hipFree(d_selected));
-            HIP_CHECK(hipFree(d_rejected));
-            HIP_CHECK(hipFree(d_selected_count_output));
-            HIP_CHECK(hipFree(d_temp_storage));
 
             if(TestFixture::use_graphs)
             {
@@ -778,12 +736,12 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
                 HIP_CHECK(rocprim::partition_three_way<config>(
                     nullptr,
                     temp_storage_size_bytes,
-                    d_input,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_first_output),
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_second_output),
+                    d_input.get(),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_first_output.get()),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_second_output.get()),
                     test_utils::wrap_in_identity_iterator<use_identity_iterator>(
-                        d_unselected_output),
-                    d_selected_counts,
+                        d_unselected_output.get()),
+                    d_selected_counts.get(),
                     input.size(),
                     first_op,
                     second_op,
@@ -810,14 +768,14 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
 
                 // Run
                 HIP_CHECK(rocprim::partition_three_way<config>(
-                    d_temp_storage,
+                    d_temp_storage.get(),
                     temp_storage_size_bytes,
-                    d_input,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_first_output),
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_second_output),
+                    d_input.get(),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_first_output.get()),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_second_output.get()),
                     test_utils::wrap_in_identity_iterator<use_identity_iterator>(
-                        d_unselected_output),
-                    d_selected_counts,
+                        d_unselected_output.get()),
+                    d_selected_counts.get(),
                     input.size(),
                     first_op,
                     second_op,
@@ -833,13 +791,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
                 HIP_CHECK(hipDeviceSynchronize());
 
                 // Check if number of selected value is as expected_selected
-                HIP_CHECK(
-                    hipMemcpy(
-                        selected_counts.data(), d_selected_counts,
-                        sizeof(selected_counts),
-                        hipMemcpyDeviceToHost
-                    )
-                );
+                const auto selected_counts = d_selected_counts.load_to_array<2>();
                 ASSERT_EQ(selected_counts, expected_counts);
 
                 // Check if output values are as expected_selected
@@ -847,14 +799,14 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
                     auto result = std::vector<U>(input.size());
                     HIP_CHECK(
                         hipMemcpy(
-                            result.data(), d_first_output,
+                            result.data(), d_first_output.get(),
                             expected_counts[0] * sizeof(result[0]),
                             hipMemcpyDeviceToHost
                         )
                     );
                     HIP_CHECK(
                         hipMemcpy(
-                            result.data() + expected_counts[0], d_second_output,
+                            result.data() + expected_counts[0], d_second_output.get(),
                             expected_counts[1] * sizeof(result[0]),
                             hipMemcpyDeviceToHost
                         )
@@ -862,7 +814,7 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
                     HIP_CHECK(
                         hipMemcpy(
                             result.data() + expected_counts[0] + expected_counts[1],
-                            d_unselected_output,
+                            d_unselected_output.get(),
                             (input.size() - expected_counts[0] - expected_counts[1]) * sizeof(result[0]),
                             hipMemcpyDeviceToHost
                         )
@@ -871,13 +823,6 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateThreeWay)
                 }();
 
                 ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected, expected.size()));
-
-                HIP_CHECK(hipFree(d_input));
-                HIP_CHECK(hipFree(d_first_output));
-                HIP_CHECK(hipFree(d_second_output));
-                HIP_CHECK(hipFree(d_unselected_output));
-                HIP_CHECK(hipFree(d_selected_counts));
-                HIP_CHECK(hipFree(d_temp_storage));
 
                 if(TestFixture::use_graphs)
                 {

--- a/test/rocprim/test_device_partition.cpp
+++ b/test/rocprim/test_device_partition.cpp
@@ -394,8 +394,7 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
             common::device_ptr<U>            d_output;
             common::device_ptr<unsigned int> d_selected_count_output;
 
-            if(!d_input.resize_with_memory_check(size)
-               || !d_output.resize_with_memory_check(size)
+            if(!d_input.resize_with_memory_check(size) || !d_output.resize_with_memory_check(size)
                || !d_selected_count_output.resize_with_memory_check(1))
             {
                 std::cout << "Out of memory. Skipping test for size = " << size << std::endl;

--- a/test/rocprim/test_device_select.cpp
+++ b/test/rocprim/test_device_select.cpp
@@ -22,6 +22,9 @@
 
 #include "../common_test_header.hpp"
 
+#include "../../common/utils.hpp"
+#include "../../common/utils_device_ptr.hpp"
+
 // required rocprim headers
 #include <rocprim/device/device_select.hpp>
 #include <rocprim/iterator/constant_iterator.hpp>
@@ -142,10 +145,10 @@ TYPED_TEST(RocprimDeviceSelectTests, Flagged)
             HIP_CHECK(rocprim::select(
                 nullptr,
                 temp_storage_size_bytes,
-                d_input,
-                d_flags,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                d_selected_count_output,
+                d_input.get(),
+                d_flags.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                d_selected_count_output.get(),
                 input.size(),
                 stream,
                 TestFixture::debug_synchronous));
@@ -171,19 +174,16 @@ TYPED_TEST(RocprimDeviceSelectTests, Flagged)
             }
 
             // Run
-            HIP_CHECK(
-                rocprim::select(
-                    d_temp_storage,
-                    temp_storage_size_bytes,
-                    d_input,
-                    d_flags,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                    d_selected_count_output,
-                    input.size(),
-                    stream,
-                    TestFixture::debug_synchronous
-                )
-            );
+            HIP_CHECK(rocprim::select(
+                d_temp_storage.get(),
+                temp_storage_size_bytes,
+                d_input.get(),
+                d_flags.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                d_selected_count_output.get(),
+                input.size(),
+                stream,
+                TestFixture::debug_synchronous));
 
             
             if(TestFixture::use_graphs)
@@ -194,34 +194,12 @@ TYPED_TEST(RocprimDeviceSelectTests, Flagged)
             HIP_CHECK(hipDeviceSynchronize());
 
             // Check if number of selected value is as expected
-            unsigned int selected_count_output = 0;
-            HIP_CHECK(
-                hipMemcpy(
-                    &selected_count_output, d_selected_count_output,
-                    sizeof(unsigned int),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+            const auto selected_count_output = d_selected_count_output.load()[0];
             ASSERT_EQ(selected_count_output, expected.size());
 
             // Check if output values are as expected
-            std::vector<U> output(input.size());
-            HIP_CHECK(
-                hipMemcpy(
-                    output.data(), d_output,
-                    output.size() * sizeof(U),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+            const auto output = d_output.load();
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected, expected.size()));
-
-            HIP_CHECK(hipFree(d_input));
-            HIP_CHECK(hipFree(d_flags));
-            HIP_CHECK(hipFree(d_output));
-            HIP_CHECK(hipFree(d_selected_count_output));
-            HIP_CHECK(hipFree(d_temp_storage));
 
             if(TestFixture::use_graphs)
             {
@@ -307,9 +285,9 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectOp)
             HIP_CHECK(rocprim::select(
                 nullptr,
                 temp_storage_size_bytes,
-                d_input,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                d_selected_count_output,
+                d_input.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                d_selected_count_output.get(),
                 input.size(),
                 select_op<T>(),
                 stream,
@@ -336,19 +314,16 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectOp)
             }
 
             // Run
-            HIP_CHECK(
-                rocprim::select(
-                    d_temp_storage,
-                    temp_storage_size_bytes,
-                    d_input,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                    d_selected_count_output,
-                    input.size(),
-                    select_op<T>(),
-                    stream,
-                    debug_synchronous
-                )
-            );
+            HIP_CHECK(rocprim::select(
+                d_temp_storage.get(),
+                temp_storage_size_bytes,
+                d_input.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                d_selected_count_output.get(),
+                input.size(),
+                select_op<T>(),
+                stream,
+                debug_synchronous));
 
             
             if(TestFixture::use_graphs)
@@ -359,33 +334,12 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectOp)
             HIP_CHECK(hipDeviceSynchronize());
 
             // Check if number of selected value is as expected
-            unsigned int selected_count_output = 0;
-            HIP_CHECK(
-                hipMemcpy(
-                    &selected_count_output, d_selected_count_output,
-                    sizeof(unsigned int),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+            const auto selected_count_output = d_selected_count_output.load()[0];
             ASSERT_EQ(selected_count_output, expected.size());
 
             // Check if output values are as expected
-            std::vector<U> output(input.size());
-            HIP_CHECK(
-                hipMemcpy(
-                    output.data(), d_output,
-                    output.size() * sizeof(U),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+            const auto output = d_output.load();
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected, expected.size()));
-
-            HIP_CHECK(hipFree(d_input));
-            HIP_CHECK(hipFree(d_output));
-            HIP_CHECK(hipFree(d_selected_count_output));
-            HIP_CHECK(hipFree(d_temp_storage));
 
             if(TestFixture::use_graphs)
             {
@@ -465,10 +419,10 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectFlagged)
             HIP_CHECK(rocprim::select(
                 nullptr,
                 temp_storage_size_bytes,
-                d_input,
-                d_flags,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                d_selected_count_output,
+                d_input.get(),
+                d_flags.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                d_selected_count_output.get(),
                 input.size(),
                 select_op<F>(),
                 stream,
@@ -496,12 +450,12 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectFlagged)
 
             // Run
             HIP_CHECK(rocprim::select(
-                d_temp_storage,
+                d_temp_storage.get(),
                 temp_storage_size_bytes,
-                d_input,
-                d_flags,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                d_selected_count_output,
+                d_input.get(),
+                d_flags.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                d_selected_count_output.get(),
                 input.size(),
                 select_op<F>(),
                 stream,
@@ -515,26 +469,12 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectFlagged)
             HIP_CHECK(hipDeviceSynchronize());
 
             // Check if number of selected value is as expected
-            unsigned int selected_count_output = 0;
-            HIP_CHECK(hipMemcpy(&selected_count_output,
-                                d_selected_count_output,
-                                sizeof(unsigned int),
-                                hipMemcpyDeviceToHost));
+            const auto selected_count_output = d_selected_count_output.load()[0];
             ASSERT_EQ(selected_count_output, expected.size());
 
             // Check if output values are as expected
-            std::vector<U> output(input.size());
-            HIP_CHECK(hipMemcpy(output.data(),
-                                d_output,
-                                output.size() * sizeof(U),
-                                hipMemcpyDeviceToHost));
+            const auto output = d_output.load();
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected, expected.size()));
-
-            HIP_CHECK(hipFree(d_input));
-            HIP_CHECK(hipFree(d_flags));
-            HIP_CHECK(hipFree(d_output));
-            HIP_CHECK(hipFree(d_selected_count_output));
-            HIP_CHECK(hipFree(d_temp_storage));
 
             if(TestFixture::use_graphs)
             {
@@ -637,9 +577,9 @@ TYPED_TEST(RocprimDeviceSelectTests, Unique)
                 HIP_CHECK(rocprim::unique(
                     nullptr,
                     temp_storage_size_bytes,
-                    d_input,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                    d_selected_count_output,
+                    d_input.get(),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                    d_selected_count_output.get(),
                     input.size(),
                     op_type(),
                     stream,
@@ -666,19 +606,16 @@ TYPED_TEST(RocprimDeviceSelectTests, Unique)
                 }
 
                 // Run
-                HIP_CHECK(
-                    rocprim::unique(
-                        d_temp_storage,
-                        temp_storage_size_bytes,
-                        d_input,
-                        test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output),
-                        d_selected_count_output,
-                        input.size(),
-                        op_type(),
-                        stream,
-                        debug_synchronous
-                    )
-                );
+                HIP_CHECK(rocprim::unique(
+                    d_temp_storage.get(),
+                    temp_storage_size_bytes,
+                    d_input.get(),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
+                    d_selected_count_output.get(),
+                    input.size(),
+                    op_type(),
+                    stream,
+                    debug_synchronous));
 
                 
                 if(TestFixture::use_graphs)
@@ -689,33 +626,12 @@ TYPED_TEST(RocprimDeviceSelectTests, Unique)
                 HIP_CHECK(hipDeviceSynchronize());
 
                 // Check if number of selected value is as expected
-                unsigned int selected_count_output = 0;
-                HIP_CHECK(
-                    hipMemcpy(
-                        &selected_count_output, d_selected_count_output,
-                        sizeof(unsigned int),
-                        hipMemcpyDeviceToHost
-                    )
-                );
-                HIP_CHECK(hipDeviceSynchronize());
+                const auto selected_count_output = d_selected_count_output.load()[0];
                 ASSERT_EQ(selected_count_output, expected.size());
 
                 // Check if output values are as expected
-                std::vector<U> output(input.size());
-                HIP_CHECK(
-                    hipMemcpy(
-                        output.data(), d_output,
-                        output.size() * sizeof(U),
-                        hipMemcpyDeviceToHost
-                    )
-                );
-                HIP_CHECK(hipDeviceSynchronize());
+                const auto output = d_output.load();
                 ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected, expected.size()));
-
-                HIP_CHECK(hipFree(d_input));
-                HIP_CHECK(hipFree(d_output));
-                HIP_CHECK(hipFree(d_selected_count_output));
-                HIP_CHECK(hipFree(d_temp_storage));
 
                 if(TestFixture::use_graphs)
                 {
@@ -1086,21 +1002,20 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKey)
                 // temp storage
                 size_t temp_storage_size_bytes;
                 // Get size of d_temp_storage
-                HIP_CHECK(
-                    rocprim::unique_by_key(
-                        nullptr,
-                        temp_storage_size_bytes,
-                        d_keys_input,
-                        d_values_input,
-                        test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_keys_output),
-                        test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_values_output),
-                        d_selected_count_output,
-                        input_keys.size(),
-                        op_type(),
-                        stream,
-                        debug_synchronous
-                    )
-                );
+                HIP_CHECK(rocprim::unique_by_key(
+                    nullptr,
+                    temp_storage_size_bytes,
+                    d_keys_input.get(),
+                    d_values_input.get(),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                        d_keys_output.get()),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                        d_values_output.get()),
+                    d_selected_count_output.get(),
+                    input_keys.size(),
+                    op_type(),
+                    stream,
+                    debug_synchronous));
 
                 HIP_CHECK(hipDeviceSynchronize());
 
@@ -1123,22 +1038,20 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKey)
                 }
 
                 // Run
-                HIP_CHECK(
-                    rocprim::unique_by_key(
-                        d_temp_storage,
-                        temp_storage_size_bytes,
-                        d_keys_input,
-                        d_values_input,
-                        test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_keys_output),
-                        test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_values_output),
-                        d_selected_count_output,
-                        input_keys.size(),
-                        op_type(),
-                        stream,
-                        debug_synchronous
-                    )
-                );
-
+                HIP_CHECK(rocprim::unique_by_key(
+                    d_temp_storage.get(),
+                    temp_storage_size_bytes,
+                    d_keys_input.get(),
+                    d_values_input.get(),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                        d_keys_output.get()),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                        d_values_output.get()),
+                    d_selected_count_output.get(),
+                    input_keys.size(),
+                    op_type(),
+                    stream,
+                    debug_synchronous));
                 
                 if(TestFixture::use_graphs)
                 {
@@ -1148,44 +1061,16 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKey)
                 HIP_CHECK(hipDeviceSynchronize());
 
                 // Check if number of selected value is as expected
-                unsigned int selected_count_output = 0;
-                HIP_CHECK(
-                    hipMemcpy(
-                        &selected_count_output, d_selected_count_output,
-                        sizeof(unsigned int),
-                        hipMemcpyDeviceToHost
-                    )
-                );
-                HIP_CHECK(hipDeviceSynchronize());
+                const auto selected_count_output = d_selected_count_output.load()[0];
                 ASSERT_EQ(selected_count_output, expected_keys.size());
 
                 // Check if outputs are as expected
-                std::vector<output_key_type> output_keys(input_keys.size());
-                HIP_CHECK(
-                    hipMemcpy(
-                        output_keys.data(), d_keys_output,
-                        output_keys.size() * sizeof(output_keys[0]),
-                        hipMemcpyDeviceToHost
-                    )
-                );
-                std::vector<output_value_type> output_values(input_values.size());
-                HIP_CHECK(
-                    hipMemcpy(
-                        output_values.data(), d_values_output,
-                        output_values.size() * sizeof(output_values[0]),
-                        hipMemcpyDeviceToHost
-                    )
-                );
-                HIP_CHECK(hipDeviceSynchronize());
-                ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_keys, expected_keys, expected_keys.size()));
-                ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_values, expected_values, expected_values.size()));
-
-                HIP_CHECK(hipFree(d_keys_input));
-                HIP_CHECK(hipFree(d_values_input));
-                HIP_CHECK(hipFree(d_keys_output));
-                HIP_CHECK(hipFree(d_values_output));
-                HIP_CHECK(hipFree(d_selected_count_output));
-                HIP_CHECK(hipFree(d_temp_storage));
+                const auto output_keys   = d_keys_output.load();
+                const auto output_values = d_values_output.load();
+                ASSERT_NO_FATAL_FAILURE(
+                    test_utils::assert_eq(output_keys, expected_keys, expected_keys.size()));
+                ASSERT_NO_FATAL_FAILURE(
+                    test_utils::assert_eq(output_values, expected_values, expected_values.size()));
 
                 if(TestFixture::use_graphs)
                 {
@@ -1295,11 +1180,13 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKeyAlias)
                 HIP_CHECK(rocprim::unique_by_key(
                     nullptr,
                     temp_storage_size_bytes,
-                    d_keys_input,
-                    d_values_input,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_keys_input),
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_values_input),
-                    d_selected_count_output,
+                    d_keys_input.get(),
+                    d_values_input.get(),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                        d_keys_input.get()),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                        d_values_input.get()),
+                    d_selected_count_output.get(),
                     input_keys.size(),
                     op_type(),
                     stream,
@@ -1327,13 +1214,15 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKeyAlias)
 
                 // Run
                 HIP_CHECK(rocprim::unique_by_key(
-                    d_temp_storage,
+                    d_temp_storage.get(),
                     temp_storage_size_bytes,
-                    d_keys_input,
-                    d_values_input,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_keys_input),
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_values_input),
-                    d_selected_count_output,
+                    d_keys_input.get(),
+                    d_values_input.get(),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                        d_keys_input.get()),
+                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                        d_values_input.get()),
+                    d_selected_count_output.get(),
                     input_keys.size(),
                     op_type(),
                     stream,
@@ -1348,35 +1237,16 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKeyAlias)
                 HIP_CHECK(hipDeviceSynchronize());
 
                 // Check if number of selected value is as expected
-                unsigned int selected_count_output = 0;
-                HIP_CHECK(hipMemcpy(&selected_count_output,
-                                    d_selected_count_output,
-                                    sizeof(unsigned int),
-                                    hipMemcpyDeviceToHost));
-                HIP_CHECK(hipDeviceSynchronize());
+                const auto selected_count_output = d_selected_count_output.load()[0];
                 ASSERT_EQ(selected_count_output, expected_keys.size());
 
                 // Check if outputs are as expected
-                std::vector<output_key_type> output_keys(input_keys.size());
-                HIP_CHECK(hipMemcpy(output_keys.data(),
-                                    d_keys_input,
-                                    output_keys.size() * sizeof(output_keys[0]),
-                                    hipMemcpyDeviceToHost));
-                std::vector<output_value_type> output_values(input_values.size());
-                HIP_CHECK(hipMemcpy(output_values.data(),
-                                    d_values_input,
-                                    output_values.size() * sizeof(output_values[0]),
-                                    hipMemcpyDeviceToHost));
-                HIP_CHECK(hipDeviceSynchronize());
+                const auto output_keys   = d_keys_input.load();
+                const auto output_values = d_values_input.load();
                 ASSERT_NO_FATAL_FAILURE(
                     test_utils::assert_eq(output_keys, expected_keys, expected_keys.size()));
                 ASSERT_NO_FATAL_FAILURE(
                     test_utils::assert_eq(output_values, expected_values, expected_values.size()));
-
-                HIP_CHECK(hipFree(d_keys_input));
-                HIP_CHECK(hipFree(d_values_input));
-                HIP_CHECK(hipFree(d_selected_count_output));
-                HIP_CHECK(hipFree(d_temp_storage));
 
                 if(TestFixture::use_graphs)
                 {

--- a/test/rocprim/test_device_select.cpp
+++ b/test/rocprim/test_device_select.cpp
@@ -109,29 +109,21 @@ TYPED_TEST(RocprimDeviceSelectTests, Flagged)
             std::vector<T> input = test_utils::get_random_data<T>(size, 1, 100, seed_value);
             std::vector<F> flags = test_utils::get_random_data<F>(size, 0, 1, seed_value);
 
-            T * d_input;
-            F * d_flags;
-            U * d_output;
-            unsigned int * d_selected_count_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_flags, flags.size() * sizeof(F)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, input.size() * sizeof(U)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
-            HIP_CHECK(
-                hipMemcpy(
-                    d_input, input.data(),
-                    input.size() * sizeof(T),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(
-                hipMemcpy(
-                    d_flags, flags.data(),
-                    flags.size() * sizeof(F),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+            common::device_ptr<T>            d_input;
+            common::device_ptr<F>            d_flags;
+            common::device_ptr<U>            d_output;
+            common::device_ptr<unsigned int> d_selected_count_output;
+
+            if(!d_input.resize_with_memory_check(size) || !d_flags.resize_with_memory_check(size)
+               || !d_output.resize_with_memory_check(size)
+               || !d_selected_count_output.resize_with_memory_check(1))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
+
+            d_input.store(input);
+            d_flags.store(flags);
 
             // Calculate expected results on host
             std::vector<U> expected;
@@ -164,9 +156,13 @@ TYPED_TEST(RocprimDeviceSelectTests, Flagged)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            void * d_temp_storage = nullptr;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
-            HIP_CHECK(hipDeviceSynchronize());
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
 
             test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
@@ -281,20 +277,18 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectOp)
             // Generate data
             std::vector<T> input = test_utils::get_random_data<T>(size, 0, 100, seed_value);
 
-            T * d_input;
-            U * d_output;
-            unsigned int * d_selected_count_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, input.size() * sizeof(U)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
-            HIP_CHECK(
-                hipMemcpy(
-                    d_input, input.data(),
-                    input.size() * sizeof(T),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+            common::device_ptr<T>            d_input;
+            common::device_ptr<U>            d_output;
+            common::device_ptr<unsigned int> d_selected_count_output;
+
+            if(!d_input.resize_with_memory_check(size) || !d_output.resize_with_memory_check(size)
+               || !d_selected_count_output.resize_with_memory_check(1))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
+
+            d_input.store(input);
 
             // Calculate expected results on host
             std::vector<U> expected;
@@ -327,9 +321,13 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectOp)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            void * d_temp_storage = nullptr;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
-            HIP_CHECK(hipDeviceSynchronize());
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
 
             test_utils::GraphHelper gHelper;;
             if(TestFixture::use_graphs)
@@ -434,19 +432,21 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectFlagged)
             std::vector<T> input = test_utils::get_random_data<T>(size, 1, 100, seed_value);
             std::vector<F> flags = test_utils::get_random_data<F>(size, 0, 1, seed_value);
 
-            T*            d_input;
-            F*            d_flags;
-            U*            d_output;
-            unsigned int* d_selected_count_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_flags, flags.size() * sizeof(F)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, input.size() * sizeof(U)));
-            HIP_CHECK(
-                test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
-            HIP_CHECK(
-                hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
-            HIP_CHECK(
-                hipMemcpy(d_flags, flags.data(), flags.size() * sizeof(F), hipMemcpyHostToDevice));
+            common::device_ptr<T>            d_input;
+            common::device_ptr<F>            d_flags;
+            common::device_ptr<U>            d_output;
+            common::device_ptr<unsigned int> d_selected_count_output;
+
+            if(!d_input.resize_with_memory_check(size) || !d_flags.resize_with_memory_check(size)
+               || !d_output.resize_with_memory_check(size)
+               || !d_selected_count_output.resize_with_memory_check(1))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
+
+            d_input.store(input);
+            d_flags.store(flags);
 
             // Calculate expected results on host
             std::vector<U> expected;
@@ -480,8 +480,13 @@ TYPED_TEST(RocprimDeviceSelectTests, SelectFlagged)
             ASSERT_GT(temp_storage_size_bytes, 0);
 
             // allocate temporary storage
-            void* d_temp_storage = nullptr;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
 
             test_utils::GraphHelper gHelper;
             if(TestFixture::use_graphs)
@@ -597,20 +602,19 @@ TYPED_TEST(RocprimDeviceSelectTests, Unique)
                 }
 
                 // Allocate and copy to device
-                T * d_input;
-                U * d_output;
-                unsigned int * d_selected_count_output;
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, input.size() * sizeof(U)));
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
-                HIP_CHECK(
-                    hipMemcpy(
-                        d_input, input.data(),
-                        input.size() * sizeof(T),
-                        hipMemcpyHostToDevice
-                    )
-                );
-                HIP_CHECK(hipDeviceSynchronize());
+                common::device_ptr<T>            d_input;
+                common::device_ptr<U>            d_output;
+                common::device_ptr<unsigned int> d_selected_count_output;
+
+                if(!d_input.resize_with_memory_check(size)
+                   || !d_output.resize_with_memory_check(size)
+                   || !d_selected_count_output.resize_with_memory_check(1))
+                {
+                    std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                    break;
+                }
+
+                d_input.store(input);
 
                 // Calculate expected results on host
                 std::vector<U> expected;
@@ -647,9 +651,13 @@ TYPED_TEST(RocprimDeviceSelectTests, Unique)
                 ASSERT_GT(temp_storage_size_bytes, 0);
 
                 // allocate temporary storage
-                void * d_temp_storage = nullptr;
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
-                HIP_CHECK(hipDeviceSynchronize());
+                common::device_ptr<void> d_temp_storage;
+
+                if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+                {
+                    std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                    break;
+                }
 
                 test_utils::GraphHelper gHelper;;
                 if(TestFixture::use_graphs)
@@ -1037,31 +1045,24 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKey)
                     = test_utils::get_random_data<value_type>(size, -1000, 1000, seed_value);
 
                 // Allocate and copy to device
-                key_type*        d_keys_input;
-                value_type*      d_values_input;
-                output_key_type* d_keys_output;
-                output_value_type* d_values_output;
-                unsigned int * d_selected_count_output;
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, input_keys.size() * sizeof(input_keys[0])));
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input, input_values.size() * sizeof(input_values[0])));
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, input_keys.size() * sizeof(output_key_type)));
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_output, input_values.size() * sizeof(output_value_type)));
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
-                HIP_CHECK(
-                    hipMemcpy(
-                        d_keys_input, input_keys.data(),
-                        input_keys.size() * sizeof(input_keys[0]),
-                        hipMemcpyHostToDevice
-                    )
-                );
-                HIP_CHECK(
-                    hipMemcpy(
-                        d_values_input, input_values.data(),
-                        input_values.size() * sizeof(input_values[0]),
-                        hipMemcpyHostToDevice
-                    )
-                );
-                HIP_CHECK(hipDeviceSynchronize());
+                common::device_ptr<key_type>          d_keys_input;
+                common::device_ptr<value_type>        d_values_input;
+                common::device_ptr<output_key_type>   d_keys_output;
+                common::device_ptr<output_value_type> d_values_output;
+                common::device_ptr<unsigned int>      d_selected_count_output;
+
+                if(!d_keys_input.resize_with_memory_check(size)
+                   || !d_values_input.resize_with_memory_check(size)
+                   || !d_keys_output.resize_with_memory_check(size)
+                   || !d_values_output.resize_with_memory_check(size)
+                   || !d_selected_count_output.resize_with_memory_check(1))
+                {
+                    std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                    break;
+                }
+
+                d_keys_input.store(input_keys);
+                d_values_input.store(input_values);
 
                 // Calculate expected results on host
                 std::vector<output_key_type> expected_keys;
@@ -1107,9 +1108,13 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKey)
                 ASSERT_GT(temp_storage_size_bytes, 0);
 
                 // allocate temporary storage
-                void * d_temp_storage = nullptr;
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
-                HIP_CHECK(hipDeviceSynchronize());
+                common::device_ptr<void> d_temp_storage;
+
+                if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+                {
+                    std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                    break;
+                }
 
                 test_utils::GraphHelper gHelper;;
                 if(TestFixture::use_graphs)
@@ -1250,26 +1255,20 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKeyAlias)
                     = test_utils::get_random_data<value_type>(size, -1000, 1000, seed_value);
 
                 // Allocate and copy to device
-                key_type*     d_keys_input;
-                value_type*   d_values_input;
-                unsigned int* d_selected_count_output;
-                HIP_CHECK(
-                    test_common_utils::hipMallocHelper(&d_keys_input,
-                                                       input_keys.size() * sizeof(input_keys[0])));
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input,
-                                                             input_values.size()
-                                                                 * sizeof(input_values[0])));
-                HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected_count_output,
-                                                             sizeof(unsigned int)));
-                HIP_CHECK(hipMemcpy(d_keys_input,
-                                    input_keys.data(),
-                                    input_keys.size() * sizeof(input_keys[0]),
-                                    hipMemcpyHostToDevice));
-                HIP_CHECK(hipMemcpy(d_values_input,
-                                    input_values.data(),
-                                    input_values.size() * sizeof(input_values[0]),
-                                    hipMemcpyHostToDevice));
-                HIP_CHECK(hipDeviceSynchronize());
+                common::device_ptr<key_type>     d_keys_input;
+                common::device_ptr<value_type>   d_values_input;
+                common::device_ptr<unsigned int> d_selected_count_output;
+
+                if(!d_keys_input.resize_with_memory_check(size)
+                   || !d_values_input.resize_with_memory_check(size)
+                   || !d_selected_count_output.resize_with_memory_check(1))
+                {
+                    std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                    break;
+                }
+
+                d_keys_input.store(input_keys);
+                d_values_input.store(input_values);
 
                 // Calculate expected results on host
                 std::vector<output_key_type>   expected_keys;
@@ -1312,10 +1311,13 @@ TYPED_TEST(RocprimDeviceUniqueByKeyTests, UniqueByKeyAlias)
                 ASSERT_GT(temp_storage_size_bytes, 0);
 
                 // allocate temporary storage
-                void* d_temp_storage = nullptr;
-                HIP_CHECK(
-                    test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
-                HIP_CHECK(hipDeviceSynchronize());
+                common::device_ptr<void> d_temp_storage;
+
+                if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+                {
+                    std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                    break;
+                }
 
                 test_utils::GraphHelper gHelper;;
                 if(TestFixture::use_graphs)


### PR DESCRIPTION
Work by @NB4444. This PR adds extra checks that skips tests that would allocate too much memory.

Closes https://github.com/ROCm/rocPRIM/issues/720