### PR TITLE
[rocPRIM] Fix syntax error in block shuffle up and down

### DIFF
--- a/rocprim/include/rocprim/block/block_shuffle.hpp
+++ b/rocprim/include/rocprim/block/block_shuffle.hpp
@@ -399,7 +399,7 @@ public:
         up(flat_id, input, prev, storage);
 
         // Update block prefix
-        block_suffix = storage->buffer.get_unsafe_array()[BlockSize - 1];
+        block_suffix = storage.buffer.get_unsafe_array()[BlockSize - 1];
     }
 
     /// \brief The thread block rotates a blocked arrange of input items,

--- a/rocprim/include/rocprim/block/block_shuffle.hpp
+++ b/rocprim/include/rocprim/block/block_shuffle.hpp
@@ -534,7 +534,7 @@ public:
         this->down(flat_id, input, next, storage);
 
         // Update block prefixstorage_->
-        block_prefix = storage->next[0];
+        block_prefix = storage.buffer.get_unsafe_array()[0];
     }
 };
 


### PR DESCRIPTION
The storage is being accessed as if it was a pointer with `->` but its not a pointer so `.` should be used instead.