### PR TITLE
6.4.2 cherrypick deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 ## rocPRIM 3.4.1 for ROCm 6.4.2
 
 ### Upcoming changes
-* The next major release may change the template parameters of warp and block algorithms.
+* Changes to the template parameters of warp and block algorithms will be made in an upcoming release.
 
 ### Deprecations
 * Due to an upcoming compiler change the following warp size-related symbols will be removed in the next major release and are thus marked as deprecated:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projects/rocPRIM/en/latest/](https://rocm.docs.amd.com/projects/rocPRIM/en/latest/).
 
+## rocPRIM 3.4.1 for ROCm 6.4.2
+
+### Upcoming changes
+* The next major release may change the template parameters of warp and block algorithms.
+
+### Deprecations
+* Due to an upcoming compiler change the following warp size-related symbols will be removed in the next major release and are thus marked as deprecated:
+  * `rocprim::device_warp_size()`
+    * For compile-time constants, this is replaced with `rocprim::arch::wavefront::min_size()` and `rocprim::arch::wavefront::max_size()`. Use this when allocating global or shared memory.
+    * For run-time constants, this is replaced with `rocprim::arch::wavefront::size().`
+  * `rocprim::warp_size()`
+  * `ROCPRIM_WAVEFRONT_SIZE
+  
 ## rocPRIM 3.4.0 for ROCm 6.4.0
 
 ### Added

--- a/benchmark/benchmark_device_memory.cpp
+++ b/benchmark/benchmark_device_memory.cpp
@@ -166,7 +166,7 @@ struct operation<atomics_inter_warp_collision, T, ItemsPerThread, BlockSize>
         (void) shared_storage;
         (void) shared_storage_size;
         (void) input;
-        unsigned int index = (threadIdx.x % rocprim::device_warp_size()) * ItemsPerThread
+        unsigned int index = (threadIdx.x % rocprim::arch::wavefront::min_size()) * ItemsPerThread
                              + blockIdx.x * blockDim.x * ItemsPerThread;
         ROCPRIM_UNROLL
         for(unsigned int i = 0; i < ItemsPerThread; i++)

--- a/benchmark/benchmark_device_radix_sort_onesweep.parallel.hpp
+++ b/benchmark/benchmark_device_radix_sort_onesweep.parallel.hpp
@@ -377,7 +377,7 @@ struct device_radix_sort_onesweep_benchmark_generator
     template<unsigned int ItemsPerThread, rocprim::block_radix_rank_algorithm RadixRankAlgorithm>
     static constexpr bool is_buildable()
     {
-        // Calculation uses `rocprim::device_warp_size()`, which is 64 on host side unless overridden.
+        // Calculation uses `rocprim::arch::wavefront::min_size()`, which is 64 on host side unless overridden.
         //   However, this does not affect the total size of shared memory for the current configuration space.
         //   Were the implementation to change, causing retuning, this needs to be re-evaluated and possibly taken into account.
         using sharedmem_storage =

--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -28,6 +28,7 @@
 #include <rocprim/block/block_scan.hpp>
 #include <rocprim/device/config_types.hpp>
 #include <rocprim/device/detail/device_config_helper.hpp> // partition_config_params
+#include <rocprim/intrinsics/arch.hpp>
 #include <rocprim/types.hpp>
 
 #include <algorithm>
@@ -541,7 +542,7 @@ inline bool is_warp_size_supported(const unsigned int required_warp_size, const 
 
 template<unsigned int LogicalWarpSize>
 __device__ constexpr bool device_test_enabled_for_warp_size_v
-    = ::rocprim::device_warp_size() >= LogicalWarpSize;
+    = ::rocprim::arch::wavefront::min_size() >= LogicalWarpSize;
 
 /// \brief Get segments of uniform random size in [1, max_segment_length] with random key.
 template<typename T>

--- a/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/rocprim/include/rocprim/block/block_exchange.hpp
@@ -26,6 +26,7 @@
 
 #include "../functional.hpp"
 #include "../intrinsics.hpp"
+#include "../intrinsics/arch.hpp"
 #include "../types.hpp"
 
 #include "config.hpp"
@@ -89,7 +90,7 @@ class block_exchange
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
     // Select warp size
     static constexpr unsigned int warp_size =
-        detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
+        detail::get_min_warp_size(BlockSize, ::rocprim::arch::wavefront::min_size());
     // Number of warps in block
     static constexpr unsigned int warps_no = ::rocprim::detail::ceiling_div(BlockSize, warp_size);
     static constexpr unsigned int banks_no = ::rocprim::detail::get_lds_banks_no();
@@ -656,16 +657,18 @@ public:
     ///     ...
     /// }
     /// \endcode
-    template<unsigned int WarpSize = device_warp_size(), class U, class Offset>
+    template<unsigned int WarpSize = arch::wavefront::min_size(), class U, class Offset>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void scatter_to_warp_striped(const T (&input)[ItemsPerThread],
                                  U (&output)[ItemsPerThread],
                                  const Offset (&ranks)[ItemsPerThread],
                                  storage_type& storage)
     {
-        static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
+        static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= arch::wavefront::max_size(),
                       "WarpSize must be a power of two and equal or less"
                       "than the size of hardware warp.");
+        assert(WarpSize <= arch::wavefront::size());
+        
         const unsigned int flat_id
             = ::rocprim::flat_block_thread_id<BlockSizeX, BlockSizeY, BlockSizeZ>();
         const unsigned int thread_id     = detail::logical_lane_id<WarpSize>();

--- a/rocprim/include/rocprim/block/block_load.hpp
+++ b/rocprim/include/rocprim/block/block_load.hpp
@@ -770,9 +770,15 @@ private:
     using block_exchange_type = block_exchange<T, BlockSizeX, ItemsPerThread, BlockSizeY, BlockSizeZ>;
 
 public:
-    ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(BlockSize % ::rocprim::device_warp_size() == 0,
+    ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(BlockSize % ::rocprim::arch::wavefront::min_size() == 0,
                                         "BlockSize must be a multiple of hardware warpsize");
 
+    ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+    block_load()
+    {
+        assert(BlockSize % ::rocprim::arch::wavefront::size() == 0);
+    }
+     
     using storage_type = typename block_exchange_type::storage_type;
 
     template<class InputIterator>

--- a/rocprim/include/rocprim/block/block_load_func.hpp
+++ b/rocprim/include/rocprim/block/block_load_func.hpp
@@ -24,9 +24,10 @@
 #include "../config.hpp"
 #include "../detail/various.hpp"
 
-#include "../intrinsics.hpp"
 #include "../functional.hpp"
+#include "../intrinsics.hpp"
 #include "../types.hpp"
+#include "rocprim/intrinsics/arch.hpp"
 
 /// \addtogroup blockmodule
 /// @{
@@ -368,7 +369,7 @@ void block_load_direct_striped(unsigned int flat_id,
 /// \param block_input - the input iterator from the thread block to load from
 /// \param items - array that data is loaded to
 template<
-    unsigned int WarpSize = device_warp_size(),
+    unsigned int WarpSize = arch::wavefront::min_size(),
     class InputIterator,
     class T,
     unsigned int ItemsPerThread
@@ -378,9 +379,11 @@ void block_load_direct_warp_striped(unsigned int flat_id,
                                     InputIterator block_input,
                                     T (&items)[ItemsPerThread])
 {
-    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
+    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= arch::wavefront::max_size(),
                  "WarpSize must be a power of two and equal or less"
                  "than the size of hardware warp.");
+    assert(WarpSize <= arch::wavefront::size());
+                 
     unsigned int thread_id = detail::logical_lane_id<WarpSize>();
     unsigned int warp_id = flat_id / WarpSize;
     unsigned int warp_offset = warp_id * WarpSize * ItemsPerThread;
@@ -420,7 +423,7 @@ void block_load_direct_warp_striped(unsigned int flat_id,
 /// \param items - array that data is loaded to
 /// \param valid - maximum range of valid numbers to load
 template<
-    unsigned int WarpSize = device_warp_size(),
+    unsigned int WarpSize = arch::wavefront::min_size(),
     class InputIterator,
     class T,
     unsigned int ItemsPerThread
@@ -431,7 +434,7 @@ void block_load_direct_warp_striped(unsigned int flat_id,
                                     T (&items)[ItemsPerThread],
                                     unsigned int valid)
 {
-    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
+    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= arch::wavefront::max_size(),
                  "WarpSize must be a power of two and equal or less"
                  "than the size of hardware warp.");
     unsigned int thread_id = detail::logical_lane_id<WarpSize>();
@@ -480,7 +483,7 @@ void block_load_direct_warp_striped(unsigned int flat_id,
 /// \param valid - maximum range of valid numbers to load
 /// \param out_of_bounds - default value assigned to out-of-bound items
 template<
-    unsigned int WarpSize = device_warp_size(),
+    unsigned int WarpSize = arch::wavefront::min_size(),
     class InputIterator,
     class T,
     unsigned int ItemsPerThread,
@@ -493,9 +496,11 @@ void block_load_direct_warp_striped(unsigned int flat_id,
                                     unsigned int valid,
                                     Default out_of_bounds)
 {
-    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
+    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= arch::wavefront::max_size(),
                  "WarpSize must be a power of two and equal or less"
                  "than the size of hardware warp.");
+    assert(WarpSize <= arch::wavefront::size());
+                 
     ROCPRIM_UNROLL
     for (unsigned int item = 0; item < ItemsPerThread; item++)
     {

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -34,6 +34,7 @@
 #include "block_exchange.hpp"
 #include "block_radix_rank.hpp"
 #include "rocprim/block/config.hpp"
+#include "rocprim/intrinsics/arch.hpp"
 
 /// \addtogroup blockmodule
 /// @{
@@ -102,10 +103,10 @@ template<class Key,
          unsigned int BlockSizeY = 1,
          unsigned int BlockSizeZ = 1,
          unsigned int RadixBitsPerPass
-         = (BlockSizeX * BlockSizeY * BlockSizeZ) % device_warp_size() == 0 ? 8 /* match */
+         = (BlockSizeX * BlockSizeY * BlockSizeZ) % arch::wavefront::min_size() == 0 ? 8 /* match */
                                                                             : 4 /* basic_memoize */,
          block_radix_rank_algorithm RadixRankAlgorithm
-         = (BlockSizeX * BlockSizeY * BlockSizeZ) % device_warp_size() == 0
+         = (BlockSizeX * BlockSizeY * BlockSizeZ) % arch::wavefront::min_size() == 0
                ? block_radix_rank_algorithm::match
                : block_radix_rank_algorithm::basic_memoize,
          block_padding_hint PaddingHint = block_padding_hint::lds_occupancy_bound>
@@ -120,7 +121,7 @@ class block_radix_sort
     static constexpr bool warp_striped = RadixRankAlgorithm == block_radix_rank_algorithm::match;
 
 #if __HIP_DEVICE_COMPILE__
-    static_assert(!warp_striped || (BlockSize % device_warp_size()) == 0,
+    static_assert(!warp_striped || (BlockSize % arch::wavefront::min_size()) == 0,
                   "When using 'block_radix_rank_algorithm::match', the block size should be a "
                   "multiple of the warp size");
 #endif
@@ -159,6 +160,12 @@ public:
 #else
     using storage_type = storage_type_; // only for Doxygen
 #endif
+
+    ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+    block_radix_sort()
+    {
+        assert(BlockSize % ::rocprim::arch::wavefront::size() == 0);
+    }
 
     /// \brief Performs ascending radix sort over keys partitioned across threads in a block.
     ///
@@ -1060,7 +1067,7 @@ public:
 
 private:
     static constexpr bool use_warp_exchange
-        = device_warp_size() % ItemsPerThread == 0 && ItemsPerThread <= 4;
+        = arch::wavefront::min_size() % ItemsPerThread == 0 && ItemsPerThread <= 4;
 
     template<class SortedValue>
     ROCPRIM_DEVICE ROCPRIM_INLINE
@@ -1126,7 +1133,7 @@ private:
         {
             // This appears to be slower with high large items per thread.
             constexpr bool use_warp_exchange
-                = device_warp_size() % ItemsPerThread == 0 && ItemsPerThread <= 4;
+                = arch::wavefront::min_size() % ItemsPerThread == 0 && ItemsPerThread <= 4;
             blocked_to_warp_striped(keys,
                                     values,
                                     storage,

--- a/rocprim/include/rocprim/block/block_radix_sort.hpp
+++ b/rocprim/include/rocprim/block/block_radix_sort.hpp
@@ -164,7 +164,7 @@ public:
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     block_radix_sort()
     {
-        assert(BlockSize % ::rocprim::arch::wavefront::size() == 0);
+        assert(!warp_striped || BlockSize % ::rocprim::arch::wavefront::size() == 0);
     }
 
     /// \brief Performs ascending radix sort over keys partitioned across threads in a block.

--- a/rocprim/include/rocprim/block/block_reduce.hpp
+++ b/rocprim/include/rocprim/block/block_reduce.hpp
@@ -98,7 +98,7 @@ struct select_block_reduce_impl<block_reduce_algorithm::raking_reduce_commutativ
 ///   * \p ItemsPerThread is greater than one,
 ///   * \p T is an arithmetic type,
 ///   * reduce operation is simple addition operator, and
-///   * the number of threads in the block is a multiple of the hardware warp size (see rocprim::device_warp_size()).
+///   * the number of threads in the block is a multiple of the hardware warp size (see rocprim::arch::wavefront::min_size()).
 /// * block_reduce has three alternative implementations: \p block_reduce_algorithm::using_warp_reduce,
 ///   \p block_reduce_algorithm::raking_reduce and \p block_reduce_algorithm::raking_reduce_commutative_only.
 /// * If the block sizes less than 64 only one warp reduction is used. The block reduction algorithm

--- a/rocprim/include/rocprim/block/block_scan.hpp
+++ b/rocprim/include/rocprim/block/block_scan.hpp
@@ -31,6 +31,7 @@
 
 #include "detail/block_scan_warp_scan.hpp"
 #include "detail/block_scan_reduce_then_scan.hpp"
+#include "rocprim/intrinsics/arch.hpp"
 
 /// \addtogroup blockmodule
 /// @{
@@ -70,7 +71,7 @@ struct select_block_scan_impl<block_scan_algorithm::reduce_then_scan>
     // When BlockSize is less than hardware warp size block_scan_warp_scan performs better than
     // block_scan_reduce_then_scan by specializing for warps
     using type = typename std::conditional<
-                    (BlockSizeX * BlockSizeY * BlockSizeZ <= ::rocprim::device_warp_size()),
+                    (BlockSizeX * BlockSizeY * BlockSizeZ <= ::rocprim::arch::wavefront::min_size()),
                     block_scan_warp_scan<T, BlockSizeX, BlockSizeY, BlockSizeZ>,
                     block_scan_reduce_then_scan<T, BlockSizeX, BlockSizeY, BlockSizeZ>
                  >::type;
@@ -96,7 +97,7 @@ struct select_block_scan_impl<block_scan_algorithm::reduce_then_scan>
 ///   * \p ItemsPerThread is greater than one,
 ///   * \p T is an arithmetic type,
 ///   * scan operation is simple addition operator, and
-///   * the number of threads in the block is a multiple of the hardware warp size (see rocprim::device_warp_size()).
+///   * the number of threads in the block is a multiple of the hardware warp size (see rocprim::arch::wavefront::min_size()).
 /// * block_scan has two alternative implementations: \p block_scan_algorithm::using_warp_scan
 ///   and block_scan_algorithm::reduce_then_scan.
 ///

--- a/rocprim/include/rocprim/block/block_store.hpp
+++ b/rocprim/include/rocprim/block/block_store.hpp
@@ -498,11 +498,17 @@ private:
     using block_exchange_type = block_exchange<T, BlockSize, ItemsPerThread>;
 
 public:
-    ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(BlockSize % ::rocprim::device_warp_size() == 0,
+    ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(BlockSize % ::rocprim::arch::wavefront::min_size() == 0,
                                         "BlockSize must be a multiple of hardware warpsize");
 
     using storage_type = typename block_exchange_type::storage_type;
 
+    ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+    block_store()
+    {
+        assert(BlockSize % ::rocprim::arch::wavefront::size() == 0);
+    }
+    
     template<class OutputIterator>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
     void store(OutputIterator block_output,

--- a/rocprim/include/rocprim/block/block_store_func.hpp
+++ b/rocprim/include/rocprim/block/block_store_func.hpp
@@ -27,6 +27,7 @@
 #include "../intrinsics.hpp"
 #include "../functional.hpp"
 #include "../types.hpp"
+#include "rocprim/intrinsics/arch.hpp"
 
 /// \addtogroup blockmodule
 /// @{
@@ -297,7 +298,7 @@ void block_store_direct_striped(unsigned int flat_id,
 /// \param block_output - the input iterator from the thread block to store to
 /// \param items - array that data is stored to thread block
 template<
-    unsigned int WarpSize = device_warp_size(),
+    unsigned int WarpSize = arch::wavefront::min_size(),
     class OutputIterator,
     class T,
     unsigned int ItemsPerThread
@@ -311,7 +312,7 @@ void block_store_direct_warp_striped(unsigned int flat_id,
                   "The type T must be such that an object of type OutputIterator "
                   "can be dereferenced and assigned a value of type T.");
 
-    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
+    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= arch::wavefront::max_size(),
                  "WarpSize must be a power of two and equal or less"
                  "than the size of hardware warp.");
     unsigned int thread_id = detail::logical_lane_id<WarpSize>();
@@ -353,7 +354,7 @@ void block_store_direct_warp_striped(unsigned int flat_id,
 /// \param items - array that data is stored to thread block
 /// \param valid - maximum range of valid numbers to store
 template<
-    unsigned int WarpSize = device_warp_size(),
+    unsigned int WarpSize = arch::wavefront::min_size(),
     class OutputIterator,
     class T,
     unsigned int ItemsPerThread
@@ -368,9 +369,11 @@ void block_store_direct_warp_striped(unsigned int flat_id,
                   "The type T must be such that an object of type OutputIterator "
                   "can be dereferenced and assigned a value of type T.");
 
-    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= device_warp_size(),
+    static_assert(detail::is_power_of_two(WarpSize) && WarpSize <= arch::wavefront::max_size(),
                  "WarpSize must be a power of two and equal or less"
                  "than the size of hardware warp.");
+    assert(WarpSize <= arch::wavefront::size());     
+    
     unsigned int thread_id = detail::logical_lane_id<WarpSize>();
     unsigned int warp_id = flat_id / WarpSize;
     unsigned int warp_offset = warp_id * WarpSize * ItemsPerThread;

--- a/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
+++ b/rocprim/include/rocprim/block/detail/block_radix_rank_match.hpp
@@ -30,6 +30,7 @@
 
 #include "../block_scan.hpp"
 #include "../config.hpp"
+#include "rocprim/intrinsics/arch.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -57,7 +58,7 @@ class block_radix_rank_match
     struct unpadded_config
     {
         static constexpr unsigned int warps
-            = ::rocprim::detail::ceiling_div(block_size, device_warp_size());
+            = ::rocprim::detail::ceiling_div(block_size, arch::wavefront::min_size());
     };
 
     struct padded_config

--- a/rocprim/include/rocprim/block/detail/block_reduce_raking_reduce.hpp
+++ b/rocprim/include/rocprim/block/detail/block_reduce_raking_reduce.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@
 #include "../../intrinsics.hpp"
 
 #include "../../warp/warp_reduce.hpp"
+#include "rocprim/intrinsics/arch.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -110,7 +111,7 @@ class block_reduce_raking_reduce
     // Warp reduce, warp_reduce_crosslane does not require shared memory (storage), but
     // logical warp size must be a power of two.
     static constexpr unsigned int warp_size_
-        = detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
+        = detail::get_min_warp_size(BlockSize, ::rocprim::arch::wavefront::min_size());
 
     static constexpr unsigned int segment_len = ceiling_div(BlockSize, warp_size_);
 

--- a/rocprim/include/rocprim/block/detail/block_reduce_warp_reduce.hpp
+++ b/rocprim/include/rocprim/block/detail/block_reduce_warp_reduce.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -47,7 +47,7 @@ class block_reduce_warp_reduce
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
     // Select warp size
     static constexpr unsigned int warp_size_ =
-        detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
+        detail::get_min_warp_size(BlockSize, ::rocprim::arch::wavefront::min_size());
     // Number of warps in block
     static constexpr unsigned int warps_no_ = (BlockSize + warp_size_ - 1) / warp_size_;
 

--- a/rocprim/include/rocprim/block/detail/block_scan_reduce_then_scan.hpp
+++ b/rocprim/include/rocprim/block/detail/block_scan_reduce_then_scan.hpp
@@ -47,12 +47,12 @@ class block_scan_reduce_then_scan
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
     // Number of items to reduce per thread
     static constexpr unsigned int thread_reduction_size_ =
-        (BlockSize + ::rocprim::device_warp_size() - 1)/ ::rocprim::device_warp_size();
+        (BlockSize + ::rocprim::arch::wavefront::min_size() - 1)/ ::rocprim::arch::wavefront::min_size();
 
     // Warp scan, warp_scan_crosslane does not require shared memory (storage), but
     // logical warp size must be a power of two.
     static constexpr unsigned int warp_size_ =
-        detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
+        detail::get_min_warp_size(BlockSize, ::rocprim::arch::wavefront::min_size());
     using warp_scan_prefix_type = ::rocprim::detail::warp_scan_crosslane<T, warp_size_>;
 
     // Minimize LDS bank conflicts

--- a/rocprim/include/rocprim/block/detail/block_scan_warp_scan.hpp
+++ b/rocprim/include/rocprim/block/detail/block_scan_warp_scan.hpp
@@ -47,7 +47,7 @@ class block_scan_warp_scan
     static constexpr unsigned int BlockSize = BlockSizeX * BlockSizeY * BlockSizeZ;
     // Select warp size
     static constexpr unsigned int warp_size_ =
-        detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
+        detail::get_min_warp_size(BlockSize, ::rocprim::arch::wavefront::min_size());
     // Number of warps in block
     static constexpr unsigned int warps_no_ = (BlockSize + warp_size_ - 1) / warp_size_;
 
@@ -504,7 +504,7 @@ private:
                              T& output,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<(BlockSize_ > ::rocprim::device_warp_size())>::type
+        -> typename std::enable_if<(BlockSize_ > ::rocprim::arch::wavefront::min_size())>::type
     {
         storage_type_& storage_ = storage.get();
         // Perform warp scan
@@ -533,7 +533,7 @@ private:
                              T& output,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<!(BlockSize_ > ::rocprim::device_warp_size())>::type
+        -> typename std::enable_if<!(BlockSize_ > ::rocprim::arch::wavefront::min_size())>::type
     {
         (void) storage;
         (void) flat_tid;
@@ -560,7 +560,7 @@ private:
                              T init,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<(BlockSize_ > ::rocprim::device_warp_size())>::type
+        -> typename std::enable_if<(BlockSize_ > ::rocprim::arch::wavefront::min_size())>::type
     {
         storage_type_& storage_ = storage.get();
         // Perform warp scan on input values
@@ -600,7 +600,7 @@ private:
                              T init,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<!(BlockSize_ > ::rocprim::device_warp_size())>::type
+        -> typename std::enable_if<!(BlockSize_ > ::rocprim::arch::wavefront::min_size())>::type
     {
         (void) flat_tid;
         (void) storage;
@@ -635,7 +635,7 @@ private:
                              T& output,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<(BlockSize_ > ::rocprim::device_warp_size())>::type
+        -> typename std::enable_if<(BlockSize_ > ::rocprim::arch::wavefront::min_size())>::type
     {
         storage_type_& storage_ = storage.get();
         // Perform warp scan on input values
@@ -671,7 +671,7 @@ private:
                              T& output,
                              storage_type& storage,
                              BinaryFunction scan_op)
-        -> typename std::enable_if<!(BlockSize_ > ::rocprim::device_warp_size())>::type
+        -> typename std::enable_if<!(BlockSize_ > ::rocprim::arch::wavefront::min_size())>::type
     {
         (void) flat_tid;
         (void) storage;

--- a/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
+++ b/rocprim/include/rocprim/block/detail/block_sort_bitonic.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -451,7 +451,7 @@ private:
 
     template<unsigned int Size, class BinaryFunction, class... KeyValue>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-        typename std::enable_if<(Size <= ::rocprim::device_warp_size())>::type
+        typename std::enable_if<(Size <= ::rocprim::arch::wavefront::min_size())>::type
         sort_power_two(const unsigned int flat_tid,
                        storage_type&      storage,
                        BinaryFunction     compare_function,
@@ -594,14 +594,14 @@ private:
     /// Requires a power of two block size and a power of two items per thread.
     template<unsigned int BS, class BinaryFunction, class... KeyValue>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-        typename std::enable_if<(BS > ::rocprim::device_warp_size())>::type
+        typename std::enable_if<(BS > ::rocprim::arch::wavefront::min_size())>::type
         sort_power_two(const unsigned int flat_tid,
                        storage_type&      storage,
                        BinaryFunction     compare_function,
                        KeyValue&... kv)
     {
-        const auto warp_id_is_even = ((flat_tid / ::rocprim::device_warp_size()) % 2) == 0;
-        ::rocprim::warp_sort<Key, ::rocprim::device_warp_size(), Value> wsort;
+        const auto warp_id_is_even = ((flat_tid / ::rocprim::arch::wavefront::min_size()) % 2) == 0;
+        ::rocprim::warp_sort<Key, ::rocprim::arch::wavefront::min_size(), Value> wsort;
         auto                                                            compare_function2
             = [compare_function, warp_id_is_even](const Key& a, const Key& b) mutable -> bool
         {
@@ -613,19 +613,19 @@ private:
         wsort.sort(kv..., compare_function2);
 
         ROCPRIM_UNROLL
-        for(unsigned int length = ::rocprim::device_warp_size(); length < BS; length *= 2)
+        for(unsigned int length = ::rocprim::arch::wavefront::min_size(); length < BS; length *= 2)
         {
             const bool dir = (flat_tid & (length * 2)) != 0;
             ROCPRIM_UNROLL
-            for(unsigned int k = length; k > ::rocprim::device_warp_size() / 2; k /= 2)
+            for(unsigned int k = length; k > ::rocprim::arch::wavefront::min_size() / 2; k /= 2)
             {
                 copy_to_shared(kv..., flat_tid, storage);
                 swap(kv..., flat_tid, flat_tid ^ k, dir, storage, compare_function);
                 ::rocprim::syncthreads();
             }
 
-            const unsigned int     id = detail::logical_lane_id<::rocprim::device_warp_size()>();
-            constexpr unsigned int s  = ::rocprim::device_warp_size() / 2;
+            const unsigned int     id = detail::logical_lane_id<::rocprim::arch::wavefront::min_size()>();
+            constexpr unsigned int s  = ::rocprim::arch::wavefront::min_size() / 2;
 
             ROCPRIM_UNROLL
             for(unsigned int k = s; k > 0; k /= 2)

--- a/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
+++ b/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
@@ -198,7 +198,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE static void vectorized_copy_bytes(const void
     using vector_type                      = uint4;
     constexpr uint32_t ints_in_vector_type = sizeof(uint4) / sizeof(uint32_t);
 
-    constexpr auto warp_size = rocprim::device_warp_size();
+    constexpr auto warp_size = rocprim::arch::wavefront::min_size();
     const auto     rank      = rocprim::detail::block_thread_id<0>() % warp_size;
 
     const uint8_t* src = reinterpret_cast<const uint8_t*>(input_buffer) + offset;
@@ -315,7 +315,7 @@ template<bool IsMemCpy,
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE static void
     copy_items(InputIt input_buffer, OutputIt output_buffer, Offset num_items, Offset offset = 0)
 {
-    constexpr auto warp_size = rocprim::device_warp_size();
+    constexpr auto warp_size = rocprim::arch::wavefront::min_size();
     output_buffer += offset;
     input_buffer += offset;
     for(Offset i = threadIdx.x % warp_size; i < num_items; i += warp_size)
@@ -610,7 +610,7 @@ private:
         {
             const uint32_t warp_id = rocprim::warp_id();
             const uint32_t warps_per_block
-                = rocprim::flat_block_size() / rocprim::device_warp_size();
+                = rocprim::flat_block_size() / rocprim::arch::wavefront::min_size();
 
             for(buffer_offset_type buffer_offset = warp_id; buffer_offset < num_wlev_buffers;
                 buffer_offset += warps_per_block)

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -117,7 +117,7 @@ struct radix_digit_count_helper
     static constexpr unsigned int atomic_stripes = 4;
     static constexpr unsigned int counters       = radix_size * atomic_stripes;
 
-    ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(BlockSize % ::rocprim::device_warp_size() == 0,
+    ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(BlockSize % ::rocprim::arch::wavefront::min_size() == 0,
                                         "BlockSize must be divisible by warp size");
     static_assert(radix_size <= BlockSize, "Radix size must not exceed BlockSize");
 
@@ -126,6 +126,12 @@ struct radix_digit_count_helper
         unsigned int digit_counters[counters];
     };
 
+    ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+    radix_digit_count_helper()
+    {
+        assert(BlockSize % ::rocprim::arch::wavefront::size() == 0);
+    }
+     
     ROCPRIM_DEVICE ROCPRIM_INLINE
     unsigned int get_counter(const unsigned stripe, const unsigned int digit)
     {

--- a/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
+++ b/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
@@ -32,6 +32,7 @@
 #include "../../thread/thread_scan.hpp"
 #include "../../type_traits.hpp"
 #include "../../warp/warp_scan.hpp"
+#include "rocprim/intrinsics/arch.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -155,13 +156,13 @@ struct discontinuity_helper
 /// Custom warp_exchange class with extra check in scatter_to_striped for out-of-bound accesses.
 template<class T,
          unsigned int ItemsPerThread,
-         unsigned int WarpSize = ::rocprim::device_warp_size()>
+         unsigned int WarpSize = ::rocprim::arch::wavefront::min_size()>
 class custom_warp_exchange
 {
     static_assert(::rocprim::detail::is_power_of_two(WarpSize),
                   "Logical warp size must be a power of two.");
     ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(
-        WarpSize <= ::rocprim::device_warp_size(),
+        WarpSize <= ::rocprim::arch::wavefront::min_size(),
         "Logical warp size cannot be larger than physical warp size.");
 
     static constexpr unsigned int warp_items = WarpSize * ItemsPerThread;
@@ -432,7 +433,7 @@ private:
 
     // Warp size.
     static constexpr unsigned int warp_size
-        = detail::get_min_warp_size(BlockSize, ::rocprim::device_warp_size());
+        = detail::get_min_warp_size(BlockSize, ::rocprim::arch::wavefront::min_size());
     // Number of warps in block.
     static constexpr unsigned int warps_no = (BlockSize + warp_size - 1) / warp_size;
 

--- a/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -737,7 +737,7 @@ void segmented_sort(KeysInputIterator keys_input,
     >;
     using long_radix_helper_type = segmented_radix_sort_helper<key_type,
                                                                value_type,
-                                                               ::rocprim::device_warp_size(),
+                                                               ::rocprim::arch::wavefront::min_size(),
                                                                block_size,
                                                                items_per_thread,
                                                                long_radix_bits,
@@ -864,7 +864,7 @@ void segmented_sort_large(KeysInputIterator keys_input,
     >;
     using long_radix_helper_type = segmented_radix_sort_helper<key_type,
                                                                value_type,
-                                                               ::rocprim::device_warp_size(),
+                                                               ::rocprim::arch::wavefront::min_size(),
                                                                block_size,
                                                                items_per_thread,
                                                                long_radix_bits,

--- a/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -141,7 +141,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE T lookback_reduce_forward(F scan_op, T prefix, T b
 {
 #ifdef ROCPRIM_DETAIL_HAS_DPP_WF
     ROCPRIM_UNROLL
-    for(unsigned int i = 0; i < device_warp_size(); ++i)
+    for(unsigned int i = 0; i < arch::wavefront::min_size(); ++i)
     {
         prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
         prefix = scan_op(prefix, block_prefix);
@@ -151,11 +151,11 @@ ROCPRIM_DEVICE ROCPRIM_INLINE T lookback_reduce_forward(F scan_op, T prefix, T b
     // iterate over rows of 16 lanes and use warp_readlane to communicate across rows.
     constexpr const int row_size = 16;
     ROCPRIM_UNROLL
-    for(int j = device_warp_size(); j > 0; j -= row_size)
+    for(int j = arch::wavefront::min_size(); j > 0; j -= row_size)
     {
         prefix = warp_readlane(
             prefix,
-            j /* automatically taken modulo device_warp_size(), first read is lane 0 */);
+            j /* automatically taken modulo arch::wavefront::min_size(), first read is lane 0 */);
         prefix = scan_op(prefix, block_prefix);
 
         ROCPRIM_UNROLL
@@ -168,7 +168,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE T lookback_reduce_forward(F scan_op, T prefix, T b
 #else
     // If no DPP available at all, fall back to shuffles.
     ROCPRIM_UNROLL
-    for(unsigned int i = 0; i < device_warp_size(); ++i)
+    for(unsigned int i = 0; i < arch::wavefront::min_size(); ++i)
     {
         prefix = warp_shuffle(prefix, lane_id() + 1);
         prefix = scan_op(prefix, block_prefix);
@@ -267,7 +267,7 @@ public:
     ROCPRIM_DEVICE ROCPRIM_INLINE void initialize_prefix(const unsigned int block_id,
                                                          const unsigned int number_of_blocks)
     {
-        constexpr unsigned int padding = ::rocprim::device_warp_size();
+        constexpr unsigned int padding = ::rocprim::arch::wavefront::min_size();
 
         if(block_id < number_of_blocks)
         {
@@ -300,7 +300,7 @@ public:
     // block_id must be > 0
     ROCPRIM_DEVICE ROCPRIM_INLINE void get(const unsigned int block_id, prefix_flag& flag, T& value)
     {
-        constexpr unsigned int padding = ::rocprim::device_warp_size();
+        constexpr unsigned int padding = ::rocprim::arch::wavefront::min_size();
 
         prefix_type prefix;
 
@@ -332,7 +332,7 @@ public:
     /// blocks/prefixes are completed.
     ROCPRIM_DEVICE ROCPRIM_INLINE T get_complete_value(const unsigned int block_id)
     {
-        constexpr unsigned int padding = ::rocprim::device_warp_size();
+        constexpr unsigned int padding = ::rocprim::arch::wavefront::min_size();
 
         auto        p = prefixes[padding + block_id];
         prefix_type prefix{};
@@ -347,7 +347,7 @@ public:
 
         // There is one lookback scan per block, though a lookback scan is done by a single warp.
         // Because every lane of the warp checks a different lookback scan state value,
-        // we need space for at least ceil(CUs / device_warp_size()) items in the cache,
+        // we need space for at least ceil(CUs / arch::wavefront::min_size()) items in the cache,
         // assuming that only one block is active per CU (assumes low occupancy).
         // For MI300, with 304 CUs, we have 304 / 64 = 5 items for the lookback cache.
         // Note that one item is kept in the `block_prefix` register, so we only need to
@@ -365,7 +365,7 @@ public:
               && cache_offset < max_lookback_per_thread)
         {
             cache[cache_offset++] = block_prefix;
-            lookback_block_id -= device_warp_size();
+            lookback_block_id -= arch::wavefront::min_size();
             this->get(lookback_block_id, flag, block_prefix);
         }
 
@@ -382,7 +382,7 @@ public:
                 // All invalid, so we have to move one block back to
                 // get back to known civilization.
                 // Don't forget to pop one item off the cache too.
-                lookback_block_id += device_warp_size();
+                lookback_block_id += arch::wavefront::min_size();
                 --cache_offset;
             }
 
@@ -418,7 +418,7 @@ private:
     ROCPRIM_DEVICE ROCPRIM_INLINE void
         set(const unsigned int block_id, const prefix_flag flag, const T value)
     {
-        constexpr unsigned int padding = ::rocprim::device_warp_size();
+        constexpr unsigned int padding = ::rocprim::arch::wavefront::min_size();
 
         prefix_type            prefix = {value, flag};
         prefix_underlying_type p;
@@ -524,7 +524,7 @@ public:
     ROCPRIM_DEVICE ROCPRIM_INLINE void initialize_prefix(const unsigned int block_id,
                                                          const unsigned int number_of_blocks)
     {
-        constexpr unsigned int padding = ::rocprim::device_warp_size();
+        constexpr unsigned int padding = ::rocprim::arch::wavefront::min_size();
         if(block_id < number_of_blocks)
         {
             prefixes_flags[padding + block_id]
@@ -549,7 +549,7 @@ public:
     // block_id must be > 0
     ROCPRIM_DEVICE ROCPRIM_INLINE void get(const unsigned int block_id, prefix_flag& flag, T& value)
     {
-        constexpr unsigned int padding = ::rocprim::device_warp_size();
+        constexpr unsigned int padding = ::rocprim::arch::wavefront::min_size();
 
         flag = this->get_flag(block_id);
 #if ROCPRIM_DETAIL_LOOKBACK_SCAN_STATE_WITHOUT_SLOW_FENCES
@@ -576,7 +576,7 @@ public:
     /// blocks/prefixes are completed.
     ROCPRIM_DEVICE ROCPRIM_INLINE T get_complete_value(const unsigned int block_id)
     {
-        constexpr unsigned int padding = ::rocprim::device_warp_size();
+        constexpr unsigned int padding = ::rocprim::arch::wavefront::min_size();
 
 #if ROCPRIM_DETAIL_LOOKBACK_SCAN_STATE_WITHOUT_SLOW_FENCES
         T           value;
@@ -596,7 +596,7 @@ public:
 
     ROCPRIM_DEVICE ROCPRIM_INLINE T get_partial_value(const unsigned int block_id)
     {
-        constexpr unsigned int padding = ::rocprim::device_warp_size();
+        constexpr unsigned int padding = ::rocprim::arch::wavefront::min_size();
 
 #if ROCPRIM_DETAIL_LOOKBACK_SCAN_STATE_WITHOUT_SLOW_FENCES
         T           value;
@@ -626,7 +626,7 @@ public:
         while(warp_all(flag != prefix_flag::COMPLETE && flag != prefix_flag::INVALID))
         {
             ++cache_offset;
-            lookback_block_id -= device_warp_size();
+            lookback_block_id -= arch::wavefront::min_size();
             flag = this->get_flag(lookback_block_id);
         }
 
@@ -643,7 +643,7 @@ public:
                 // All invalid, so we have to move one block back to
                 // get back to known civilization.
                 // Don't forget to pop one item off the cache too.
-                lookback_block_id += device_warp_size();
+                lookback_block_id += arch::wavefront::min_size();
                 --cache_offset;
             }
 
@@ -671,7 +671,7 @@ public:
         // These are all guaranteed to be PARTIAL
         while(cache_offset > 0)
         {
-            lookback_block_id += device_warp_size();
+            lookback_block_id += arch::wavefront::min_size();
             --cache_offset;
             block_prefix = this->get_partial_value(lookback_block_id);
             prefix       = lookback_reduce_forward(scan_op, prefix, block_prefix);
@@ -683,7 +683,7 @@ public:
 private:
     ROCPRIM_DEVICE ROCPRIM_INLINE prefix_flag get_flag(const unsigned int block_id)
     {
-        constexpr unsigned int padding = ::rocprim::device_warp_size();
+        constexpr unsigned int padding = ::rocprim::arch::wavefront::min_size();
 
         const unsigned int SLEEP_MAX     = 32;
         unsigned int       times_through = 1;
@@ -709,7 +709,7 @@ private:
     ROCPRIM_DEVICE ROCPRIM_INLINE void
         set(const unsigned int block_id, const prefix_flag flag, const T value)
     {
-        constexpr unsigned int padding = ::rocprim::device_warp_size();
+        constexpr unsigned int padding = ::rocprim::arch::wavefront::min_size();
 
 #if ROCPRIM_DETAIL_LOOKBACK_SCAN_STATE_WITHOUT_SLOW_FENCES
         auto* values = static_cast<value_underlying_type*>(
@@ -775,7 +775,7 @@ private:
         // from (block_id_ - 2) block etc.
         using headflag_scan_op_type = reverse_binary_op_wrapper<BinaryFunction, T, T>;
         using warp_reduce_prefix_type
-            = warp_reduce_crosslane<T, ::rocprim::device_warp_size(), false>;
+            = warp_reduce_crosslane<T, ::rocprim::arch::wavefront::min_size(), false>;
 
         T block_prefix;
         scan_state_.get(block_id, flag, block_prefix);
@@ -803,7 +803,7 @@ private:
             // while we don't load a complete prefix, reduce partial prefixes
             while(::rocprim::detail::warp_all(flag != prefix_flag::COMPLETE))
             {
-                previous_block_id -= ::rocprim::device_warp_size();
+                previous_block_id -= ::rocprim::arch::wavefront::min_size();
                 reduce_partial_prefixes(previous_block_id, flag, partial_prefix);
                 prefix = scan_op_(partial_prefix, prefix);
             }

--- a/rocprim/include/rocprim/intrinsics.hpp
+++ b/rocprim/include/rocprim/intrinsics.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@
 // Meta configuration for rocPRIM
 #include "config.hpp"
 
+#include "intrinsics/arch.hpp"
 #include "intrinsics/atomic.hpp"
 #include "intrinsics/bit.hpp"
 #include "intrinsics/thread.hpp"

--- a/rocprim/include/rocprim/intrinsics/arch.hpp
+++ b/rocprim/include/rocprim/intrinsics/arch.hpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ROCPRIM_INTRINSICS_ARCH_HPP_
+#define ROCPRIM_INTRINSICS_ARCH_HPP_
+
+#include "../config.hpp"
+
+BEGIN_ROCPRIM_NAMESPACE
+
+/// \brief Utilities to query architecture details.
+namespace arch
+{
+
+/// \brief Utilities to query wavefront details.
+namespace wavefront
+{
+
+/// \brief Return the number of threads in the wavefront.
+///
+/// This function is not `constexpr`.
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+unsigned int size()
+{
+    // This function is **not** constexpr because it will
+    // be using '__builtin_amdgcn_wavefrontsize()'.
+    return ROCPRIM_WAVEFRONT_SIZE;
+}
+
+/// \brief Return the minimum number of threads in the wavefront.
+///
+/// This function can be used to setup compile time allocation of
+/// global or shared memory.
+///
+/// \par Example
+/// \parblock
+/// The example below shows how shared memory can be allocated
+/// to collect per warp results.
+/// \code{.cpp}
+/// constexpr auto total_items = 1024;
+/// constexpr auto max_warps   = total_items / arch::min_size();
+///
+/// // If we want to use shared memory to exchange data
+/// // between warps, we can allocate it as:
+/// __shared int per_warp_results[max_warps];
+/// \endcode
+/// \endparblock
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE
+constexpr unsigned int min_size()
+{
+#if __HIP_DEVICE_COMPILE__
+    return ROCPRIM_WAVEFRONT_SIZE;
+#else
+    return ROCPRIM_WARP_SIZE_32;
+#endif
+}
+
+/// \brief Return the maximum number of threads in the wavefront.
+///
+/// This function can be used to setup compile time allocation of
+/// global or shared memory.
+///
+/// \par Example
+/// \parblock
+/// The example below shows how an array can be allocated
+/// to collect a single warp's results.
+/// \code{.cpp}
+/// constexpr auto items_per_thread = 2;
+///
+/// // If we want to collect all the elements in a single array
+/// // on a single thread, we can allocate it as:
+/// int single_warp[items_per_thread * arch::max_size()];
+/// \endcode
+/// \endparblock
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE
+constexpr unsigned int max_size()
+{
+#if __HIP_DEVICE_COMPILE__
+    return ROCPRIM_WAVEFRONT_SIZE;
+#else
+    return ROCPRIM_WARP_SIZE_64;
+#endif
+}
+}; // namespace wavefront
+
+} // namespace arch
+
+END_ROCPRIM_NAMESPACE
+
+#endif

--- a/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -25,6 +25,7 @@
 
 #include "../config.hpp"
 #include "../detail/various.hpp"
+#include "../intrinsics/arch.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -33,14 +34,15 @@ BEGIN_ROCPRIM_NAMESPACE
 
 // Sizes
 
-/// \brief [DEPRECATED] Returns a number of threads in a hardware warp.
+/// \brief Returns a number of threads in a hardware warp.
 ///
 /// It is constant for a device.
-/// This function is not supported for gfx1030 and newer architectures and will be removed in a future release.
-/// Please use the new host_warp_size() and device_warp_size() functions.
-[[deprecated("Use host_warp_size() or device_warp_size() "
-             "instead.")]] ROCPRIM_HOST_DEVICE inline constexpr unsigned int
-    warp_size()
+///
+/// \warning This function will be removed in a future release.
+[[deprecated(
+     "Use the functions provided in 'rocprim::arch::wavefront' instead.")]]
+ROCPRIM_HOST_DEVICE
+inline constexpr unsigned int warp_size()
 {
     return ROCPRIM_WAVEFRONT_SIZE;
 }
@@ -49,6 +51,10 @@ BEGIN_ROCPRIM_NAMESPACE
 /// At device side this constant is available at compile time.
 ///
 /// It is constant for a device.
+///
+/// \warning This function will be removed in a future release.
+[[deprecated("Use the functions provided in 'rocprim::arch::wavefront' "
+             "instead.")]]
 ROCPRIM_DEVICE ROCPRIM_INLINE
 constexpr unsigned int device_warp_size()
 {
@@ -128,7 +134,7 @@ unsigned int flat_tile_thread_id()
 ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int warp_id()
 {
-    return flat_block_thread_id()/device_warp_size();
+    return flat_block_thread_id()/arch::wavefront::size();
 }
 
 /// \brief Returns warp id in a block (tile), given the flat (linear, 1D) thread identifier in a multidimensional tile (block).
@@ -136,7 +142,7 @@ unsigned int warp_id()
 ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int warp_id(unsigned int flat_id)
 {
-    return flat_id/device_warp_size();
+    return flat_id/arch::wavefront::size();
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -146,7 +152,7 @@ template<unsigned int BlockSizeX, unsigned int BlockSizeY, unsigned int BlockSiz
 ROCPRIM_DEVICE ROCPRIM_INLINE
 unsigned int warp_id()
 {
-    return flat_block_thread_id<BlockSizeX, BlockSizeY, BlockSizeZ>()/device_warp_size();
+    return flat_block_thread_id<BlockSizeX, BlockSizeY, BlockSizeZ>()/arch::wavefront::size();
 }
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
@@ -301,7 +307,7 @@ namespace detail
 
     template<>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    unsigned int logical_lane_id<device_warp_size()>()
+    unsigned int logical_lane_id<arch::wavefront::min_size()>()
     {
         return lane_id();
     }
@@ -316,7 +322,7 @@ namespace detail
 
     template<>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    unsigned int logical_warp_id<device_warp_size()>()
+    unsigned int logical_warp_id<arch::wavefront::min_size()>()
     {
         return warp_id();
     }

--- a/rocprim/include/rocprim/intrinsics/warp_shuffle.hpp
+++ b/rocprim/include/rocprim/intrinsics/warp_shuffle.hpp
@@ -119,20 +119,20 @@ T warp_swizzle(const T& input)
 /// \brief Shuffle for any data type.
 ///
 /// Each thread in warp obtains \p input from <tt>src_lane</tt>-th thread
-/// in warp. If \p width is less than device_warp_size() then each subsection of the
+/// in warp. If \p width is less than arch::wavefront::min_size() then each subsection of the
 /// warp behaves as a separate entity with a starting logical lane id of 0.
 /// If \p src_lane is not in [0; \p width) range, the returned value is
 /// equal to \p input passed by the <tt>src_lane modulo width</tt> thread.
 ///
 /// Note: The optional \p width parameter must be a power of 2; results are
-/// undefined if it is not a power of 2, or it is greater than device_warp_size().
+/// undefined if it is not a power of 2, or it is greater than arch::wavefront::min_size().
 ///
 /// \param input - input to pass to other threads
 /// \param src_lane - warp if of a thread whose \p input should be returned
 /// \param width - logical warp width
 template<class T>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-T warp_shuffle(const T& input, const int src_lane, const int width = device_warp_size())
+T warp_shuffle(const T& input, const int src_lane, const int width = arch::wavefront::min_size())
 {
     return detail::warp_shuffle_op(
         input,
@@ -150,14 +150,14 @@ T warp_shuffle(const T& input, const int src_lane, const int width = device_warp
 /// thread's own \p input is returned.
 ///
 /// Note: The optional \p width parameter must be a power of 2; results are
-/// undefined if it is not a power of 2, or it is greater than device_warp_size().
+/// undefined if it is not a power of 2, or it is greater than arch::wavefront::min_size().
 ///
 /// \param input - input to pass to other threads
 /// \param delta - offset for calculating source lane id
 /// \param width - logical warp width
 template<class T>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-T warp_shuffle_up(const T& input, const unsigned int delta, const int width = device_warp_size())
+T warp_shuffle_up(const T& input, const unsigned int delta, const int width = arch::wavefront::min_size())
 {
     return detail::warp_shuffle_op(
         input,
@@ -175,14 +175,14 @@ T warp_shuffle_up(const T& input, const unsigned int delta, const int width = de
 /// thread's own \p input is returned.
 ///
 /// Note: The optional \p width parameter must be a power of 2; results are
-/// undefined if it is not a power of 2, or it is greater than device_warp_size().
+/// undefined if it is not a power of 2, or it is greater than arch::wavefront::min_size().
 ///
 /// \param input - input to pass to other threads
 /// \param delta - offset for calculating source lane id
 /// \param width - logical warp width
 template<class T>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-T warp_shuffle_down(const T& input, const unsigned int delta, const int width = device_warp_size())
+T warp_shuffle_down(const T& input, const unsigned int delta, const int width = arch::wavefront::min_size())
 {
     return detail::warp_shuffle_op(
         input,
@@ -199,14 +199,14 @@ T warp_shuffle_down(const T& input, const unsigned int delta, const int width = 
 /// thread in warp.
 ///
 /// Note: The optional \p width parameter must be a power of 2; results are
-/// undefined if it is not a power of 2, or it is greater than device_warp_size().
+/// undefined if it is not a power of 2, or it is greater than arch::wavefront::min_size().
 ///
 /// \param input - input to pass to other threads
 /// \param lane_mask - mask used for calculating source lane id
 /// \param width - logical warp width
 template<class T>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-T warp_shuffle_xor(const T& input, const int lane_mask, const int width = device_warp_size())
+T warp_shuffle_xor(const T& input, const int lane_mask, const int width = arch::wavefront::min_size())
 {
     return detail::warp_shuffle_op(
         input,
@@ -227,7 +227,7 @@ namespace detail
 /// Defaults to warp_shuffle_xor.
 ///
 /// Note: The optional \p width parameter must be a power of 2; results are
-/// undefined if it is not a power of 2, or it is greater than device_warp_size().
+/// undefined if it is not a power of 2, or it is greater than arch::wavefront::min_size().
 ///
 /// \param v - input to pass to other threads
 /// \param mask - mask used for calculating source lane id
@@ -235,7 +235,7 @@ namespace detail
 template<class V>
 ROCPRIM_DEVICE ROCPRIM_INLINE V warp_swizzle_shuffle(V&        v,
                                                      const int mask,
-                                                     const int width = device_warp_size())
+                                                     const int width = arch::wavefront::min_size())
 {
     switch(mask)
     {
@@ -260,7 +260,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE V warp_swizzle_shuffle(V&        v,
 /// than the logical warp size will wrap around.
 ///
 /// Note: The optional \p width parameter must be a power of 2; results are
-/// undefined if it is not a power of 2, or it is greater than device_warp_size().
+/// undefined if it is not a power of 2, or it is greater than arch::wavefront::min_size().
 ///
 /// \param input - input to pass to other threads
 /// \param dst_lane - the destination lane to which the value from this thread is written.
@@ -268,7 +268,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE V warp_swizzle_shuffle(V&        v,
 template<typename T>
 ROCPRIM_DEVICE ROCPRIM_INLINE T warp_permute(const T&  input,
                                              const int dst_lane,
-                                             const int width = device_warp_size())
+                                             const int width = arch::wavefront::min_size())
 {
     // The amdgcn intrinsic does not support virtual warp sizes, so in order to support those, manually
     // wrap around the dst_lane within groups of log2(width) bits.
@@ -294,7 +294,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE T warp_permute(const T&  input,
 /// \brief Broadcast the first lane to all threads.
 ///
 /// Each thread in the warp obtains \p input from the first active thread in a warp.
-/// This function always operates on all <tt>device_warp_size()</tt> threads in the warp.
+/// This function always operates on all <tt>arch::wavefront::min_size()</tt> threads in the warp.
 ///
 /// \remark This operation is significantly faster than \p warp_shuffle.
 ///
@@ -312,7 +312,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE T warp_readfirstlane(const T& input)
 /// in the warp. \p src_lane must be the same value for all threads in the warp.
 /// This function does not distinguish between active threads and non-active
 /// threads: all threads must participate in the broadcast. This function also
-/// always operates on all <tt>device_warp_size()</tt> threads in the warp.
+/// always operates on all <tt>arch::wavefront::min_size()</tt> threads in the warp.
 ///
 /// \remark This operation is significantly faster than \p warp_shuffle.
 ///

--- a/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -115,7 +115,7 @@ public:
         reduce_impl(input,
                     output,
                     reduce_op,
-                    std::integral_constant<bool, (WarpSize < ::rocprim::device_warp_size())>{});
+                    std::integral_constant<bool, (WarpSize < ::rocprim::arch::wavefront::min_size())>{});
     }
 
     template<class BinaryFunction>

--- a/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,7 @@
 #include "../../detail/various.hpp"
 
 #include "../../intrinsics.hpp"
+#include "../../intrinsics/arch.hpp"
 #include "../../types.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE

--- a/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_segment_bounds.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@ namespace detail
 // Returns logical warp id of the last thread in thread's segment
 template<bool HeadSegmented, unsigned int WarpSize, class Flag>
 ROCPRIM_DEVICE ROCPRIM_INLINE auto last_in_warp_segment(Flag flag) ->
-    typename std::enable_if<(WarpSize <= device_warp_size()), unsigned int>::type
+    typename std::enable_if<(WarpSize <= arch::wavefront::min_size()), unsigned int>::type
 {
     // Get flags (now every thread know where the flags are)
     lane_mask_type warp_flags = ::rocprim::ballot(flag);

--- a/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
+++ b/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
@@ -122,7 +122,7 @@ private:
         const auto lane = lane_id();
         const auto warp = warp_id();
 
-        const auto warp_offset     = warp * ItemsPerThread * device_warp_size();
+        const auto warp_offset     = warp * ItemsPerThread * arch::wavefront::min_size();
         const auto warp_input_size = warp_offset > input_size ? 0 : input_size - warp_offset;
         const auto shared_keys     = &storage.keys[warp_offset];
 
@@ -181,7 +181,7 @@ private:
         const auto lane = lane_id();
         const auto warp = warp_id();
 
-        const auto warp_offset     = warp * ItemsPerThread * device_warp_size();
+        const auto warp_offset     = warp * ItemsPerThread * arch::wavefront::min_size();
         const auto warp_input_size = warp_offset > input_size ? 0 : input_size - warp_offset;
         const auto shared_keys     = &storage.keys[warp_offset];
         const auto shared_values   = &storage.values[warp_offset];
@@ -477,7 +477,7 @@ public:
     {
         (void)storage;
 
-        const auto warp_offset     = warp_id() * device_warp_size();
+        const auto warp_offset     = warp_id() * arch::wavefront::min_size();
         const auto warp_input_size = warp_offset > input_size ? 0 : input_size - warp_offset;
 
         ROCPRIM_UNROLL
@@ -562,7 +562,7 @@ public:
     {
         (void)storage;
 
-        const auto warp_offset     = warp_id() * device_warp_size();
+        const auto warp_offset     = warp_id() * arch::wavefront::min_size();
         const auto warp_input_size = warp_offset > input_size ? 0 : input_size - warp_offset;
 
         ROCPRIM_UNROLL

--- a/rocprim/include/rocprim/warp/warp_exchange.hpp
+++ b/rocprim/include/rocprim/warp/warp_exchange.hpp
@@ -79,14 +79,14 @@ BEGIN_ROCPRIM_NAMESPACE
 template<
     class T,
     unsigned int ItemsPerThread,
-    unsigned int WarpSize = ::rocprim::device_warp_size()
+    unsigned int WarpSize = ::rocprim::arch::wavefront::min_size()
 >
 class warp_exchange
 {
     static_assert(::rocprim::detail::is_power_of_two(WarpSize),
                   "Logical warp size must be a power of two.");
     ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(
-        WarpSize <= ::rocprim::device_warp_size(),
+        WarpSize <= ::rocprim::arch::wavefront::min_size(),
         "Logical warp size cannot be larger than physical warp size.");
 
     struct storage_type_
@@ -155,7 +155,7 @@ class warp_exchange
         blocked_striped_shuffle_efficient_impl(const T (&input)[ItemsPerThread],
                                                U (&output)[ItemsPerThread])
     {
-        static constexpr bool IS_ARCH_WARP = WarpSize == ::rocprim::device_warp_size();
+        static constexpr bool IS_ARCH_WARP = WarpSize == ::rocprim::arch::wavefront::min_size();
         const unsigned int    flat_lane_id = ::rocprim::detail::logical_lane_id<WarpSize>();
         const unsigned int    lane_id = IS_ARCH_WARP ? flat_lane_id : (flat_lane_id % WarpSize);
         T                     temp[ItemsPerThread];

--- a/rocprim/include/rocprim/warp/warp_load.hpp
+++ b/rocprim/include/rocprim/warp/warp_load.hpp
@@ -116,7 +116,7 @@ enum class warp_load_method
 template<
     class T,
     unsigned int ItemsPerThread,
-    unsigned int WarpSize = ::rocprim::device_warp_size(),
+    unsigned int WarpSize = ::rocprim::arch::wavefront::min_size(),
     warp_load_method Method = warp_load_method::warp_load_direct
 >
 class warp_load
@@ -124,7 +124,7 @@ class warp_load
     static_assert(::rocprim::detail::is_power_of_two(WarpSize),
                   "Logical warp size must be a power of two.");
     ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(
-        WarpSize <= ::rocprim::device_warp_size(),
+        WarpSize <= ::rocprim::arch::wavefront::min_size(),
         "Logical warp size cannot be larger than physical warp size.");
 
 private:
@@ -249,7 +249,7 @@ class warp_load<T, ItemsPerThread, WarpSize, warp_load_method::warp_load_striped
     static_assert(::rocprim::detail::is_power_of_two(WarpSize),
                   "Logical warp size must be a power of two.");
     ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(
-        WarpSize <= ::rocprim::device_warp_size(),
+        WarpSize <= ::rocprim::arch::wavefront::min_size(),
         "Logical warp size cannot be larger than physical warp size.");
 
 public:
@@ -315,7 +315,7 @@ class warp_load<T, ItemsPerThread, WarpSize, warp_load_method::warp_load_vectori
     static_assert(::rocprim::detail::is_power_of_two(WarpSize),
                   "Logical warp size must be a power of two.");
     ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(
-        WarpSize <= ::rocprim::device_warp_size(),
+        WarpSize <= ::rocprim::arch::wavefront::min_size(),
         "Logical warp size cannot be larger than physical warp size.");
 
 public:
@@ -390,7 +390,7 @@ class warp_load<T, ItemsPerThread, WarpSize, warp_load_method::warp_load_transpo
     static_assert(::rocprim::detail::is_power_of_two(WarpSize),
                   "Logical warp size must be a power of two.");
     ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(
-        WarpSize <= ::rocprim::device_warp_size(),
+        WarpSize <= ::rocprim::arch::wavefront::min_size(),
         "Logical warp size cannot be larger than physical warp size.");
 
 private:

--- a/rocprim/include/rocprim/warp/warp_reduce.hpp
+++ b/rocprim/include/rocprim/warp/warp_reduce.hpp
@@ -61,14 +61,14 @@ struct select_warp_reduce_impl
 ///
 /// \tparam T - the input/output type.
 /// \tparam WarpSize - the size of logical warp size, which can be equal to or less than
-/// the size of hardware warp (see rocprim::device_warp_size()). Reduce operations are performed
+/// the size of hardware warp (see rocprim::arch::wavefront::min_size()). Reduce operations are performed
 /// separately within groups determined by WarpSize.
 /// \tparam UseAllReduce - input parameter to determine whether to broadcast final reduction
 /// value to all threads (default is false).
 ///
 /// \par Overview
 /// * \p WarpSize must be equal to or less than the size of hardware warp (see
-/// rocprim::device_warp_size()). If it is less, reduce is performed separately within groups
+/// rocprim::arch::wavefront::min_size()). If it is less, reduce is performed separately within groups
 /// determined by WarpSize. \n
 /// For example, if \p WarpSize is 4, hardware warp is 64, reduction will be performed in logical
 /// warps grouped like this: `{ {0, 1, 2, 3}, {4, 5, 6, 7 }, ..., {60, 61, 62, 63} }`
@@ -108,7 +108,7 @@ struct select_warp_reduce_impl
 /// \endparblock
 template<
     class T,
-    unsigned int WarpSize = device_warp_size(),
+    unsigned int WarpSize = arch::wavefront::min_size(),
     bool UseAllReduce = false
 >
 class warp_reduce
@@ -181,7 +181,7 @@ public:
                                               T&             output,
                                               storage_type&  storage,
                                               BinaryFunction reduce_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::reduce(input, output, storage, reduce_op);
     }
@@ -191,7 +191,7 @@ public:
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         reduce(T, T&, storage_type&, BinaryFunction reduce_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) reduce_op;
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
@@ -250,7 +250,7 @@ public:
                                               int            valid_items,
                                               storage_type&  storage,
                                               BinaryFunction reduce_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::reduce(input, output, valid_items, storage, reduce_op);
     }
@@ -260,7 +260,7 @@ public:
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         reduce(T, T&, int, storage_type&, BinaryFunction reduce_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) reduce_op;
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
@@ -294,7 +294,7 @@ public:
                                                              storage_type&  storage,
                                                              BinaryFunction reduce_op
                                                              = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::head_segmented_reduce(input, output, flag, storage, reduce_op);
     }
@@ -306,7 +306,7 @@ public:
              unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto head_segmented_reduce(
         T, T&, Flag, storage_type&, BinaryFunction reduce_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) reduce_op;
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
@@ -340,7 +340,7 @@ public:
                                                              storage_type&  storage,
                                                              BinaryFunction reduce_op
                                                              = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::tail_segmented_reduce(input, output, flag, storage, reduce_op);
     }
@@ -352,7 +352,7 @@ public:
              unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto tail_segmented_reduce(
         T, T&, Flag, storage_type&, BinaryFunction reduce_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) reduce_op;
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");

--- a/rocprim/include/rocprim/warp/warp_scan.hpp
+++ b/rocprim/include/rocprim/warp/warp_scan.hpp
@@ -61,12 +61,12 @@ struct select_warp_scan_impl
 ///
 /// \tparam T - the input/output type.
 /// \tparam WarpSize - the size of logical warp size, which can be equal to or less than
-/// the size of hardware warp (see rocprim::device_warp_size()). Scan operations are performed
+/// the size of hardware warp (see rocprim::arch::wavefront::min_size()). Scan operations are performed
 /// separately within groups determined by WarpSize.
 ///
 /// \par Overview
 /// * \p WarpSize must be equal to or less than the size of hardware warp (see
-/// rocprim::device_warp_size()). If it is less, scan is performed separately within groups
+/// rocprim::arch::wavefront::min_size()). If it is less, scan is performed separately within groups
 /// determined by WarpSize. \n
 /// For example, if \p WarpSize is 4, hardware warp is 64, scan will be performed in logical
 /// warps grouped like this: `{ {0, 1, 2, 3}, {4, 5, 6, 7 }, ..., {60, 61, 62, 63} }`
@@ -106,7 +106,7 @@ struct select_warp_scan_impl
 /// \endparblock
 template<
     class T,
-    unsigned int WarpSize = device_warp_size()
+    unsigned int WarpSize = arch::wavefront::min_size()
 >
 class warp_scan
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -182,7 +182,7 @@ public:
                                                       T&             output,
                                                       storage_type&  storage,
                                                       BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::inclusive_scan(input, output, storage, scan_op);
     }
@@ -192,7 +192,7 @@ public:
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         inclusive_scan(T, T&, storage_type&, BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) scan_op;
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
@@ -254,7 +254,7 @@ public:
                                                       T&             reduction,
                                                       storage_type&  storage,
                                                       BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::inclusive_scan(input, output, reduction, storage, scan_op);
     }
@@ -264,7 +264,7 @@ public:
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         inclusive_scan(T, T&, T&, storage_type&, BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) scan_op;
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
@@ -329,7 +329,7 @@ public:
                                                       T              init,
                                                       storage_type&  storage,
                                                       BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::exclusive_scan(input, output, init, storage, scan_op);
     }
@@ -339,7 +339,7 @@ public:
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         exclusive_scan(T, T&, T, storage_type&, BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) scan_op;
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
@@ -406,7 +406,7 @@ public:
                                                       T&             reduction,
                                                       storage_type&  storage,
                                                       BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::exclusive_scan(input, output, init, reduction, storage, scan_op);
     }
@@ -416,7 +416,7 @@ public:
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         exclusive_scan(T, T&, T, T&, storage_type&, BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) scan_op;
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
@@ -437,7 +437,7 @@ public:
                                                       storage_type&  storage,
                                                       BinaryFunction scan_op = BinaryFunction())
 #ifndef DOXYGEN_DOCUMENTATION_BUILD
-        -> std::enable_if_t<FunctionWarpSize <= device_warp_size()>
+        -> std::enable_if_t<FunctionWarpSize <= arch::wavefront::min_size()>
 #else
         -> void
 #endif
@@ -451,7 +451,7 @@ public:
                                                       T& /*output*/,
                                                       storage_type& /*storage*/,
                                                       BinaryFunction /*scan_op*/ = BinaryFunction())
-        -> std::enable_if_t<(FunctionWarpSize > device_warp_size())>
+        -> std::enable_if_t<(FunctionWarpSize > arch::wavefront::min_size())>
     {
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size."
                                  " Aborting warp scan.");
@@ -475,7 +475,7 @@ public:
                                                       T&             reduction,
                                                       BinaryFunction scan_op = BinaryFunction())
 #ifndef DOXYGEN_DOCUMENTATION_BUILD
-        -> std::enable_if_t<FunctionWarpSize <= device_warp_size()>
+        -> std::enable_if_t<FunctionWarpSize <= arch::wavefront::min_size()>
 #else
         -> void
 #endif
@@ -490,7 +490,7 @@ public:
                                                       storage_type& /*storage*/,
                                                       T& /*reduction*/,
                                                       BinaryFunction /*scan_op*/ = BinaryFunction())
-        -> std::enable_if_t<(FunctionWarpSize > device_warp_size())>
+        -> std::enable_if_t<(FunctionWarpSize > arch::wavefront::min_size())>
     {
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size."
                                  " Aborting warp scan.");
@@ -562,7 +562,7 @@ public:
                                             T              init,
                                             storage_type&  storage,
                                             BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::scan(input, inclusive_output, exclusive_output, init, storage, scan_op);
     }
@@ -572,7 +572,7 @@ public:
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         scan(T, T&, T&, T, storage_type&, BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) scan_op;
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
@@ -645,7 +645,7 @@ public:
                                             T&             reduction,
                                             storage_type&  storage,
                                             BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::scan(
             input, inclusive_output, exclusive_output, init, reduction,
@@ -658,7 +658,7 @@ public:
     template<class BinaryFunction = ::rocprim::plus<T>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         scan(T, T&, T&, T, T&, storage_type&, BinaryFunction scan_op = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) scan_op;
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size . Aborting warp sort.");
@@ -677,7 +677,7 @@ public:
     template<unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         broadcast(T input, const unsigned int src_lane, storage_type& storage) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), T>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), T>::type
     {
         return base_type::broadcast(input, src_lane, storage);
     }
@@ -686,7 +686,7 @@ public:
     /// Invalid Warp Size
     template<unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto broadcast(T, const unsigned int, storage_type&) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), T>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), T>::type
     {
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
         return T();
@@ -698,14 +698,14 @@ protected:
     template<unsigned int FunctionWarpSize = WarpSize>
     [[deprecated]] ROCPRIM_DEVICE ROCPRIM_INLINE auto
         to_exclusive(T inclusive_input, T& exclusive_output, storage_type& storage) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         return base_type::to_exclusive(inclusive_input, exclusive_output, storage);
     }
 
     template<unsigned int FunctionWarpSize = WarpSize>
     [[deprecated]] ROCPRIM_DEVICE ROCPRIM_INLINE auto to_exclusive(T, T&, storage_type&) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
         return;

--- a/rocprim/include/rocprim/warp/warp_sort.hpp
+++ b/rocprim/include/rocprim/warp/warp_sort.hpp
@@ -47,7 +47,7 @@ BEGIN_ROCPRIM_NAMESPACE
 /// \par Overview
 /// * \p WarpSize must be power of two.
 /// * \p WarpSize must be equal to or less than the size of hardware warp (see
-/// rocprim::device_warp_size()). If it is less, sort is performed separately within groups
+/// rocprim::arch::wavefront::min_size()). If it is less, sort is performed separately within groups
 /// determined by WarpSize.
 /// For example, if \p WarpSize is 4, hardware warp is 64, sort will be performed in logical
 /// warps grouped like this: `{ {0, 1, 2, 3}, {4, 5, 6, 7 }, ..., {60, 61, 62, 63} }`
@@ -102,7 +102,7 @@ BEGIN_ROCPRIM_NAMESPACE
 /// \endparblock
 template<
     class Key,
-    unsigned int WarpSize = device_warp_size(),
+    unsigned int WarpSize = arch::wavefront::min_size(),
     class Value = empty_type
 >
 class warp_sort : detail::warp_sort_shuffle<Key, WarpSize, Value>
@@ -136,7 +136,7 @@ public:
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto sort(Key&           thread_key,
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::sort(thread_key, compare_function);
     }
@@ -146,7 +146,7 @@ public:
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto sort(Key&,
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) compare_function; // disables unused parameter warning
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
@@ -168,7 +168,7 @@ public:
              unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto sort(Key (&thread_keys)[ItemsPerThread],
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::sort(thread_keys, compare_function);
     }
@@ -180,7 +180,7 @@ public:
              unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto sort(Key (&thread_keys)[ItemsPerThread],
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) thread_keys;      // disables unused parameter warning
         (void) compare_function; // disables unused parameter warning
@@ -220,7 +220,7 @@ public:
     ROCPRIM_DEVICE ROCPRIM_INLINE auto sort(Key&           thread_key,
                                             storage_type&  storage,
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::sort(
             thread_key, storage, compare_function
@@ -232,7 +232,7 @@ public:
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         sort(Key&, storage_type&, BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) compare_function; // disables unused parameter warning
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
@@ -274,7 +274,7 @@ public:
     ROCPRIM_DEVICE ROCPRIM_INLINE auto sort(Key (&thread_keys)[ItemsPerThread],
                                             storage_type&  storage,
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::sort(
             thread_keys, storage, compare_function
@@ -289,7 +289,7 @@ public:
     ROCPRIM_DEVICE ROCPRIM_INLINE auto sort(Key (&thread_keys)[ItemsPerThread],
                                             storage_type&,
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) thread_keys;      // disables unused parameter warning
         (void) compare_function; // disables unused parameter warning
@@ -312,7 +312,7 @@ public:
     ROCPRIM_DEVICE ROCPRIM_INLINE auto sort(Key&           thread_key,
                                             Value&         thread_value,
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::sort(
             thread_key, thread_value, compare_function
@@ -324,7 +324,7 @@ public:
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         sort(Key&, Value&, BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) compare_function; // disables unused parameter warning
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
@@ -348,7 +348,7 @@ public:
     ROCPRIM_DEVICE ROCPRIM_INLINE auto sort(Key (&thread_keys)[ItemsPerThread],
                                             Value (&thread_values)[ItemsPerThread],
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::sort(
             thread_keys, thread_values, compare_function
@@ -363,7 +363,7 @@ public:
     ROCPRIM_DEVICE ROCPRIM_INLINE auto sort(Key (&thread_keys)[ItemsPerThread],
                                             Value (&thread_values)[ItemsPerThread],
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) thread_keys;      // disables unused parameter warning
         (void) thread_values;    // disables unused parameter warning
@@ -406,7 +406,7 @@ public:
                                             Value&         thread_value,
                                             storage_type&  storage,
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::sort(
             thread_key, thread_value, storage, compare_function
@@ -418,7 +418,7 @@ public:
     template<class BinaryFunction = ::rocprim::less<Key>, unsigned int FunctionWarpSize = WarpSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE auto
         sort(Key&, Value&, storage_type&, BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) compare_function; // disables unused parameter warning
         ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size. Aborting warp sort.");
@@ -462,7 +462,7 @@ public:
                                             Value (&thread_values)[ItemsPerThread],
                                             storage_type&  storage,
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize <= device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize <= arch::wavefront::min_size()), void>::type
     {
         base_type::sort(
             thread_keys, thread_values, storage, compare_function
@@ -478,7 +478,7 @@ public:
                                             Value (&thread_values)[ItemsPerThread],
                                             storage_type&,
                                             BinaryFunction compare_function = BinaryFunction()) ->
-        typename std::enable_if<(FunctionWarpSize > device_warp_size()), void>::type
+        typename std::enable_if<(FunctionWarpSize > arch::wavefront::min_size()), void>::type
     {
         (void) thread_keys;      // disables unused parameter warning
         (void) thread_values;    // disables unused parameter warning

--- a/rocprim/include/rocprim/warp/warp_store.hpp
+++ b/rocprim/include/rocprim/warp/warp_store.hpp
@@ -118,7 +118,7 @@ enum class warp_store_method
 template<
     class T,
     unsigned int ItemsPerThread,
-    unsigned int WarpSize = ::rocprim::device_warp_size(),
+    unsigned int WarpSize = ::rocprim::arch::wavefront::min_size(),
     warp_store_method Method = warp_store_method::warp_store_direct
 >
 class warp_store
@@ -126,7 +126,7 @@ class warp_store
     static_assert(::rocprim::detail::is_power_of_two(WarpSize),
                   "Logical warp size must be a power of two.");
     ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(
-        WarpSize <= ::rocprim::device_warp_size(),
+        WarpSize <= ::rocprim::arch::wavefront::min_size(),
         "Logical warp size cannot be larger than physical warp size.");
 
 private:
@@ -223,7 +223,7 @@ class warp_store<T, ItemsPerThread, WarpSize, warp_store_method::warp_store_stri
     static_assert(::rocprim::detail::is_power_of_two(WarpSize),
                   "Logical warp size must be a power of two.");
     ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(
-        WarpSize <= ::rocprim::device_warp_size(),
+        WarpSize <= ::rocprim::arch::wavefront::min_size(),
         "Logical warp size cannot be larger than physical warp size.");
 
 public:
@@ -269,7 +269,7 @@ class warp_store<T, ItemsPerThread, WarpSize, warp_store_method::warp_store_vect
     static_assert(::rocprim::detail::is_power_of_two(WarpSize),
                   "Logical warp size must be a power of two.");
     ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(
-        WarpSize <= ::rocprim::device_warp_size(),
+        WarpSize <= ::rocprim::arch::wavefront::min_size(),
         "Logical warp size cannot be larger than physical warp size.");
 
 public:
@@ -324,7 +324,7 @@ class warp_store<T, ItemsPerThread, WarpSize, warp_store_method::warp_store_tran
     static_assert(::rocprim::detail::is_power_of_two(WarpSize),
                   "Logical warp size must be a power of two.");
     ROCPRIM_DETAIL_DEVICE_STATIC_ASSERT(
-        WarpSize <= ::rocprim::device_warp_size(),
+        WarpSize <= ::rocprim::arch::wavefront::min_size(),
         "Logical warp size cannot be larger than physical warp size.");
 
 private:

--- a/test/rocprim/test_block_exchange.kernels.hpp
+++ b/test/rocprim/test_block_exchange.kernels.hpp
@@ -378,10 +378,10 @@ auto test_block_exchange(int device_id) -> typename std::enable_if<Method == 2>:
     std::vector<output_type> expected(size);
     std::vector<output_type> output(size, output_type(0));
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t warp_size      = std::min(block_size, size_t(current_device_warp_size));
+    const size_t warp_size      = std::min(block_size, size_t(current_arch::wavefront::min_size));
     const size_t warps_no       = (block_size + warp_size - 1) / warp_size;
     const size_t items_per_warp = warp_size * items_per_thread;
 
@@ -482,10 +482,10 @@ auto test_block_exchange(int device_id) -> typename std::enable_if<Method == 3>:
     std::vector<output_type> expected(size);
     std::vector<output_type> output(size, output_type(0));
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t warp_size      = std::min(block_size, size_t(current_device_warp_size));
+    const size_t warp_size      = std::min(block_size, size_t(current_arch::wavefront::min_size));
     const size_t warps_no       = (block_size + warp_size - 1) / warp_size;
     const size_t items_per_warp = warp_size * items_per_thread;
 

--- a/test/rocprim/test_block_exchange.kernels.hpp
+++ b/test/rocprim/test_block_exchange.kernels.hpp
@@ -378,10 +378,10 @@ auto test_block_exchange(int device_id) -> typename std::enable_if<Method == 2>:
     std::vector<output_type> expected(size);
     std::vector<output_type> output(size, output_type(0));
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t warp_size      = std::min(block_size, size_t(current_arch::wavefront::min_size));
+    const size_t warp_size      = std::min(block_size, size_t(current_device_warp_size));
     const size_t warps_no       = (block_size + warp_size - 1) / warp_size;
     const size_t items_per_warp = warp_size * items_per_thread;
 
@@ -482,10 +482,10 @@ auto test_block_exchange(int device_id) -> typename std::enable_if<Method == 3>:
     std::vector<output_type> expected(size);
     std::vector<output_type> output(size, output_type(0));
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t warp_size      = std::min(block_size, size_t(current_arch::wavefront::min_size));
+    const size_t warp_size      = std::min(block_size, size_t(current_device_warp_size));
     const size_t warps_no       = (block_size + warp_size - 1) / warp_size;
     const size_t items_per_warp = warp_size * items_per_thread;
 

--- a/test/rocprim/test_block_load_store.kernels.hpp
+++ b/test/rocprim/test_block_load_store.kernels.hpp
@@ -483,7 +483,7 @@ struct enable_block_load_store_test
     static constexpr bool value
         = (LoadMethod != rocprim::block_load_method::block_load_warp_transpose
            && StoreMethod != rocprim::block_store_method::block_store_warp_transpose)
-          || BlockSize % rocprim::device_warp_size() == 0;
+          || BlockSize % rocprim::arch::wavefront::min_size() == 0;
 };
 
 struct dummy_load_store

--- a/test/rocprim/test_intrinsics.cpp
+++ b/test/rocprim/test_intrinsics.cpp
@@ -564,7 +564,7 @@ __global__ void masked_bit_count_kernel(unsigned int*             out,
                                         const max_lane_mask_type  active_lanes)
 {
     const unsigned int out_index = blockIdx.x * blockDim.x + threadIdx.x;
-    const unsigned int in_index  = out_index / rocprim::device_warp_size();
+    const unsigned int in_index  = out_index / rocprim::arch::wavefront::min_size();
 
     const auto   value  = static_cast<rocprim::lane_mask_type>(in[in_index]);
     unsigned int result = test_type_helper<unsigned int>::uninitialized();
@@ -686,7 +686,7 @@ __global__ void warp_any_all_kernel(unsigned int*             out,
 {
     const unsigned int index     = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int predicate
-        = (in[index / rocprim::device_warp_size()] >> rocprim::lane_id()) & 1;
+        = (in[index / rocprim::arch::wavefront::min_size()] >> rocprim::lane_id()) & 1;
 
     unsigned int result = test_type_helper<unsigned int>::uninitialized();
     if(is_lane_active(active_lanes, rocprim::lane_id()))
@@ -1183,7 +1183,7 @@ __global__ void group_elect_kernel(max_lane_mask_type* output,
     const unsigned int input_index = blockIdx.x * blockDim.x + threadIdx.x;
 
     const unsigned int output_index
-        = blockIdx.x * warps_per_block + threadIdx.x / ::rocprim::device_warp_size();
+        = blockIdx.x * warps_per_block + threadIdx.x / ::rocprim::arch::wavefront::min_size();
 
     if(rocprim::group_elect(input[input_index]))
     {

--- a/test/rocprim/test_utils.hpp
+++ b/test/rocprim/test_utils.hpp
@@ -472,7 +472,7 @@ void iota_modulo(ForwardIt first, ForwardIt last, T lbound, const size_t ubound)
 
 template<unsigned int LogicalWarpSize>
 __device__ constexpr bool device_test_enabled_for_warp_size_v
-    = ::rocprim::device_warp_size() >= LogicalWarpSize;
+    = ::rocprim::arch::wavefront::min_size() >= LogicalWarpSize;
 
 template<bool MakeConst, typename T>
 inline auto wrap_in_const(T* ptr) -> typename std::enable_if_t<MakeConst, const T*>

--- a/test/rocprim/test_warp_exchange.cpp
+++ b/test/rocprim/test_warp_exchange.cpp
@@ -214,7 +214,7 @@ __device__ auto warp_exchange_test(T* d_input, T* d_output)
     -> std::enable_if_t<test_utils::device_test_enabled_for_warp_size_v<LogicalWarpSize>>
 {
     using warp_exchange_type         = ::rocprim::warp_exchange<T, ItemsPerThread, LogicalWarpSize>;
-    constexpr unsigned int num_warps = ::rocprim::device_warp_size() / LogicalWarpSize;
+    constexpr unsigned int num_warps = ::rocprim::arch::wavefront::min_size() / LogicalWarpSize;
     ROCPRIM_SHARED_MEMORY typename warp_exchange_type::storage_type storage[num_warps];
 
     T thread_data[ItemsPerThread];
@@ -242,7 +242,7 @@ __device__ auto warp_exchange_test_not_inplace(T* d_input, T* d_output)
     -> std::enable_if_t<test_utils::device_test_enabled_for_warp_size_v<LogicalWarpSize>>
 {
     using warp_exchange_type         = ::rocprim::warp_exchange<T, ItemsPerThread, LogicalWarpSize>;
-    constexpr unsigned int num_warps = ::rocprim::device_warp_size() / LogicalWarpSize;
+    constexpr unsigned int num_warps = ::rocprim::arch::wavefront::min_size() / LogicalWarpSize;
     ROCPRIM_SHARED_MEMORY typename warp_exchange_type::storage_type storage[num_warps];
 
     T thread_data[ItemsPerThread];
@@ -424,7 +424,7 @@ __device__ auto warp_exchange_scatter_test(T* d_input, T* d_output, OffsetT* d_r
 {
     using warp_exchange_type = ::rocprim::warp_exchange<T, ItemsPerThread, LogicalWarpSize>;
 
-    constexpr unsigned int num_warps = ::rocprim::device_warp_size() / LogicalWarpSize;
+    constexpr unsigned int num_warps = ::rocprim::arch::wavefront::min_size() / LogicalWarpSize;
     ROCPRIM_SHARED_MEMORY typename warp_exchange_type::storage_type storage[num_warps];
 
     T thread_data[ItemsPerThread];

--- a/test/rocprim/test_warp_reduce.hpp
+++ b/test/rocprim/test_warp_reduce.hpp
@@ -55,19 +55,19 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSum)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -107,7 +107,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSum)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
@@ -115,7 +115,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSum)
                 device_input, device_output
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
@@ -174,19 +174,19 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSum)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -230,7 +230,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSum)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_allreduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
@@ -238,7 +238,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSum)
                 device_input, device_output
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_allreduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
@@ -297,20 +297,20 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSumValid)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
     const size_t valid = logical_warp_size - 1;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -350,7 +350,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSumValid)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
@@ -358,7 +358,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSumValid)
                 device_input, device_output, valid
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
@@ -418,20 +418,20 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSumValid)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
     const size_t valid = logical_warp_size - 1;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -475,7 +475,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSumValid)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_allreduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
@@ -483,7 +483,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSumValid)
                 device_input, device_output, valid
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_allreduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
@@ -541,19 +541,19 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceCustomStruct)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -602,7 +602,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceCustomStruct)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
@@ -610,7 +610,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceCustomStruct)
                 device_input, device_output
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
@@ -673,19 +673,19 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -745,7 +745,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
         expected[segment_head_index] = static_cast<T>(reduction);
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(head_segmented_warp_reduce_kernel<T, flag_type, block_size_ws32, logical_warp_size>),
@@ -753,7 +753,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
                 device_input, device_flags, device_output
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(head_segmented_warp_reduce_kernel<T, flag_type, block_size_ws64, logical_warp_size>),
@@ -828,19 +828,19 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, TailSegmentedReduceSum)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -911,7 +911,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, TailSegmentedReduceSum)
         }
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(tail_segmented_warp_reduce_kernel<T, flag_type, block_size_ws32, logical_warp_size>),
@@ -919,7 +919,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, TailSegmentedReduceSum)
                 device_input, device_flags, device_output
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(tail_segmented_warp_reduce_kernel<T, flag_type, block_size_ws64, logical_warp_size>),

--- a/test/rocprim/test_warp_reduce.hpp
+++ b/test/rocprim/test_warp_reduce.hpp
@@ -55,19 +55,19 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSum)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -107,7 +107,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSum)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
@@ -115,7 +115,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSum)
                 device_input, device_output
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
@@ -174,19 +174,19 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSum)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -230,7 +230,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSum)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_allreduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
@@ -238,7 +238,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSum)
                 device_input, device_output
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_allreduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
@@ -297,20 +297,20 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSumValid)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
     const size_t valid = logical_warp_size - 1;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -350,7 +350,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSumValid)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
@@ -358,7 +358,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceSumValid)
                 device_input, device_output, valid
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
@@ -418,20 +418,20 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSumValid)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
     const size_t valid = logical_warp_size - 1;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -475,7 +475,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSumValid)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_allreduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
@@ -483,7 +483,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, AllReduceSumValid)
                 device_input, device_output, valid
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_allreduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
@@ -541,19 +541,19 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceCustomStruct)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -602,7 +602,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceCustomStruct)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws32, logical_warp_size>),
@@ -610,7 +610,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, ReduceCustomStruct)
                 device_input, device_output
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_reduce_sum_kernel<T, block_size_ws64, logical_warp_size>),
@@ -673,19 +673,19 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -745,7 +745,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
         expected[segment_head_index] = static_cast<T>(reduction);
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(head_segmented_warp_reduce_kernel<T, flag_type, block_size_ws32, logical_warp_size>),
@@ -753,7 +753,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, HeadSegmentedReduceSum)
                 device_input, device_flags, device_output
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(head_segmented_warp_reduce_kernel<T, flag_type, block_size_ws64, logical_warp_size>),
@@ -828,19 +828,19 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, TailSegmentedReduceSum)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     static constexpr unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -911,7 +911,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, TailSegmentedReduceSum)
         }
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(tail_segmented_warp_reduce_kernel<T, flag_type, block_size_ws32, logical_warp_size>),
@@ -919,7 +919,7 @@ typed_test_def(RocprimWarpReduceTests, name_suffix, TailSegmentedReduceSum)
                 device_input, device_flags, device_output
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(tail_segmented_warp_reduce_kernel<T, flag_type, block_size_ws64, logical_warp_size>),

--- a/test/rocprim/test_warp_scan.hpp
+++ b/test/rocprim/test_warp_scan.hpp
@@ -55,19 +55,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -108,7 +108,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_kernel<T, block_size_ws32, logical_warp_size>),
@@ -116,7 +116,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
                 device_input, device_output
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_kernel<T, block_size_ws64, logical_warp_size>),
@@ -177,19 +177,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -240,7 +240,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_reduce_kernel<T, block_size_ws32, logical_warp_size>),
@@ -248,7 +248,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
                 device_input, device_output, device_output_reductions
             );
         }
-        else if(current_arch::wavefront::min_size == ws64)
+        else if(current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_reduce_kernel<T, block_size_ws64, logical_warp_size>),
@@ -321,19 +321,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -376,7 +376,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_kernel<T, block_size_ws32, logical_warp_size>),
@@ -384,7 +384,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
                 device_input, device_output, init
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_kernel<T, block_size_ws64, logical_warp_size>),
@@ -445,23 +445,23 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScanWoInit)
               ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
               : rocprim::max<size_t>((ws64 / logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t       size      = block_size * grid_size;
 
     // Check if warp size is supported
-    if((logical_warp_size > current_arch::wavefront::min_size)
-       || (current_arch::wavefront::min_size != ws32
-           && current_arch::wavefront::min_size != ws64)) // Only WarpSize 32 and 64 is supported
+    if((logical_warp_size > current_device_warp_size)
+       || (current_device_warp_size != ws32
+           && current_device_warp_size != ws64)) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: "
                "%d.    Skipping test\n",
                logical_warp_size,
                block_size,
-               current_arch::wavefront::min_size);
+               current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -507,7 +507,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScanWoInit)
             hipMemcpy(device_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
 
         // Launching kernel
-        if(current_arch::wavefront::min_size == ws32)
+        if(current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(
@@ -519,7 +519,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScanWoInit)
                 device_input,
                 device_output);
         }
-        else if(current_arch::wavefront::min_size == ws64)
+        else if(current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(
@@ -588,19 +588,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -660,7 +660,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_reduce_kernel<T, block_size_ws32, logical_warp_size>),
@@ -668,7 +668,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
                 device_input, device_output, device_output_reductions, init
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_reduce_kernel<T, block_size_ws64, logical_warp_size>),
@@ -740,23 +740,23 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScanWoInit)
               ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
               : rocprim::max<size_t>((ws64 / logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t       size      = block_size * grid_size;
 
     // Check if warp size is supported
-    if((logical_warp_size > current_arch::wavefront::min_size)
-       || (current_arch::wavefront::min_size != ws32
-           && current_arch::wavefront::min_size != ws64)) // Only WarpSize 32 and 64 is supported
+    if((logical_warp_size > current_device_warp_size)
+       || (current_device_warp_size != ws32
+           && current_device_warp_size != ws64)) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: "
                "%d.    Skipping test\n",
                logical_warp_size,
                block_size,
-               current_arch::wavefront::min_size);
+               current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -816,7 +816,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScanWoInit)
             hipMemcpy(device_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
 
         // Launching kernel
-        if(current_arch::wavefront::min_size == ws32)
+        if(current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_reduce_wo_init_kernel<T,
@@ -830,7 +830,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScanWoInit)
                 device_output,
                 device_output_reductions);
         }
-        else if(current_arch::wavefront::min_size == ws64)
+        else if(current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_reduce_wo_init_kernel<T,
@@ -908,19 +908,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -983,7 +983,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_scan_kernel<T, block_size_ws32, logical_warp_size>),
@@ -991,7 +991,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
                 device_input, device_inclusive_output, device_exclusive_output, init
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_scan_kernel<T, block_size_ws64, logical_warp_size>),
@@ -1066,19 +1066,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -1151,7 +1151,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_scan_reduce_kernel<T, block_size_ws32, logical_warp_size>),
@@ -1160,7 +1160,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
                 device_inclusive_output, device_exclusive_output, device_output_reductions, init
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_scan_reduce_kernel<T, block_size_ws64, logical_warp_size>),
@@ -1246,19 +1246,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
 
-    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_arch::wavefront::min_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_device_warp_size) ||
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -1309,7 +1309,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
         );
 
         // Launching kernel
-        if (current_arch::wavefront::min_size == ws32)
+        if (current_device_warp_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_kernel<T, block_size_ws32, logical_warp_size>),
@@ -1317,7 +1317,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
                 device_input, device_output
             );
         }
-        else if (current_arch::wavefront::min_size == ws64)
+        else if (current_device_warp_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_kernel<T, block_size_ws64, logical_warp_size>),

--- a/test/rocprim/test_warp_scan.hpp
+++ b/test/rocprim/test_warp_scan.hpp
@@ -55,19 +55,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -108,7 +108,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_kernel<T, block_size_ws32, logical_warp_size>),
@@ -116,7 +116,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
                 device_input, device_output
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_kernel<T, block_size_ws64, logical_warp_size>),
@@ -177,19 +177,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -240,7 +240,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_reduce_kernel<T, block_size_ws32, logical_warp_size>),
@@ -248,7 +248,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanReduce)
                 device_input, device_output, device_output_reductions
             );
         }
-        else if(current_device_warp_size == ws64)
+        else if(current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_reduce_kernel<T, block_size_ws64, logical_warp_size>),
@@ -321,19 +321,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -376,7 +376,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_kernel<T, block_size_ws32, logical_warp_size>),
@@ -384,7 +384,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScan)
                 device_input, device_output, init
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_kernel<T, block_size_ws64, logical_warp_size>),
@@ -445,23 +445,23 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScanWoInit)
               ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
               : rocprim::max<size_t>((ws64 / logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t       size      = block_size * grid_size;
 
     // Check if warp size is supported
-    if((logical_warp_size > current_device_warp_size)
-       || (current_device_warp_size != ws32
-           && current_device_warp_size != ws64)) // Only WarpSize 32 and 64 is supported
+    if((logical_warp_size > current_arch::wavefront::min_size)
+       || (current_arch::wavefront::min_size != ws32
+           && current_arch::wavefront::min_size != ws64)) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: "
                "%d.    Skipping test\n",
                logical_warp_size,
                block_size,
-               current_device_warp_size);
+               current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -507,7 +507,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScanWoInit)
             hipMemcpy(device_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
 
         // Launching kernel
-        if(current_device_warp_size == ws32)
+        if(current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(
@@ -519,7 +519,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveScanWoInit)
                 device_input,
                 device_output);
         }
-        else if(current_device_warp_size == ws64)
+        else if(current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(
@@ -588,19 +588,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -660,7 +660,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_reduce_kernel<T, block_size_ws32, logical_warp_size>),
@@ -668,7 +668,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScan)
                 device_input, device_output, device_output_reductions, init
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_reduce_kernel<T, block_size_ws64, logical_warp_size>),
@@ -740,23 +740,23 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScanWoInit)
               ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
               : rocprim::max<size_t>((ws64 / logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t       size      = block_size * grid_size;
 
     // Check if warp size is supported
-    if((logical_warp_size > current_device_warp_size)
-       || (current_device_warp_size != ws32
-           && current_device_warp_size != ws64)) // Only WarpSize 32 and 64 is supported
+    if((logical_warp_size > current_arch::wavefront::min_size)
+       || (current_arch::wavefront::min_size != ws32
+           && current_arch::wavefront::min_size != ws64)) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: "
                "%d.    Skipping test\n",
                logical_warp_size,
                block_size,
-               current_device_warp_size);
+               current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -816,7 +816,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScanWoInit)
             hipMemcpy(device_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
 
         // Launching kernel
-        if(current_device_warp_size == ws32)
+        if(current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_reduce_wo_init_kernel<T,
@@ -830,7 +830,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ExclusiveReduceScanWoInit)
                 device_output,
                 device_output_reductions);
         }
-        else if(current_device_warp_size == ws64)
+        else if(current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_exclusive_scan_reduce_wo_init_kernel<T,
@@ -908,19 +908,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -983,7 +983,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_scan_kernel<T, block_size_ws32, logical_warp_size>),
@@ -991,7 +991,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, Scan)
                 device_input, device_inclusive_output, device_exclusive_output, init
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_scan_kernel<T, block_size_ws64, logical_warp_size>),
@@ -1066,19 +1066,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -1151,7 +1151,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_scan_reduce_kernel<T, block_size_ws32, logical_warp_size>),
@@ -1160,7 +1160,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, ScanReduce)
                 device_inclusive_output, device_exclusive_output, device_output_reductions, init
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_scan_reduce_kernel<T, block_size_ws64, logical_warp_size>),
@@ -1246,19 +1246,19 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
             ? rocprim::max<size_t>(ws64, logical_warp_size * 4)
             : rocprim::max<size_t>((ws64/logical_warp_size), 1) * logical_warp_size;
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
 
-    const size_t block_size = current_device_warp_size == ws32 ? block_size_ws32 : block_size_ws64;
+    const size_t block_size = current_arch::wavefront::min_size == ws32 ? block_size_ws32 : block_size_ws64;
     const unsigned int grid_size = 4;
     const size_t size = block_size * grid_size;
 
     // Check if warp size is supported
-    if( (logical_warp_size > current_device_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+    if( (logical_warp_size > current_arch::wavefront::min_size) ||
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -1309,7 +1309,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
         );
 
         // Launching kernel
-        if (current_device_warp_size == ws32)
+        if (current_arch::wavefront::min_size == ws32)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_kernel<T, block_size_ws32, logical_warp_size>),
@@ -1317,7 +1317,7 @@ typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScanCustomType)
                 device_input, device_output
             );
         }
-        else if (current_device_warp_size == ws64)
+        else if (current_arch::wavefront::min_size == ws64)
         {
             hipLaunchKernelGGL(
                 HIP_KERNEL_NAME(warp_inclusive_scan_kernel<T, block_size_ws64, logical_warp_size>),

--- a/test/rocprim/test_warp_sort.hpp
+++ b/test/rocprim/test_warp_sort.hpp
@@ -41,8 +41,8 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, Sort)
     static constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
     static constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
     static constexpr size_t block_size = std::max<size_t>(256U, logical_warp_size * 4);
 
     static constexpr unsigned int grid_size = 4;
@@ -51,12 +51,12 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, Sort)
     SCOPED_TRACE(testing::Message() << "with size = " << size);
 
     // Check if warp size is supported
-    if( logical_warp_size > current_device_warp_size ||
+    if( logical_warp_size > current_arch::wavefront::min_size ||
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 
@@ -140,8 +140,8 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, SortKeyInt)
     static constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
     static constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
-    unsigned int current_device_warp_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
+    unsigned int current_arch::wavefront::min_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
     static constexpr size_t block_size = std::max<size_t>(256U, logical_warp_size * 4);
 
     static constexpr unsigned int grid_size = 4;
@@ -150,12 +150,12 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, SortKeyInt)
     SCOPED_TRACE(testing::Message() << "with size = " << size);
 
     // Check if warp size is supported
-    if( logical_warp_size > current_device_warp_size ||
+    if( logical_warp_size > current_arch::wavefront::min_size ||
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
-        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
+        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_device_warp_size);
+            logical_warp_size, block_size, current_arch::wavefront::min_size);
         GTEST_SKIP();
     }
 

--- a/test/rocprim/test_warp_sort.hpp
+++ b/test/rocprim/test_warp_sort.hpp
@@ -41,8 +41,8 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, Sort)
     static constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
     static constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
     static constexpr size_t block_size = std::max<size_t>(256U, logical_warp_size * 4);
 
     static constexpr unsigned int grid_size = 4;
@@ -51,12 +51,12 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, Sort)
     SCOPED_TRACE(testing::Message() << "with size = " << size);
 
     // Check if warp size is supported
-    if( logical_warp_size > current_arch::wavefront::min_size ||
+    if( logical_warp_size > current_device_warp_size ||
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 
@@ -140,8 +140,8 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, SortKeyInt)
     static constexpr size_t ws32 = size_t(ROCPRIM_WARP_SIZE_32);
     static constexpr size_t ws64 = size_t(ROCPRIM_WARP_SIZE_64);
 
-    unsigned int current_arch::wavefront::min_size;
-    HIP_CHECK(::rocprim::host_warp_size(device_id, current_arch::wavefront::min_size));
+    unsigned int current_device_warp_size;
+    HIP_CHECK(::rocprim::host_warp_size(device_id, current_device_warp_size));
     static constexpr size_t block_size = std::max<size_t>(256U, logical_warp_size * 4);
 
     static constexpr unsigned int grid_size = 4;
@@ -150,12 +150,12 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, SortKeyInt)
     SCOPED_TRACE(testing::Message() << "with size = " << size);
 
     // Check if warp size is supported
-    if( logical_warp_size > current_arch::wavefront::min_size ||
+    if( logical_warp_size > current_device_warp_size ||
         !rocprim::detail::is_power_of_two(logical_warp_size) ||
-        (current_arch::wavefront::min_size != ws32 && current_arch::wavefront::min_size != ws64) ) // Only WarpSize 32 and 64 is supported
+        (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
         printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
-            logical_warp_size, block_size, current_arch::wavefront::min_size);
+            logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
 

--- a/test/rocprim/test_warp_sort.kernels.hpp
+++ b/test/rocprim/test_warp_sort.kernels.hpp
@@ -23,18 +23,10 @@
 #ifndef TEST_WARP_SORT_KERNELS_HPP_
 #define TEST_WARP_SORT_KERNELS_HPP_
 
-template<
-    unsigned int ItemsPerThread,
-    unsigned int BlockSize,
-    unsigned int LogicalWarpSize,
-    class T
->
+template<unsigned int ItemsPerThread, unsigned int BlockSize, unsigned int LogicalWarpSize, class T>
 __global__
 __launch_bounds__(BlockSize)
-auto test_hip_warp_sort(T* d_output)
-    -> typename std::enable_if<
-        ItemsPerThread == 1 , void
-    >::type
+auto test_hip_warp_sort(T* d_output) -> typename std::enable_if<ItemsPerThread == 1, void>::type
 {
     unsigned int i = threadIdx.x + (blockIdx.x * blockDim.x);
     T value = d_output[i];
@@ -43,47 +35,40 @@ auto test_hip_warp_sort(T* d_output)
     d_output[i] = value;
 }
 
-template<
-    unsigned int ItemsPerThread,
-    unsigned int BlockSize,
-    unsigned int LogicalWarpSize,
-    class KeyType,
-    class ValueType
->
+template<unsigned int ItemsPerThread,
+         unsigned int BlockSize,
+         unsigned int LogicalWarpSize,
+         class KeyType,
+         class ValueType>
 __global__
 __launch_bounds__(BlockSize)
-auto test_hip_sort_key_value_kernel(KeyType* d_output_key, ValueType* d_output_value)
-    -> typename std::enable_if<
-        ItemsPerThread == 1 , void
-    >::type
+auto test_hip_sort_key_value_kernel(KeyType* d_output_key, ValueType* d_output_value) ->
+    typename std::enable_if<ItemsPerThread == 1, void>::type
 {
-    unsigned int i = threadIdx.x + (blockIdx.x * blockDim.x);
-    KeyType key = d_output_key[i];
-    ValueType value = d_output_value[i];
+    unsigned int i     = threadIdx.x + (blockIdx.x * blockDim.x);
+    KeyType      key   = d_output_key[i];
+    ValueType    value = d_output_value[i];
     rocprim::warp_sort<KeyType, LogicalWarpSize, ValueType> wsort;
     wsort.sort(key, value);
-    d_output_key[i] = key;
+    d_output_key[i]   = key;
     d_output_value[i] = value;
 }
 
-template<
-    unsigned int ItemsPerThread,
-    unsigned int BlockSize,
-    unsigned int LogicalWarpSize,
-    class KeyType
->
-__global__
-__launch_bounds__(BlockSize)
-auto test_hip_warp_sort(KeyType * device_key_output)
-    -> typename std::enable_if<
-        (ItemsPerThread != 1 && LogicalWarpSize <= ::rocprim::arch::wavefront::min_size()) , void
-    >::type
+template<unsigned int ItemsPerThread,
+         unsigned int BlockSize,
+         unsigned int LogicalWarpSize,
+         class KeyType>
+__device__
+auto test_hip_warp_sort_impl(KeyType* device_key_output)
+    -> std::enable_if_t<(LogicalWarpSize <= ::rocprim::arch::wavefront::min_size())>
 {
-    const unsigned int lid = threadIdx.x;
+    const unsigned int lid          = threadIdx.x;
     const unsigned int block_offset = blockIdx.x * ItemsPerThread * BlockSize;
 
     KeyType keys[ItemsPerThread];
-    ::rocprim::block_load_direct_warp_striped<LogicalWarpSize>(lid, device_key_output + block_offset, keys);
+    ::rocprim::block_load_direct_warp_striped<LogicalWarpSize>(lid,
+                                                               device_key_output + block_offset,
+                                                               keys);
 
     rocprim::warp_sort<KeyType, LogicalWarpSize> wsort;
     wsort.sort(keys);
@@ -91,69 +76,77 @@ auto test_hip_warp_sort(KeyType * device_key_output)
     ::rocprim::block_store_direct_blocked(lid, device_key_output + block_offset, keys);
 }
 
-template<
-    unsigned int ItemsPerThread,
-    unsigned int BlockSize,
-    unsigned int LogicalWarpSize,
-    class KeyType
->
-__global__
-__launch_bounds__(BlockSize)
-auto test_hip_warp_sort(KeyType* /*device_key_output*/)
-    -> typename std::enable_if<
-        (ItemsPerThread != 1 && LogicalWarpSize > ::rocprim::arch::wavefront::min_size()), void
-    >::type
-{
-    // This kernel will never be actually called, the tests are filtered at runtime if the warp size
-    // of the current device is less than the tested LogicalWarpSize
-}
+template<unsigned int ItemsPerThread,
+         unsigned int BlockSize,
+         unsigned int LogicalWarpSize,
+         class KeyType>
+__device__
+auto test_hip_warp_sort_impl(KeyType*)
+    -> std::enable_if_t<(LogicalWarpSize > ::rocprim::arch::wavefront::min_size())>
+{}
 
-template<
-    unsigned int ItemsPerThread,
-    unsigned int BlockSize,
-    unsigned int LogicalWarpSize,
-    class KeyType,
-    class ValueType
->
+template<unsigned int ItemsPerThread,
+         unsigned int BlockSize,
+         unsigned int LogicalWarpSize,
+         class KeyType>
 __global__
 __launch_bounds__(BlockSize)
-auto test_hip_sort_key_value_kernel(KeyType* device_key_output, ValueType* device_value_output)
-    -> typename std::enable_if<
-        (ItemsPerThread != 1 && LogicalWarpSize <= ::rocprim::arch::wavefront::min_size()), void
-    >::type
+auto test_hip_warp_sort(KeyType* device_key_output) ->
+    typename std::enable_if<(ItemsPerThread != 1), void>::type
 {
-    const unsigned int lid = threadIdx.x;
+    test_hip_warp_sort_impl<ItemsPerThread, BlockSize, LogicalWarpSize, KeyType>(device_key_output);
+}
+template<unsigned int ItemsPerThread,
+         unsigned int BlockSize,
+         unsigned int LogicalWarpSize,
+         class KeyType,
+         class ValueType>
+__device__
+auto test_hip_sort_key_value_impl(KeyType* device_key_output, ValueType* device_value_output)
+    -> std::enable_if_t<(LogicalWarpSize <= ::rocprim::arch::wavefront::min_size())>
+{
+    const unsigned int lid          = threadIdx.x;
     const unsigned int block_offset = blockIdx.x * ItemsPerThread * BlockSize;
 
-    KeyType keys[ItemsPerThread];
+    KeyType   keys[ItemsPerThread];
     ValueType values[ItemsPerThread];
-    ::rocprim::block_load_direct_warp_striped<LogicalWarpSize>(lid, device_key_output + block_offset, keys);
-    ::rocprim::block_load_direct_warp_striped<LogicalWarpSize>(lid, device_value_output + block_offset, values);
+    ::rocprim::block_load_direct_warp_striped<LogicalWarpSize>(lid,
+                                                               device_key_output + block_offset,
+                                                               keys);
+    ::rocprim::block_load_direct_warp_striped<LogicalWarpSize>(lid,
+                                                               device_value_output + block_offset,
+                                                               values);
 
     rocprim::warp_sort<KeyType, LogicalWarpSize, ValueType> wsort;
     wsort.sort(keys, values);
 
     ::rocprim::block_store_direct_blocked(lid, device_key_output + block_offset, keys);
     ::rocprim::block_store_direct_blocked(lid, device_value_output + block_offset, values);
-
 }
 
-template<
-    unsigned int ItemsPerThread,
-    unsigned int BlockSize,
-    unsigned int LogicalWarpSize,
-    class KeyType,
-    class ValueType
->
+template<unsigned int ItemsPerThread,
+         unsigned int BlockSize,
+         unsigned int LogicalWarpSize,
+         class KeyType,
+         class ValueType>
+__device__
+auto test_hip_sort_key_value_impl(KeyType*, ValueType*)
+    -> std::enable_if_t<(LogicalWarpSize > ::rocprim::arch::wavefront::min_size())>
+{}
+
+template<unsigned int ItemsPerThread,
+         unsigned int BlockSize,
+         unsigned int LogicalWarpSize,
+         class KeyType,
+         class ValueType>
 __global__
 __launch_bounds__(BlockSize)
-auto test_hip_sort_key_value_kernel(KeyType* /*device_key_output*/, ValueType* /*device_value_output*/)
-    -> typename std::enable_if<
-        (ItemsPerThread != 1 && LogicalWarpSize > ::rocprim::arch::wavefront::min_size()), void
-    >::type
+auto test_hip_sort_key_value_kernel(KeyType* device_key_output, ValueType* device_value_output) ->
+    typename std::enable_if<(ItemsPerThread != 1), void>::type
 {
-    // This kernel will never be actually called, the tests are filtered at runtime if the warp size
-    // of the current device is less than the tested LogicalWarpSize
+    test_hip_sort_key_value_impl<ItemsPerThread, BlockSize, LogicalWarpSize, KeyType, ValueType>(
+        device_key_output,
+        device_value_output);
 }
 
 #endif // TEST_WARP_SORT_KERNELS_HPP_

--- a/test/rocprim/test_warp_sort.kernels.hpp
+++ b/test/rocprim/test_warp_sort.kernels.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -76,7 +76,7 @@ __global__
 __launch_bounds__(BlockSize)
 auto test_hip_warp_sort(KeyType * device_key_output)
     -> typename std::enable_if<
-        (ItemsPerThread != 1 && LogicalWarpSize <= ::rocprim::device_warp_size()) , void
+        (ItemsPerThread != 1 && LogicalWarpSize <= ::rocprim::arch::wavefront::min_size()) , void
     >::type
 {
     const unsigned int lid = threadIdx.x;
@@ -101,7 +101,7 @@ __global__
 __launch_bounds__(BlockSize)
 auto test_hip_warp_sort(KeyType* /*device_key_output*/)
     -> typename std::enable_if<
-        (ItemsPerThread != 1 && LogicalWarpSize > ::rocprim::device_warp_size()), void
+        (ItemsPerThread != 1 && LogicalWarpSize > ::rocprim::arch::wavefront::min_size()), void
     >::type
 {
     // This kernel will never be actually called, the tests are filtered at runtime if the warp size
@@ -119,7 +119,7 @@ __global__
 __launch_bounds__(BlockSize)
 auto test_hip_sort_key_value_kernel(KeyType* device_key_output, ValueType* device_value_output)
     -> typename std::enable_if<
-        (ItemsPerThread != 1 && LogicalWarpSize <= ::rocprim::device_warp_size()), void
+        (ItemsPerThread != 1 && LogicalWarpSize <= ::rocprim::arch::wavefront::min_size()), void
     >::type
 {
     const unsigned int lid = threadIdx.x;
@@ -149,7 +149,7 @@ __global__
 __launch_bounds__(BlockSize)
 auto test_hip_sort_key_value_kernel(KeyType* /*device_key_output*/, ValueType* /*device_value_output*/)
     -> typename std::enable_if<
-        (ItemsPerThread != 1 && LogicalWarpSize > ::rocprim::device_warp_size()), void
+        (ItemsPerThread != 1 && LogicalWarpSize > ::rocprim::arch::wavefront::min_size()), void
     >::type
 {
     // This kernel will never be actually called, the tests are filtered at runtime if the warp size


### PR DESCRIPTION
We may need to backport deprecation of warp size-related symbols to 6.4.2.