### PR TITLE
fix(rocprim): backport atomic ordered block id toggle via env variable

### DIFF
--- a/benchmark/benchmark_block_run_length_decode.cpp
+++ b/benchmark/benchmark_block_run_length_decode.cpp
@@ -29,6 +29,7 @@
 #include <rocprim/block/block_run_length_decode.hpp>
 #include <rocprim/block/block_store_func.hpp>
 
+#include <chrono>
 #include <random>
 #include <vector>
 

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -25,6 +25,7 @@
 
 #include <rocprim/intrinsics/thread.hpp>
 
+#ifndef HIP_CHECK
 #ifdef USE_GTEST
     // GoogleTest-compatible HIP_CHECK macro. FAIL is called to log the Google Test trace.
     // The lambda is invoked immediately as assertions that generate a fatal failure can
@@ -50,6 +51,7 @@
                 exit(error);                                                                    \
             }                                                                                   \
         }
+#endif
 #endif
 
 namespace common

--- a/common/utils.hpp
+++ b/common/utils.hpp
@@ -26,32 +26,32 @@
 #include <rocprim/intrinsics/thread.hpp>
 
 #ifndef HIP_CHECK
-#ifdef USE_GTEST
-    // GoogleTest-compatible HIP_CHECK macro. FAIL is called to log the Google Test trace.
-    // The lambda is invoked immediately as assertions that generate a fatal failure can
-    // only be used in void-returning functions.
-    #define HIP_CHECK(condition)                                                            \
-        {                                                                                   \
-            hipError_t error = condition;                                                   \
-            if(error != hipSuccess)                                                         \
-            {                                                                               \
-                [error]()                                                                   \
-                { FAIL() << "HIP error " << error << ": " << hipGetErrorString(error); }(); \
-                exit(error);                                                                \
-            }                                                                               \
-        }
-#else
-    #define HIP_CHECK(condition)                                                                \
-        {                                                                                       \
-            hipError_t error = condition;                                                       \
-            if(error != hipSuccess)                                                             \
+    #ifdef USE_GTEST
+        // GoogleTest-compatible HIP_CHECK macro. FAIL is called to log the Google Test trace.
+        // The lambda is invoked immediately as assertions that generate a fatal failure can
+        // only be used in void-returning functions.
+        #define HIP_CHECK(condition)                                                            \
             {                                                                                   \
-                std::cout << "HIP error: " << hipGetErrorString(error) << " file: " << __FILE__ \
-                          << " line: " << __LINE__ << std::endl;                                \
-                exit(error);                                                                    \
-            }                                                                                   \
-        }
-#endif
+                hipError_t error = condition;                                                   \
+                if(error != hipSuccess)                                                         \
+                {                                                                               \
+                    [error]()                                                                   \
+                    { FAIL() << "HIP error " << error << ": " << hipGetErrorString(error); }(); \
+                    exit(error);                                                                \
+                }                                                                               \
+            }
+    #else
+        #define HIP_CHECK(condition)                                                          \
+            {                                                                                 \
+                hipError_t error = condition;                                                 \
+                if(error != hipSuccess)                                                       \
+                {                                                                             \
+                    std::cout << "HIP error: " << hipGetErrorString(error)                    \
+                              << " file: " << __FILE__ << " line: " << __LINE__ << std::endl; \
+                    exit(error);                                                              \
+                }                                                                             \
+            }
+    #endif
 #endif
 
 namespace common

--- a/rocprim/include/rocprim/detail/various.hpp
+++ b/rocprim/include/rocprim/detail/various.hpp
@@ -453,15 +453,15 @@ struct lookback_variant_util
     {
         using T = std::integral_constant<bool, true>;
         using F = std::integral_constant<bool, false>;
-        if (use_sleep)
+        if(use_sleep)
         {
-            if (use_atomic)
+            if(use_atomic)
             {
                 return f(T{}, T{});
             }
             return f(T{}, F{});
         }
-        if (use_atomic)
+        if(use_atomic)
         {
             return f(F{}, T{});
         }

--- a/rocprim/include/rocprim/detail/various.hpp
+++ b/rocprim/include/rocprim/detail/various.hpp
@@ -449,7 +449,7 @@ struct lookback_variant_util
     {}
 
     template<typename Func>
-    auto operator()(Func f)
+    auto operator()(Func f /* [](auto use_sleep, auto use_atomic){ ... } */)
     {
         using T = std::integral_constant<bool, true>;
         using F = std::integral_constant<bool, false>;

--- a/rocprim/include/rocprim/detail/various.hpp
+++ b/rocprim/include/rocprim/detail/various.hpp
@@ -439,6 +439,36 @@ struct select_max_by_value<T, U, Vs...>
 template<typename... Ts>
 using select_max_by_value_t = typename select_max_by_value<Ts...>::type;
 
+struct lookback_variant_util
+{
+    bool use_sleep;
+    bool use_atomic;
+
+    lookback_variant_util(bool use_sleep, bool use_atomic)
+        : use_sleep(use_sleep), use_atomic(use_atomic)
+    {}
+
+    template<typename Func>
+    auto operator()(Func f)
+    {
+        using T = std::integral_constant<bool, true>;
+        using F = std::integral_constant<bool, false>;
+        if (use_sleep)
+        {
+            if (use_atomic)
+            {
+                return f(T{}, T{});
+            }
+            return f(T{}, F{});
+        }
+        if (use_atomic)
+        {
+            return f(F{}, T{});
+        }
+        return f(F{}, F{});
+    }
+};
+
 } // end namespace detail
 END_ROCPRIM_NAMESPACE
 

--- a/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
+++ b/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
@@ -330,7 +330,8 @@ template<class Config,
          bool IsMemCpy,
          class InputBufferItType,
          class OutputBufferItType,
-         class BufferSizeItType>
+         class BufferSizeItType,
+         class WrappedBlockId>
 struct batch_memcpy_impl
 {
     using input_buffer_type  = typename std::iterator_traits<InputBufferItType>::value_type;
@@ -366,6 +367,8 @@ struct batch_memcpy_impl
 
     // Offset over tiles.
     using tile_offset_type = uint32_t;
+
+    using ordered_bid_type = WrappedBlockId;
 
     // The byte offset within a thread-level buffer. Must fit at least `wlev_size_threshold`.
     static_assert(wlev_size_threshold < std::numeric_limits<uint16_t>::max(),
@@ -452,6 +455,8 @@ private:
 
             union shared_t
             {
+                typename ordered_bid_type::storage_type ordered_bid;
+
                 union analysis_t
                 {
                     typename buffer_load_type::storage_type     load_storage;
@@ -900,9 +905,11 @@ private:
     };
 
 public:
-    __global__ static void init_tile_state_kernel(blev_buffer_scan_state_type buffer_scan_state,
-                                                  blev_block_scan_state_type  block_scan_state,
-                                                  tile_offset_type            num_tiles)
+    __global__
+    static void init_tile_state_kernel(blev_buffer_scan_state_type buffer_scan_state,
+                                       blev_block_scan_state_type  block_scan_state,
+                                       tile_offset_type            num_tiles,
+                                       ordered_bid_type              ordered_bid)
     {
         const uint32_t block_id        = rocprim::detail::block_id<0>();
         const uint32_t block_size      = rocprim::detail::block_size<0>();
@@ -912,23 +919,32 @@ public:
         buffer_scan_state.initialize_prefix(flat_thread_id, num_tiles);
 
         block_scan_state.initialize_prefix(flat_thread_id, num_tiles);
+
+        if(flat_thread_id == 0)
+        {
+            ordered_bid.reset();
+        }
     }
 
-    __global__ static void
-        non_blev_memcpy_kernel(copyable_buffers            buffers,
-                               buffer_offset_type          num_buffers,
-                               copyable_blev_buffers       blev_buffers,
-                               blev_buffer_scan_state_type blev_buffer_scan_state,
-                               blev_block_scan_state_type  blev_block_scan_state)
+    __global__
+    static void non_blev_memcpy_kernel(copyable_buffers            buffers,
+                                       buffer_offset_type          num_buffers,
+                                       copyable_blev_buffers       blev_buffers,
+                                       blev_buffer_scan_state_type blev_buffer_scan_state,
+                                       blev_block_scan_state_type  blev_block_scan_state,
+                                       ordered_bid_type            ordered_bid)
     {
         ROCPRIM_SHARED_MEMORY typename non_blev_memcpy::storage_type temp_storage;
+        auto tile_id = ordered_bid.get(rocprim::flat_tile_thread_id(),
+                                       temp_storage.get().shared.ordered_bid);
+
         non_blev_memcpy{}.copy(temp_storage.get(),
                                buffers,
                                num_buffers,
                                blev_buffers,
                                blev_buffer_scan_state,
                                blev_block_scan_state,
-                               rocprim::flat_block_id());
+                               tile_id);
     }
 
     __global__ static void blev_memcpy_kernel(copyable_blev_buffers       blev_buffers,
@@ -1033,14 +1049,6 @@ ROCPRIM_INLINE static hipError_t batch_memcpy_func(void*              temporary_
     using BufferOffsetType = unsigned int;
     using BlockOffsetType  = unsigned int;
 
-    hipError_t error = hipSuccess;
-
-    using batch_memcpy_impl_type = detail::batch_memcpy_impl<Config,
-                                                             IsMemCpy,
-                                                             InputBufferItType,
-                                                             OutputBufferItType,
-                                                             BufferSizeItType>;
-
     static constexpr uint32_t non_blev_block_size         = Config::non_blev_block_size;
     static constexpr uint32_t non_blev_buffers_per_thread = Config::non_blev_buffers_per_thread;
     static constexpr uint32_t blev_block_size             = Config::blev_block_size;
@@ -1048,194 +1056,225 @@ ROCPRIM_INLINE static hipError_t batch_memcpy_func(void*              temporary_
     constexpr uint32_t buffers_per_block = non_blev_block_size * non_blev_buffers_per_thread;
     const uint32_t     num_blocks = rocprim::detail::ceiling_div(num_copies, buffers_per_block);
 
-    using scan_state_buffer_type = rocprim::detail::lookback_scan_state<BufferOffsetType>;
-    using scan_state_block_type  = rocprim::detail::lookback_scan_state<BlockOffsetType>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
 
-    // Pack buffers
-    typename batch_memcpy_impl_type::copyable_buffers const buffers{
-        sources,
-        destinations,
-        sizes,
-    };
+    ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(false, use_atomic_block_id)(
+        [&](auto /* use_sleepy_scan */, auto use_atomic_block_id)
+        {
+            using block_id_type
+                = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
 
-    detail::temp_storage::layout scan_state_buffer_layout{};
-    error = scan_state_buffer_type::get_temp_storage_layout(num_blocks,
-                                                            stream,
-                                                            scan_state_buffer_layout);
-    if(error != hipSuccess)
-    {
-        return error;
-    }
+            using batch_memcpy_impl_type = detail::batch_memcpy_impl<Config,
+                                                                     IsMemCpy,
+                                                                     InputBufferItType,
+                                                                     OutputBufferItType,
+                                                                     BufferSizeItType,
+                                                                     block_id_type>;
 
-    detail::temp_storage::layout blev_block_scan_state_layout{};
-    error = scan_state_block_type::get_temp_storage_layout(num_blocks,
-                                                           stream,
-                                                           blev_block_scan_state_layout);
-    if(error != hipSuccess)
-    {
-        return error;
-    }
+            using scan_state_buffer_type = rocprim::detail::lookback_scan_state<BufferOffsetType>;
+            using scan_state_block_type  = rocprim::detail::lookback_scan_state<BlockOffsetType>;
+            using block_id_type
+                = detail::block_id_wrapper<uint32_t, decltype(use_atomic_block_id)::value>;
 
-    uint8_t* blev_buffer_scan_data;
-    uint8_t* blev_block_scan_state_data;
+            hipError_t error = hipSuccess;
 
-    // The non-blev kernel will prepare blev copy. Communication between the two
-    // kernels is done via `blev_buffers`.
-    typename batch_memcpy_impl_type::copyable_blev_buffers blev_buffers{};
+            // Pack buffers
+            typename batch_memcpy_impl_type::copyable_buffers const buffers{
+                sources,
+                destinations,
+                sizes,
+            };
 
-    // Partition `d_temp_storage`.
-    // If `d_temp_storage` is null, calculate the allocation size instead.
-    error = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.srcs, num_copies),
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.dsts, num_copies),
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.sizes, num_copies),
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.offsets, num_copies),
-            detail::temp_storage::make_partition(&blev_buffer_scan_data, scan_state_buffer_layout),
-            detail::temp_storage::make_partition(&blev_block_scan_state_data,
-                                                 blev_block_scan_state_layout)));
+            detail::temp_storage::layout scan_state_buffer_layout{};
+            error = scan_state_buffer_type::get_temp_storage_layout(num_blocks,
+                                                                    stream,
+                                                                    scan_state_buffer_layout);
+            if(error != hipSuccess)
+            {
+                return error;
+            }
 
-    // If allocation failed, return error.
-    if(error != hipSuccess)
-    {
-        return error;
-    }
+            detail::temp_storage::layout blev_block_scan_state_layout{};
+            error = scan_state_block_type::get_temp_storage_layout(num_blocks,
+                                                                   stream,
+                                                                   blev_block_scan_state_layout);
+            if(error != hipSuccess)
+            {
+                return error;
+            }
 
-    // Return the storage size.
-    if(temporary_storage == nullptr)
-    {
-        return hipSuccess;
-    }
+            uint8_t* blev_buffer_scan_data;
+            uint8_t* blev_block_scan_state_data;
 
-    // Compute launch parameters.
+            // The non-blev kernel will prepare blev copy. Communication between the two
+            // kernels is done via `blev_buffers`.
+            typename batch_memcpy_impl_type::copyable_blev_buffers blev_buffers{};
+            
+            typename block_id_type::id_type* block_id_pool = nullptr;
 
-    int device_id = hipGetStreamDeviceId(stream);
+            // Partition `d_temp_storage`.
+            // If `d_temp_storage` is null, calculate the allocation size instead.
+            error = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.srcs, num_copies),
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.dsts, num_copies),
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.sizes, num_copies),
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.offsets, num_copies),
+                    detail::temp_storage::make_partition(&blev_buffer_scan_data,
+                                                         scan_state_buffer_layout),
+                    detail::temp_storage::make_partition(&blev_block_scan_state_data,
+                                                         blev_block_scan_state_layout),
+                    detail::temp_storage::ptr_aligned_array(&block_id_pool,
+                                                            block_id_type::get_storage_size())));
+            // If allocation failed, return error.
+            if(error != hipSuccess)
+            {
+                return error;
+            }
 
-    // Get the number of multiprocessors
-    int multiprocessor_count{};
-    error = hipDeviceGetAttribute(&multiprocessor_count,
-                                  hipDeviceAttributeMultiprocessorCount,
-                                  device_id);
-    if(error != hipSuccess)
-    {
-        return error;
-    }
+            // Return the storage size.
+            if(temporary_storage == nullptr)
+            {
+                return hipSuccess;
+            }
 
-    // `hipOccupancyMaxActiveBlocksPerMultiprocessor` uses the default device.
-    // We need to perserve the current default device id while we change it temporarily
-    // to get the max occupancy on this stream.
-    int previous_device;
-    error = hipGetDevice(&previous_device);
-    if(error != hipSuccess)
-    {
-        return error;
-    }
+            // Compute launch parameters.
 
-    error = hipSetDevice(device_id);
-    if(error != hipSuccess)
-    {
-        return error;
-    }
+            int device_id = hipGetStreamDeviceId(stream);
 
-    int blev_occupancy{};
-    error = hipOccupancyMaxActiveBlocksPerMultiprocessor(&blev_occupancy,
-                                                         batch_memcpy_impl_type::blev_memcpy_kernel,
-                                                         blev_block_size,
-                                                         0 /* dynSharedMemPerBlk */);
-    if(error != hipSuccess)
-    {
-        return error;
-    }
+            // Get the number of multiprocessors
+            int multiprocessor_count{};
+            error = hipDeviceGetAttribute(&multiprocessor_count,
+                                          hipDeviceAttributeMultiprocessorCount,
+                                          device_id);
+            if(error != hipSuccess)
+            {
+                return error;
+            }
 
-    // Restore the default device id to initial state
-    error = hipSetDevice(previous_device);
-    if(error != hipSuccess)
-    {
-        return error;
-    }
+            // `hipOccupancyMaxActiveBlocksPerMultiprocessor` uses the default device.
+            // We need to perserve the current default device id while we change it temporarily
+            // to get the max occupancy on this stream.
+            int previous_device;
+            error = hipGetDevice(&previous_device);
+            if(error != hipSuccess)
+            {
+                return error;
+            }
 
-    constexpr BlockOffsetType init_kernel_threads = 128;
-    const BlockOffsetType     init_kernel_grid_size
-        = rocprim::detail::ceiling_div(num_blocks, init_kernel_threads);
+            error = hipSetDevice(device_id);
+            if(error != hipSuccess)
+            {
+                return error;
+            }
 
-    auto batch_memcpy_blev_grid_size
-        = multiprocessor_count * blev_occupancy * 1 /* subscription factor */;
+            int blev_occupancy{};
+            error = hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                &blev_occupancy,
+                batch_memcpy_impl_type::blev_memcpy_kernel,
+                blev_block_size,
+                0 /* dynSharedMemPerBlk */);
+            if(error != hipSuccess)
+            {
+                return error;
+            }
 
-    BlockOffsetType batch_memcpy_grid_size = num_blocks;
+            // Restore the default device id to initial state
+            error = hipSetDevice(previous_device);
+            if(error != hipSuccess)
+            {
+                return error;
+            }
 
-    // Prepare init_scan_states_kernel.
-    scan_state_buffer_type scan_state_buffer{};
-    error = scan_state_buffer_type::create(scan_state_buffer,
-                                           blev_buffer_scan_data,
-                                           num_blocks,
-                                           stream);
-    if(error != hipSuccess)
-    {
-        return error;
-    }
+            constexpr BlockOffsetType init_kernel_threads = 128;
+            const BlockOffsetType     init_kernel_grid_size
+                = rocprim::detail::ceiling_div(num_blocks, init_kernel_threads);
 
-    scan_state_block_type scan_state_block{};
-    error = scan_state_block_type::create(scan_state_block,
-                                          blev_block_scan_state_data,
-                                          num_blocks,
-                                          stream);
-    if(error != hipSuccess)
-    {
-        return error;
-    }
+            auto batch_memcpy_blev_grid_size
+                = multiprocessor_count * blev_occupancy * 1 /* subscription factor */;
 
-    // Launch init_scan_states_kernel.
-    batch_memcpy_impl_type::
-        init_tile_state_kernel<<<init_kernel_grid_size, init_kernel_threads, 0, stream>>>(
-            scan_state_buffer,
-            scan_state_block,
-            num_blocks);
-    error = hipGetLastError();
-    if(error != hipSuccess)
-    {
-        return error;
-    }
-    if(debug_synchronous)
-    {
-        ROCPRIM_RETURN_ON_ERROR(hipStreamSynchronize(stream));
-    }
+            BlockOffsetType batch_memcpy_grid_size = num_blocks;
 
-    // Launch batch_memcpy_non_blev_kernel.
-    batch_memcpy_impl_type::
-        non_blev_memcpy_kernel<<<batch_memcpy_grid_size, non_blev_block_size, 0, stream>>>(
-            buffers,
-            num_copies,
-            blev_buffers,
-            scan_state_buffer,
-            scan_state_block);
-    error = hipGetLastError();
-    if(error != hipSuccess)
-    {
-        return error;
-    }
-    if(debug_synchronous)
-    {
-        ROCPRIM_RETURN_ON_ERROR(hipStreamSynchronize(stream));
-    }
+            // Prepare init_scan_states_kernel.
+            scan_state_buffer_type scan_state_buffer{};
+            error = scan_state_buffer_type::create(scan_state_buffer,
+                                                   blev_buffer_scan_data,
+                                                   num_blocks,
+                                                   stream);
+            if(error != hipSuccess)
+            {
+                return error;
+            }
 
-    // Launch batch_memcpy_blev_kernel.
-    batch_memcpy_impl_type::
-        blev_memcpy_kernel<<<batch_memcpy_blev_grid_size, blev_block_size, 0, stream>>>(
-            blev_buffers,
-            scan_state_buffer,
-            batch_memcpy_grid_size - 1);
-    error = hipGetLastError();
-    if(error != hipSuccess)
-    {
-        return error;
-    }
-    if(debug_synchronous)
-    {
-        ROCPRIM_RETURN_ON_ERROR(hipStreamSynchronize(stream));
-    }
+            scan_state_block_type scan_state_block{};
+            error = scan_state_block_type::create(scan_state_block,
+                                                  blev_block_scan_state_data,
+                                                  num_blocks,
+                                                  stream);
+            if(error != hipSuccess)
+            {
+                return error;
+            }
 
+            block_id_type block_id = block_id_type::create(block_id_pool);
+
+            // Launch init_scan_states_kernel.
+            batch_memcpy_impl_type::
+                init_tile_state_kernel<<<init_kernel_grid_size, init_kernel_threads, 0, stream>>>(
+                    scan_state_buffer,
+                    scan_state_block,
+                    num_blocks,
+                    block_id);
+            error = hipGetLastError();
+            if(error != hipSuccess)
+            {
+                return error;
+            }
+            if(debug_synchronous)
+            {
+                ROCPRIM_RETURN_ON_ERROR(hipStreamSynchronize(stream));
+            }
+
+            // Launch batch_memcpy_non_blev_kernel.
+            batch_memcpy_impl_type::
+                non_blev_memcpy_kernel<<<batch_memcpy_grid_size, non_blev_block_size, 0, stream>>>(
+                    buffers,
+                    num_copies,
+                    blev_buffers,
+                    scan_state_buffer,
+                    scan_state_block,
+                    block_id);
+            error = hipGetLastError();
+            if(error != hipSuccess)
+            {
+                return error;
+            }
+            if(debug_synchronous)
+            {
+                ROCPRIM_RETURN_ON_ERROR(hipStreamSynchronize(stream));
+            }
+
+            // Launch batch_memcpy_blev_kernel.
+            batch_memcpy_impl_type::
+                blev_memcpy_kernel<<<batch_memcpy_blev_grid_size, blev_block_size, 0, stream>>>(
+                    blev_buffers,
+                    scan_state_buffer,
+                    batch_memcpy_grid_size - 1);
+            error = hipGetLastError();
+            if(error != hipSuccess)
+            {
+                return error;
+            }
+            if(debug_synchronous)
+            {
+                ROCPRIM_RETURN_ON_ERROR(hipStreamSynchronize(stream));
+            }
+
+            return hipSuccess;
+        }));
     return hipSuccess;
 }
 

--- a/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
+++ b/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
@@ -909,7 +909,7 @@ public:
     static void init_tile_state_kernel(blev_buffer_scan_state_type buffer_scan_state,
                                        blev_block_scan_state_type  block_scan_state,
                                        tile_offset_type            num_tiles,
-                                       ordered_bid_type              ordered_bid)
+                                       ordered_bid_type            ordered_bid)
     {
         const uint32_t block_id        = rocprim::detail::block_id<0>();
         const uint32_t block_size      = rocprim::detail::block_size<0>();
@@ -1062,8 +1062,7 @@ ROCPRIM_INLINE static hipError_t batch_memcpy_func(void*              temporary_
     ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(false, use_atomic_block_id)(
         [&](auto /* use_sleepy_scan */, auto use_atomic_block_id)
         {
-            using block_id_type
-                = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
+            using block_id_type = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
 
             using batch_memcpy_impl_type = detail::batch_memcpy_impl<Config,
                                                                      IsMemCpy,
@@ -1110,7 +1109,7 @@ ROCPRIM_INLINE static hipError_t batch_memcpy_func(void*              temporary_
             // The non-blev kernel will prepare blev copy. Communication between the two
             // kernels is done via `blev_buffers`.
             typename batch_memcpy_impl_type::copyable_blev_buffers blev_buffers{};
-            
+
             typename block_id_type::id_type* block_id_pool = nullptr;
 
             // Partition `d_temp_storage`.

--- a/rocprim/include/rocprim/device/detail/device_nth_element.hpp
+++ b/rocprim/include/rocprim/device/detail/device_nth_element.hpp
@@ -436,7 +436,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
         typename WrappedBlockId::storage_type     ordered_bid;
     } storage;
 
-    auto block_id = ordered_bid.get(threadIdx.x, storage.ordered_bid);
+    auto    block_id = ordered_bid.get(threadIdx.x, storage.ordered_bid);
     uint8_t buckets[num_items_per_thread];
 
     const size_t   nth_element     = nth_element_data->bucket_idx;
@@ -593,8 +593,7 @@ template<class config,
          class KeysIterator,
          class BinaryFunction,
          class WrappedBlockId>
-ROCPRIM_KERNEL
-    __launch_bounds__(device_params<config>().kernel_config.block_size)
+ROCPRIM_KERNEL __launch_bounds__(device_params<config>().kernel_config.block_size)
 void kernel_copy_buckets(KeysIterator                                             keys,
                          typename std::iterator_traits<KeysIterator>::value_type* tree,
                          const size_t                                             size,

--- a/rocprim/include/rocprim/device/detail/device_nth_element.hpp
+++ b/rocprim/include/rocprim/device/detail/device_nth_element.hpp
@@ -36,14 +36,13 @@
 
 #include "device_config_helper.hpp"
 
-#include <cstdint>
-#include <hip/amd_detail/amd_hip_runtime.h>
 #include <hip/hip_runtime.h>
 
-#include <iostream>
-
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
+#include <iostream>
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -397,7 +396,7 @@ ROCPRIM_KERNEL __launch_bounds__(
     kernel_find_nth_element_bucket_impl<config>(buckets, nth_element_data, equality_buckets, rank);
 }
 
-template<class config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
+template<class config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction, class WrappedBlockId>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     kernel_copy_buckets_impl(KeysIterator                                             keys,
                              typename std::iterator_traits<KeysIterator>::value_type* tree,
@@ -406,7 +405,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                              n_th_element_iteration_data*         nth_element_data,
                              typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
                              bool*          equality_buckets,
-                             BinaryFunction compare_function)
+                             BinaryFunction compare_function,
+                             WrappedBlockId ordered_bid)
 {
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
     using state    = nth_element_onesweep_lookback_state;
@@ -433,8 +433,10 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
         typename block_rank::storage_type         rank;
         typename block_load_element::storage_type load_element;
         size_t                                    buckets_block_offsets_shared[num_partitions];
+        typename WrappedBlockId::storage_type     ordered_bid;
     } storage;
 
+    auto block_id = ordered_bid.get(threadIdx.x, storage.ordered_bid);
     uint8_t buckets[num_items_per_thread];
 
     const size_t   nth_element     = nth_element_data->bucket_idx;
@@ -443,7 +445,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     const bool     equality_bucket = nth_element_data->equality_bucket;
     const bool     equality_bucket_before = nth_element > 0 && equality_buckets[nth_element - 1];
 
-    const size_t offset            = blockIdx.x * num_items_per_block;
+    const size_t offset            = block_id * num_items_per_block;
     const bool   is_complete_block = offset + num_items_per_block <= size;
 
     key_type elements[num_items_per_thread];
@@ -519,11 +521,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     const unsigned int partition = threadIdx.x;
     if(partition < num_partitions)
     {
-        state* block_state = &lookback_states[blockIdx.x * num_partitions + partition];
+        state* block_state = &lookback_states[block_id * num_partitions + partition];
         state(state::PARTIAL, partition_counts[0]).store(block_state);
 
         unsigned int exclusive_prefix  = 0;
-        unsigned int lookback_block_id = blockIdx.x;
+        unsigned int lookback_block_id = block_id;
         // The main back tracking loop.
         while(lookback_block_id > 0)
         {
@@ -586,17 +588,22 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     }
 }
 
-template<class config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
+template<class config,
+         unsigned int NumPartitions,
+         class KeysIterator,
+         class BinaryFunction,
+         class WrappedBlockId>
 ROCPRIM_KERNEL
-    __launch_bounds__(device_params<config>().kernel_config.block_size) void kernel_copy_buckets(
-        KeysIterator                                             keys,
-        typename std::iterator_traits<KeysIterator>::value_type* tree,
-        const size_t                                             size,
-        nth_element_onesweep_lookback_state*                     lookback_states,
-        n_th_element_iteration_data*                             nth_element_data,
-        typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
-        bool*                                                    equality_buckets,
-        BinaryFunction                                           compare_function)
+    __launch_bounds__(device_params<config>().kernel_config.block_size)
+void kernel_copy_buckets(KeysIterator                                             keys,
+                         typename std::iterator_traits<KeysIterator>::value_type* tree,
+                         const size_t                                             size,
+                         nth_element_onesweep_lookback_state*                     lookback_states,
+                         n_th_element_iteration_data*                             nth_element_data,
+                         typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
+                         bool*                                                    equality_buckets,
+                         BinaryFunction                                           compare_function,
+                         WrappedBlockId                                           ordered_bid)
 {
     kernel_copy_buckets_impl<config, NumPartitions>(keys,
                                                     tree,
@@ -605,11 +612,17 @@ ROCPRIM_KERNEL
                                                     nth_element_data,
                                                     keys_buffer,
                                                     equality_buckets,
-                                                    compare_function);
+                                                    compare_function,
+                                                    ordered_bid);
 }
 
-template<class config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
-ROCPRIM_INLINE hipError_t
+template<class config,
+         unsigned int NumPartitions,
+         class KeysIterator,
+         class BinaryFunction,
+         class WrappedBlockId>
+ROCPRIM_INLINE
+hipError_t
     nth_element_keys_impl(KeysIterator                                             keys,
                           typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
                           typename std::iterator_traits<KeysIterator>::value_type* tree,
@@ -625,7 +638,8 @@ ROCPRIM_INLINE hipError_t
                           n_th_element_iteration_data* nth_element_data,
                           BinaryFunction               compare_function,
                           hipStream_t                  stream,
-                          bool                         debug_synchronous)
+                          bool                         debug_synchronous,
+                          WrappedBlockId               ordered_bid)
 {
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
 
@@ -668,6 +682,9 @@ ROCPRIM_INLINE hipError_t
                                                        num_partitions * num_blocks,
                                                        stream));
 
+        // Reset ordered block id.
+        ROCPRIM_RETURN_ON_ERROR(ordered_bid.reset_from_host(stream));
+
         start_timer();
         kernel_find_splitters<config>
             <<<1, num_splitters, 0, stream>>>(keys, tree, equality_buckets, size, compare_function);
@@ -697,7 +714,8 @@ ROCPRIM_INLINE hipError_t
                                                                nth_element_data,
                                                                keys_buffer,
                                                                equality_buckets,
-                                                               compare_function);
+                                                               compare_function,
+                                                               ordered_bid);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_copy_buckets", size, start);
 
         // Copy the results in keys_buffer back to the keys

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -21,8 +21,8 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_DEVICE_RADIX_SORT_HPP_
 #define ROCPRIM_DEVICE_DETAIL_DEVICE_RADIX_SORT_HPP_
 
-#include <type_traits>
 #include <iterator>
+#include <type_traits>
 
 #include "../../config.hpp"
 #include "../../detail/various.hpp"
@@ -39,7 +39,8 @@
 #include "../../block/block_radix_sort.hpp"
 #include "../../block/block_scan.hpp"
 #include "../../block/block_store_func.hpp"
-#include "../../thread/radix_key_codec.hpp"
+
+#include "ordered_block_id.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -92,7 +93,7 @@ void sort_warp_striped_to_striped(SortType sorter,
                                   unsigned int                     begin_bit,
                                   unsigned int                     end_bit)
 {
-    (void) values;
+    (void)values;
     if ROCPRIM_IF_CONSTEXPR(Descending)
     {
         sorter.sort_desc_warp_striped_to_striped(keys, storage, begin_bit, end_bit, decomposer);
@@ -103,17 +104,15 @@ void sort_warp_striped_to_striped(SortType sorter,
     }
 }
 
-template<
-    unsigned int WarpSize,
-    unsigned int BlockSize,
-    unsigned int ItemsPerThread,
-    unsigned int RadixBits,
-    bool Descending
->
+template<unsigned int WarpSize,
+         unsigned int BlockSize,
+         unsigned int ItemsPerThread,
+         unsigned int RadixBits,
+         bool         Descending>
 struct radix_digit_count_helper
 {
     static constexpr unsigned int radix_size     = 1 << RadixBits;
-    static constexpr unsigned int warp_size = WarpSize;
+    static constexpr unsigned int warp_size      = WarpSize;
     static constexpr unsigned int atomic_stripes = 4;
     static constexpr unsigned int counters       = radix_size * atomic_stripes;
 
@@ -250,27 +249,27 @@ struct radix_sort_single_helper
              class ValuesInputIterator,
              class ValuesOutputIterator,
              class Decomposer>
-    ROCPRIM_DEVICE ROCPRIM_INLINE void sort_single(KeysInputIterator    keys_input,
-                                                   KeysOutputIterator   keys_output,
-                                                   ValuesInputIterator  values_input,
-                                                   ValuesOutputIterator values_output,
-                                                   unsigned int         size,
-                                                   Decomposer           decomposer,
-                                                   unsigned int         bit,
-                                                   unsigned int         current_radix_bits,
-                                                   storage_type&        storage)
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void sort_single(KeysInputIterator    keys_input,
+                     KeysOutputIterator   keys_output,
+                     ValuesInputIterator  values_input,
+                     ValuesOutputIterator values_output,
+                     unsigned int         size,
+                     Decomposer           decomposer,
+                     unsigned int         bit,
+                     unsigned int         current_radix_bits,
+                     storage_type&        storage)
     {
-        const unsigned int flat_id = ::rocprim::detail::block_thread_id<0>();
-        const unsigned int flat_block_id = ::rocprim::detail::block_id<0>();
+        const unsigned int flat_id             = ::rocprim::detail::block_thread_id<0>();
+        const unsigned int flat_block_id       = ::rocprim::detail::block_id<0>();
         const unsigned int block_offset        = flat_block_id * items_per_block;
         const bool         is_incomplete_block = flat_block_id == (size / items_per_block);
         const unsigned int valid_in_last_block = size - block_offset;
 
-        using key_type = typename std::iterator_traits<KeysInputIterator>::value_type;
-
+        using key_type  = typename std::iterator_traits<KeysInputIterator>::value_type;
         using key_codec = radix_key_codec<key_type, Descending>;
 
-        key_type keys[ItemsPerThread];
+        key_type   keys[ItemsPerThread];
         value_type values[ItemsPerThread];
         if(!is_incomplete_block)
         {
@@ -378,9 +377,9 @@ struct radix_sort_and_scatter_helper
              class ValuesInputIterator,
              class ValuesOutputIterator>
     ROCPRIM_DEVICE ROCPRIM_INLINE
-    void sort_and_scatter(KeysInputIterator keys_input,
-                          KeysOutputIterator keys_output,
-                          ValuesInputIterator values_input,
+    void sort_and_scatter(KeysInputIterator    keys_input,
+                          KeysOutputIterator   keys_output,
+                          ValuesInputIterator  values_input,
                           ValuesOutputIterator values_output,
                           Offset               begin_offset,
                           Offset               end_offset,
@@ -397,7 +396,8 @@ struct radix_sort_and_scatter_helper
             storage.digit_offsets[flat_id] = digit_start;
         }
 
-        for(Offset block_offset = begin_offset; block_offset < end_offset; block_offset += items_per_block)
+        for(Offset block_offset = begin_offset; block_offset < end_offset;
+            block_offset += items_per_block)
         {
             Key keys[ItemsPerThread];
 
@@ -596,13 +596,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void sort_single(KeysInputIterator    keys_i
                                                      unsigned int         bit,
                                                      unsigned int         current_radix_bits)
 {
-    using key_type = typename std::iterator_traits<KeysInputIterator>::value_type;
+    using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
     using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
 
-    using sort_single_helper = radix_sort_single_helper<
-        BlockSize, ItemsPerThread, Descending,
-        key_type, value_type
-    >;
+    using sort_single_helper
+        = radix_sort_single_helper<BlockSize, ItemsPerThread, Descending, key_type, value_type>;
 
     ROCPRIM_SHARED_MEMORY typename sort_single_helper::storage_type storage;
 
@@ -619,8 +617,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void sort_single(KeysInputIterator    keys_i
 
 template<class T>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-auto compare_nan_sensitive(const T& a, const T& b)
-    -> typename std::enable_if<rocprim::is_floating_point<T>::value, bool>::type
+auto compare_nan_sensitive(const T& a, const T& b) ->
+    typename std::enable_if<rocprim::is_floating_point<T>::value, bool>::type
 {
     // Beware: the performance of this function is extremely vulnerable to refactoring.
     // Always check benchmark_device_segmented_radix_sort and benchmark_device_radix_sort
@@ -644,7 +642,8 @@ auto compare_nan_sensitive(const T& a, const T& b)
 }
 
 template<class T>
-ROCPRIM_DEVICE auto compare_nan_sensitive(const T& a, const T& b) ->
+ROCPRIM_DEVICE
+auto compare_nan_sensitive(const T& a, const T& b) ->
     typename std::enable_if<!rocprim::is_floating_point<T>::value, bool>::type
 {
     return a > b;
@@ -656,7 +655,8 @@ struct radix_merge_compare;
 template<class T>
 struct radix_merge_compare<false, false, T, identity_decomposer>
 {
-    ROCPRIM_DEVICE bool operator()(const T& a, const T& b) const
+    ROCPRIM_DEVICE
+    bool operator()(const T& a, const T& b) const
     {
         return compare_nan_sensitive<T>(b, a);
     }
@@ -665,7 +665,8 @@ struct radix_merge_compare<false, false, T, identity_decomposer>
 template<class T>
 struct radix_merge_compare<true, false, T, identity_decomposer>
 {
-    ROCPRIM_DEVICE bool operator()(const T& a, const T& b) const
+    ROCPRIM_DEVICE
+    bool operator()(const T& a, const T& b) const
     {
         return compare_nan_sensitive<T>(a, b);
     }
@@ -682,13 +683,14 @@ struct radix_merge_compare<Descending, true, T, identity_decomposer>
     {
         T radix_mask_upper  = (T(1) << (current_radix_bits + start_bit)) - 1;
         T radix_mask_bottom = (T(1) << start_bit) - 1;
-        radix_mask = radix_mask_upper ^ radix_mask_bottom;
+        radix_mask          = radix_mask_upper ^ radix_mask_bottom;
     }
 
-    ROCPRIM_DEVICE bool operator()(const T& a, const T& b) const
+    ROCPRIM_DEVICE
+    bool operator()(const T& a, const T& b) const
     {
-        const T masked_key_a  = a & radix_mask;
-        const T masked_key_b  = b & radix_mask;
+        const T masked_key_a = a & radix_mask;
+        const T masked_key_b = b & radix_mask;
         return Descending ? masked_key_a > masked_key_b : masked_key_b > masked_key_a;
     }
 };
@@ -706,7 +708,8 @@ struct radix_merge_compare<Descending, true, T, Decomposer>
         : decomposer_(decomposer), start_bit_(start_bit), radix_bits_(current_radix_bits)
     {}
 
-    ROCPRIM_HOST_DEVICE bool operator()(T lhs, T rhs) const
+    ROCPRIM_HOST_DEVICE
+    bool operator()(T lhs, T rhs) const
     {
         using codec_t = radix_key_codec<T, Descending>;
 
@@ -787,8 +790,8 @@ struct onesweep_histograms_helper
         return (place * radix_size + digit) * atomic_stripes + stripe_index;
     }
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE void clear_histogram(const unsigned int flat_id,
-                                                       storage_type&      storage)
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void clear_histogram(const unsigned int flat_id, storage_type& storage)
     {
         for(unsigned int i = flat_id; i < histogram_counters; i += BlockSize)
         {
@@ -916,7 +919,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void onesweep_histograms(KeysInputIterator  
                                                              const unsigned int begin_bit,
                                                              const unsigned int end_bit)
 {
-    using key_type = typename std::iterator_traits<KeysInputIterator>::value_type;
+    using key_type          = typename std::iterator_traits<KeysInputIterator>::value_type;
     using count_helper_type = onesweep_histograms_helper<key_type,
                                                          BlockSize,
                                                          ItemsPerThread,
@@ -926,7 +929,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void onesweep_histograms(KeysInputIterator  
 
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
-    const Offset block_id     = ::rocprim::detail::block_id<0>();
+    const Offset block_id = ::rocprim::detail::block_id<0>();
     const Offset block_offset = block_id * ItemsPerThread * BlockSize;
 
     ROCPRIM_SHARED_MEMORY typename count_helper_type::storage_type storage;
@@ -968,7 +971,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void onesweep_histograms(KeysInputIterator  
 }
 
 template<unsigned int BlockSize, unsigned int RadixBits, class Offset>
-ROCPRIM_DEVICE void onesweep_scan_histograms(Offset* global_digit_offsets)
+ROCPRIM_DEVICE
+void onesweep_scan_histograms(Offset* global_digit_offsets)
 {
     using block_scan_type = block_scan<Offset, BlockSize>;
 
@@ -1013,23 +1017,27 @@ struct onesweep_lookback_state
         : state(static_cast<underlying_type>(status) | value)
     {}
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE underlying_type value() const
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    underlying_type value() const
     {
         return this->state & value_mask;
     }
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE prefix_flag status() const
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    prefix_flag status() const
     {
         return static_cast<prefix_flag>(this->state & status_mask);
     }
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE static onesweep_lookback_state load(onesweep_lookback_state* ptr)
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    static onesweep_lookback_state load(onesweep_lookback_state* ptr)
     {
         underlying_type state = ::rocprim::detail::atomic_load(&ptr->state);
         return onesweep_lookback_state(state);
     }
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE void store(onesweep_lookback_state* ptr) const
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void store(onesweep_lookback_state* ptr) const
     {
         ::rocprim::detail::atomic_store(&ptr->state, this->state);
     }
@@ -1043,7 +1051,8 @@ template<class Key,
          unsigned int               RadixBits,
          bool                       Descending,
          block_radix_rank_algorithm RadixRankAlgorithm,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 struct onesweep_iteration_helper
 {
     static constexpr unsigned int radix_size      = 1u << RadixBits;
@@ -1058,7 +1067,7 @@ struct onesweep_iteration_helper
 
     static constexpr unsigned int digits_per_thread = radix_rank_type::digits_per_thread;
 
-    union storage_type_
+    union data_storage
     {
         typename radix_rank_type::storage_type rank;
         struct
@@ -1066,10 +1075,16 @@ struct onesweep_iteration_helper
             Offset global_digit_offsets[radix_size];
             union
             {
-                Key          ordered_block_keys[items_per_block];
-                Value        ordered_block_values[items_per_block];
+                Key   ordered_block_keys[items_per_block];
+                Value ordered_block_values[items_per_block];
             };
         };
+    };
+
+    struct storage_type_
+    {
+        data_storage                          data;
+        typename BlockIdWrapper::storage_type ordered_bid;
     };
 
     ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_WITH_PUSH
@@ -1081,21 +1096,23 @@ struct onesweep_iteration_helper
              class KeysOutputIterator,
              class ValuesInputIterator,
              class ValuesOutputIterator>
-    ROCPRIM_DEVICE void onesweep(KeysInputIterator        keys_input,
-                                 KeysOutputIterator       keys_output,
-                                 ValuesInputIterator      values_input,
-                                 ValuesOutputIterator     values_output,
-                                 Offset*                  global_digit_offsets_in,
-                                 Offset*                  global_digit_offsets_out,
-                                 onesweep_lookback_state* lookback_states,
-                                 Decomposer               decomposer,
-                                 const unsigned int       bit,
-                                 const unsigned int       current_radix_bits,
-                                 const unsigned int       valid_items,
-                                 storage_type_&           storage)
+    ROCPRIM_DEVICE
+    void onesweep(KeysInputIterator        keys_input,
+                  KeysOutputIterator       keys_output,
+                  ValuesInputIterator      values_input,
+                  ValuesOutputIterator     values_output,
+                  Offset*                  global_digit_offsets_in,
+                  Offset*                  global_digit_offsets_out,
+                  onesweep_lookback_state* lookback_states,
+                  Decomposer               decomposer,
+                  const unsigned int       bit,
+                  const unsigned int       current_radix_bits,
+                  const unsigned int       valid_items,
+                  data_storage&            storage,
+                  unsigned int             ordered_bid)
     {
         const unsigned int flat_id      = ::rocprim::detail::block_thread_id<0>();
-        const unsigned int block_id     = ::rocprim::detail::block_id<0>();
+        const unsigned int block_id     = ordered_bid;
         const unsigned int block_offset = block_id * items_per_block;
 
         // Load keys into private memory, and encode them to unsigned integers.
@@ -1337,7 +1354,8 @@ template<unsigned int               BlockSize,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Offset,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     onesweep_iteration(KeysInputIterator        keys_input,
                        KeysOutputIterator       keys_output,
@@ -1350,7 +1368,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                        Decomposer               decomposer,
                        const unsigned int       bit,
                        const unsigned int       current_radix_bits,
-                       const unsigned int       full_blocks)
+                       const unsigned int       full_blocks,
+                       BlockIdWrapper           ordered_bid)
 {
     using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
     using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
@@ -1363,12 +1382,14 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                      RadixBits,
                                                                      Descending,
                                                                      RadixRankAlgorithm,
-                                                                     Decomposer>;
-
-    constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
-    const unsigned int     block_id        = ::rocprim::detail::block_id<0>();
+                                                                     Decomposer,
+                                                                     BlockIdWrapper>;
 
     ROCPRIM_SHARED_MEMORY typename onesweep_iteration_helper_type::storage_type storage;
+
+    constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
+    const unsigned int     thread_id       = ::rocprim::detail::block_thread_id<0>();
+    const unsigned int     block_id        = ordered_bid.get(thread_id, storage.get().ordered_bid);
 
     if(block_id < full_blocks)
     {
@@ -1383,7 +1404,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                  bit,
                                                                  current_radix_bits,
                                                                  items_per_block,
-                                                                 storage.get());
+                                                                 storage.get().data,
+                                                                 block_id);
     }
     else
     {
@@ -1399,7 +1421,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                   bit,
                                                                   current_radix_bits,
                                                                   valid_in_last_block,
-                                                                  storage.get());
+                                                                  storage.get().data,
+                                                                  block_id);
     }
 }
 

--- a/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -602,7 +602,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void sort_single(KeysInputIterator    keys_i
     using sort_single_helper
         = radix_sort_single_helper<BlockSize, ItemsPerThread, Descending, key_type, value_type>;
 
-    ROCPRIM_SHARED_MEMORY typename sort_single_helper::storage_type storage;
+    ROCPRIM_SHARED_MEMORY
+    typename sort_single_helper::storage_type storage;
 
     sort_single_helper().template sort_single<>(keys_input,
                                                 keys_output,
@@ -1385,7 +1386,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                      Decomposer,
                                                                      BlockIdWrapper>;
 
-    ROCPRIM_SHARED_MEMORY typename onesweep_iteration_helper_type::storage_type storage;
+    ROCPRIM_SHARED_MEMORY
+    typename onesweep_iteration_helper_type::storage_type storage;
 
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
     const unsigned int     thread_id       = ::rocprim::detail::block_thread_id<0>();

--- a/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
+++ b/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
@@ -469,7 +469,8 @@ template<lookback_scan_determinism Determinism,
          typename UniqueCountIterator,
          typename CompareFunction,
          typename BinaryOp,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename WrappedBlockId>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto kernel_impl(KeyIterator,
                                                      ValueIterator,
                                                      const UniqueIterator,
@@ -482,7 +483,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto kernel_impl(KeyIterator,
                                                      const std::size_t,
                                                      const std::size_t,
                                                      const std::size_t* const,
-                                                     const AccumulatorType* const)
+                                                     const AccumulatorType* const,
+                                                     WrappedBlockId)
     -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
 {
     // No need to build the kernel with sleep on a device that does not require it
@@ -498,7 +500,8 @@ template<lookback_scan_determinism Determinism,
          typename UniqueCountIterator,
          typename CompareFunction,
          typename BinaryOp,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename WrappedBlockId>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     kernel_impl(KeyIterator                    keys_input,
                 ValueIterator                  values_input,
@@ -512,7 +515,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                 const std::size_t              total_number_of_blocks,
                 const std::size_t              size,
                 const std::size_t* const       global_head_count,
-                const AccumulatorType* const   previous_accumulated)
+                const AccumulatorType* const   previous_accumulated,
+                WrappedBlockId                 ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
 {
     static constexpr reduce_by_key_config_params params = device_params<Config>();
@@ -537,10 +541,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
 
     ROCPRIM_SHARED_MEMORY union
     {
+        typename WrappedBlockId::storage_type ordered_bid;
         typename tile_processor::storage_type tile;
     } storage;
 
-    const unsigned int  block_id     = rocprim::flat_block_id<block_size, 1, 1>();
+    const unsigned int  block_id     = ordered_bid.get(threadIdx.x, storage.ordered_bid);
     const unsigned int  block_offset = block_id * items_per_block;
     const KeyIterator   block_keys   = keys_input + block_offset;
     const ValueIterator block_values = values_input + block_offset;

--- a/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
+++ b/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
@@ -764,7 +764,8 @@ template<typename Config,
          typename OffsetsOutputIterator,
          typename CountsOutputIterator,
          typename RunsCountOutputIterator,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename WrappedBlockId>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     non_trivial_kernel_impl(InputIterator,
                             const OffsetsOutputIterator,
@@ -772,7 +773,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                             const RunsCountOutputIterator,
                             const LookbackScanState,
                             const size_t,
-                            const size_t)
+                            const size_t,
+                            WrappedBlockId)
         -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
 {
     // No need to build the kernel with sleep on a device that does not require it
@@ -784,7 +786,8 @@ template<typename Config,
          typename OffsetsOutputIterator,
          typename CountsOutputIterator,
          typename RunsCountOutputIterator,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename WrappedBlockId>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     non_trivial_kernel_impl(InputIterator                  input,
                             const OffsetsOutputIterator    offsets_output,
@@ -792,7 +795,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                             const RunsCountOutputIterator  runs_count_output,
                             const LookbackScanState        scan_state,
                             const size_t              grid_size,
-                            const size_t              size)
+                            const size_t              size,
+                            WrappedBlockId            ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
 {
     static constexpr non_trivial_runs_config_params params     = device_params<Config>();
@@ -815,9 +819,12 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                                          load_input_method,
                                          scan_algorithm>;
 
-    ROCPRIM_SHARED_MEMORY typename block_processor::storage_type_ storage;
+    ROCPRIM_SHARED_MEMORY union {
+        typename block_processor::storage_type_ storage;
+        typename WrappedBlockId::storage_type   ordered_bid_storage;
+    };
 
-    const size_t block_id = flat_block_id<block_size, 1, 1>();
+    const size_t block_id = ordered_bid.get(rocprim::flat_tile_thread_id(), ordered_bid_storage);
 
     const size_t        block_offset = block_id * items_per_block;
     const InputIterator block_input  = input + block_offset;

--- a/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
+++ b/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
@@ -820,11 +820,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                                          scan_algorithm>;
 
     ROCPRIM_SHARED_MEMORY union {
-        typename block_processor::storage_type_ storage;
+        typename block_processor::storage_type_ block_processor_storage;
         typename WrappedBlockId::storage_type   ordered_bid_storage;
-    };
+    } storage;
 
-    const size_t block_id = ordered_bid.get(rocprim::flat_tile_thread_id(), ordered_bid_storage);
+    const size_t block_id = ordered_bid.get(threadIdx.x, storage.ordered_bid_storage);
 
     const size_t        block_offset = block_id * items_per_block;
     const InputIterator block_input  = input + block_offset;
@@ -841,7 +841,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                                         block_id,
                                         grid_size,
                                         size,
-                                        storage);
+                                        storage.block_processor_storage);
     }
     else if(valid_in_last_block > 0)
     {
@@ -852,7 +852,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                                                                     block_id,
                                                                     grid_size,
                                                                     size,
-                                                                    storage);
+                                                                    storage.block_processor_storage);
         // First thread of last block sets the total number of non-trivial runs found and updates
         // the counts with the last run's length if necessary.
         if(threadIdx.x == 0)

--- a/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
+++ b/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
@@ -819,7 +819,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                                          load_input_method,
                                          scan_algorithm>;
 
-    ROCPRIM_SHARED_MEMORY union {
+    ROCPRIM_SHARED_MEMORY union
+    {
         typename block_processor::storage_type_ block_processor_storage;
         typename WrappedBlockId::storage_type   ordered_bid_storage;
     } storage;
@@ -845,14 +846,15 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     }
     else if(valid_in_last_block > 0)
     {
-        OffsetCountPairType total = block_processor{}.process_block(block_input,
-                                                                    offsets_output,
-                                                                    counts_output,
-                                                                    scan_state,
-                                                                    block_id,
-                                                                    grid_size,
-                                                                    size,
-                                                                    storage.block_processor_storage);
+        OffsetCountPairType total
+            = block_processor{}.process_block(block_input,
+                                              offsets_output,
+                                              counts_output,
+                                              scan_state,
+                                              block_id,
+                                              grid_size,
+                                              size,
+                                              storage.block_processor_storage);
         // First thread of last block sets the total number of non-trivial runs found and updates
         // the counts with the last run's length if necessary.
         if(threadIdx.x == 0)

--- a/rocprim/include/rocprim/device/detail/device_scan.hpp
+++ b/rocprim/include/rocprim/device/detail/device_scan.hpp
@@ -95,7 +95,8 @@ template<lookback_scan_determinism Determinism,
          class OutputIterator,
          class BinaryFunction,
          class AccType,
-         class LookbackScanState>
+         class LookbackScanState,
+         class BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto lookback_scan_kernel_impl(InputIterator,
                                                                    OutputIterator,
                                                                    const size_t,
@@ -103,10 +104,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto lookback_scan_kernel_impl(InputIterator
                                                                    BinaryFunction,
                                                                    LookbackScanState,
                                                                    const unsigned int,
-                                                                   AccType* = nullptr,
-                                                                   AccType* = nullptr,
-                                                                   bool     = false,
-                                                                   bool     = false)
+                                                                   AccType*,
+                                                                   AccType*,
+                                                                   bool,
+                                                                   bool,
+                                                                   BlockIdWrapper)
     -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
 {
     // No need to build the kernel with sleep on a device that does not require it
@@ -119,7 +121,8 @@ template<lookback_scan_determinism Determinism,
          class OutputIterator,
          class BinaryFunction,
          class AccType,
-         class LookbackScanState>
+         class LookbackScanState,
+         class BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     lookback_scan_kernel_impl(InputIterator      input,
                               OutputIterator     output,
@@ -128,10 +131,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                               BinaryFunction     scan_op,
                               LookbackScanState  scan_state,
                               const unsigned int number_of_blocks,
-                              AccType*           previous_last_element = nullptr,
-                              AccType*           new_last_element      = nullptr,
-                              bool               override_first_value  = false,
-                              bool               save_last_value       = false)
+                              AccType*           previous_last_element,
+                              AccType*           new_last_element,
+                              bool               override_first_value,
+                              bool               save_last_value,
+                              BlockIdWrapper     ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
 {
     static_assert(std::is_same<AccType, typename LookbackScanState::value_type>::value,
@@ -153,15 +157,16 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
 
     ROCPRIM_SHARED_MEMORY union
     {
+        typename BlockIdWrapper::storage_type   ordered_bid;
         typename block_load_type::storage_type  load;
         typename block_store_type::storage_type store;
         typename block_scan_type::storage_type  scan;
     } storage;
 
     const auto         flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
-    const auto         flat_block_id        = ::rocprim::detail::block_id<0>();
-    const unsigned int block_offset         = flat_block_id * items_per_block;
-    const auto         valid_in_last_block  = size - items_per_block * (number_of_blocks - 1);
+    const size_t       flat_block_id = ordered_bid.get(flat_block_thread_id, storage.ordered_bid);
+    const unsigned int block_offset  = flat_block_id * items_per_block;
+    const auto         valid_in_last_block = size - items_per_block * (number_of_blocks - 1);
 
     // For input values
     AccType values[items_per_thread];

--- a/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
+++ b/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
@@ -252,7 +252,8 @@ namespace detail
              typename ResultType,
              typename CompareFunction,
              typename BinaryFunction,
-             typename LookbackScanState>
+             typename LookbackScanState,
+             typename WrappedBlockId>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
         device_scan_by_key_kernel_impl(KeyInputIterator,
                                        InputIterator,
@@ -264,7 +265,8 @@ namespace detail
                                        const size_t,
                                        const size_t,
                                        const size_t,
-                                       const rocprim::tuple<ResultType, bool>* const)
+                                       const rocprim::tuple<ResultType, bool>* const,
+                                       WrappedBlockId)
             -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
     {
         // No need to build the kernel with sleep on a device that does not require it
@@ -279,7 +281,8 @@ namespace detail
              typename ResultType,
              typename CompareFunction,
              typename BinaryFunction,
-             typename LookbackScanState>
+             typename LookbackScanState,
+             typename WrappedBlockId>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto device_scan_by_key_kernel_impl(
         KeyInputIterator                              keys,
         InputIterator                                 values,
@@ -291,7 +294,8 @@ namespace detail
         const size_t                                  size,
         const size_t                                  starting_block,
         const size_t                                  number_of_blocks,
-        const rocprim::tuple<ResultType, bool>* const previous_last_value)
+        const rocprim::tuple<ResultType, bool>* const previous_last_value,
+        WrappedBlockId                                ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
     {
         using result_type = ResultType;
@@ -325,13 +329,16 @@ namespace detail
 
         ROCPRIM_SHARED_MEMORY union
         {
+            typename WrappedBlockId::storage_type  ordered_bid;
             typename load_flagged::storage_type    load;
             typename block_scan_type::storage_type scan;
             typename store_unwrap::storage_type    store;
         } storage;
 
         const auto flat_thread_id = ::rocprim::detail::block_thread_id<0>();
-        const auto flat_block_id  = ::rocprim::detail::block_id<0>();
+        const auto flat_block_id
+            = ordered_bid.get(flat_thread_id,
+                              storage.ordered_bid);
 
         // Load input
         wrapped_type wrapped_values[items_per_thread];

--- a/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
+++ b/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
@@ -336,9 +336,7 @@ namespace detail
         } storage;
 
         const auto flat_thread_id = ::rocprim::detail::block_thread_id<0>();
-        const auto flat_block_id
-            = ordered_bid.get(flat_thread_id,
-                              storage.ordered_bid);
+        const auto flat_block_id  = ordered_bid.get(flat_thread_id, storage.ordered_bid);
 
         // Load input
         wrapped_type wrapped_values[items_per_thread];

--- a/rocprim/include/rocprim/device/detail/device_scan_common.hpp
+++ b/rocprim/include/rocprim/device/detail/device_scan_common.hpp
@@ -54,12 +54,12 @@ void access_indexed_lookback_value(LookBackScanState  lookback_scan_state,
     }
 }
 
-template<typename LookBackScanState>
-ROCPRIM_DEVICE ROCPRIM_INLINE void
-    init_lookback_scan_state(LookBackScanState              lookback_scan_state,
-                             const unsigned int             number_of_blocks,
-                             ordered_block_id<unsigned int> ordered_bid,
-                             unsigned int                   flat_thread_id)
+template<typename LookBackScanState, typename WrappedBlockId>
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void init_lookback_scan_state(LookBackScanState  lookback_scan_state,
+                              const unsigned int number_of_blocks,
+                              WrappedBlockId     ordered_bid,
+                              unsigned int       flat_thread_id)
 {
     // Reset ordered_block_id.
     if(flat_thread_id == 0)
@@ -81,14 +81,14 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void init_lookback_scan_state(LookBackScanState  l
     lookback_scan_state.initialize_prefix(flat_thread_id, number_of_blocks);
 }
 
-template<typename LookBackScanState>
-ROCPRIM_KERNEL
-    __launch_bounds__(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void init_lookback_scan_state_kernel(
-        LookBackScanState                             lookback_scan_state,
-        const unsigned int                            number_of_blocks,
-        ordered_block_id<unsigned int>                ordered_bid,
-        unsigned int                                  save_index = 0,
-        typename LookBackScanState::value_type* const save_dest  = nullptr)
+template<typename LookBackScanState, typename WrappedBlockId>
+ROCPRIM_KERNEL __launch_bounds__(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE)
+void init_lookback_scan_state_kernel(LookBackScanState  lookback_scan_state,
+                                     const unsigned int number_of_blocks,
+                                     WrappedBlockId     ordered_bid,
+                                     unsigned int       save_index = 0,
+                                     typename LookBackScanState::value_type* const save_dest
+                                     = nullptr)
 {
     const unsigned int block_id        = ::rocprim::detail::block_id<0>();
     const unsigned int block_size      = ::rocprim::detail::block_size<0>();

--- a/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
+++ b/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
@@ -21,46 +21,74 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_ORDERED_BLOCK_ID_HPP_
 #define ROCPRIM_DEVICE_DETAIL_ORDERED_BLOCK_ID_HPP_
 
-#include <type_traits>
-
+#include "../../common.hpp"
 #include "../../config.hpp"
 #include "../../detail/temp_storage.hpp"
 #include "../../intrinsics/atomic.hpp"
 #include "../../intrinsics/thread.hpp"
+#include "../config_types.hpp"
+
+#include <atomic>
+#include <exception>
+#include <type_traits>
 
 BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
 
-// Helper struct for generating ordered unique ids for blocks in a grid.
+/// Helper struct for generating ordered unique ids for blocks in a grid.
 template<class T /* id type */ = unsigned int>
 struct ordered_block_id
 {
+    // It's a bit confusing on how this API *should* be used. So here is how it should be initialized:
+    //   using ordered_bid_type = ordered_block_id<>;
+    //   ordered_bid_type::id_type* ordered_bid_storage;
+    //
+    //   detail::temp_storage::make_linear_partition(
+    //     detail::temp_storage::make_partition(&ordered_bid_storage, ordered_bid_type::get_temp_storage_layout())
+    //   );
+    //
+    //   auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+    //
+    //   my_kernel<<<x, y>>>(ordered_bid);
+    //
+    // On the kernel side it should be:
+    //   __globbal__ my_kernel(ordered_block_id<> ordered_bid)
+    //   {
+    //     __shared__ ordered_block_id<>::storage ordered_bid_storage;
+    //
+    //     auto tid      = threadIdx.x;
+    //     auto block_id = ordered_bid.get(tid, ordered_bid_storage);
+    //   }
     static_assert(std::is_integral<T>::value, "T must be integer");
     using id_type = T;
 
-    // shared memory temporary storage type
+    /// Pointer to global memory that contains the atomic counter for block id.
+    id_type* id;
+
+    /// Shared memory for sharing the received block id to other threads in the block.
     struct storage_type
     {
         id_type id;
     };
 
-    ROCPRIM_HOST static inline
-    ordered_block_id create(id_type * id)
+    ROCPRIM_HOST
+    static inline ordered_block_id create(id_type* ordered_bid_storage)
     {
         ordered_block_id ordered_id;
-        ordered_id.id = id;
+        ordered_id.id = ordered_bid_storage;
         return ordered_id;
     }
 
-    ROCPRIM_HOST static inline
-    size_t get_storage_size()
+    ROCPRIM_HOST
+    static inline size_t get_storage_size()
     {
         return sizeof(id_type);
     }
 
-    ROCPRIM_HOST static inline detail::temp_storage::layout get_temp_storage_layout()
+    ROCPRIM_HOST
+    static inline detail::temp_storage::layout get_temp_storage_layout()
     {
         return detail::temp_storage::layout{get_storage_size(), alignof(id_type)};
     }
@@ -82,7 +110,13 @@ struct ordered_block_id
         return storage.id;
     }
 
-    id_type* id;
+    /// Resets the ordered block id from host. Don't use this if we have an init kernel!
+    /// Call `ordered_block_id::reset()` from that kernel instead.
+    ROCPRIM_HOST ROCPRIM_INLINE
+    hipError_t reset_from_host(const hipStream_t = hipStreamDefault)
+    {
+        return hipMemset(id, 0, sizeof(id_type));
+    }
 };
 
 template<class T = unsigned int, bool UsingOrderedBlockId = false>
@@ -98,7 +132,7 @@ struct block_id_wrapper<T, false>
     {};
 
     ROCPRIM_HOST
-    static inline block_id_wrapper create(id_type* /*id*/)
+    static inline block_id_wrapper create(void* /*id*/)
     {
         block_id_wrapper ordered_id;
         return ordered_id;
@@ -141,10 +175,11 @@ struct block_id_wrapper<T, true>
     using storage_type = typename ::rocprim::detail::ordered_block_id<id_type>::storage_type;
 
     ROCPRIM_HOST
-    static inline block_id_wrapper create(id_type* id)
+    static inline block_id_wrapper create(void* id)
     {
         block_id_wrapper id_wrapper;
-        id_wrapper.ordered_id = detail::ordered_block_id<id_type>::create(id);
+        id_wrapper.ordered_id
+            = detail::ordered_block_id<id_type>::create(static_cast<id_type*>(id));
         return id_wrapper;
     }
 
@@ -182,6 +217,86 @@ struct block_id_wrapper<T, true>
 
     ::rocprim::detail::ordered_block_id<id_type> ordered_id;
 };
+
+ROCPRIM_INLINE ROCPRIM_HOST
+hipError_t check_if_using_atomic_block_id(hipStream_t stream, bool& enable)
+{
+    // Define possible options
+    enum class use_atomic_block_id : int
+    {
+        never  = 0,
+        hotfix = 1,
+        always = 2,
+
+        default_option = use_atomic_block_id::hotfix,
+    };
+
+    struct data_t
+    {
+        bool                valid  = false;
+        use_atomic_block_id option = use_atomic_block_id::hotfix;
+    };
+
+    // Store our data in a static atomic.
+    static std::atomic<data_t> cache{data_t{}};
+
+    // First load the atomic, if it's invalid, we need to check the env vars.
+    data_t data = cache.load(std::memory_order_acquire);
+    if(!data.valid)
+    {
+        // Try to parse the env var, if it fails fall back to the default option.
+        auto* env = std::getenv("ROCPRIM_USE_ATOMIC_BLOCK_ID");
+
+        data.option = use_atomic_block_id::default_option;
+        try
+        {
+            if(env != nullptr)
+            {
+                data.option = use_atomic_block_id(std::stoi(env));
+            }
+        }
+        catch(std::exception)
+        {
+            data.option = use_atomic_block_id::default_option;
+        }
+
+        data.valid = true;
+        // Now finally update our static atomic.
+        cache.store(data, std::memory_order_release);
+    }
+
+    // Now we have our data, we need to check what the behaviour is.
+    bool needs_hotfix = false;
+    if(data.option == use_atomic_block_id::hotfix)
+    {
+        // First get the device ID.
+        int device_id;
+        ROCPRIM_RETURN_ON_ERROR(::rocprim::detail::get_device_from_stream(stream, device_id));
+
+        // Then we get the arch. This property is cached.
+        target_arch arch;
+        ROCPRIM_RETURN_ON_ERROR(rocprim::detail::get_device_arch(device_id, arch));
+
+        needs_hotfix = arch == target_arch::gfx942;
+    }
+
+    switch(data.option)
+    {
+            // clang-format off
+        case use_atomic_block_id::never:
+            enable = false;
+            break;
+        case use_atomic_block_id::always:
+            enable = true;
+            break;
+        case use_atomic_block_id::hotfix:
+        default:
+            enable = needs_hotfix;
+        //clang-format on
+    }
+
+    return hipSuccess;
+}
 
 } // end of detail namespace
 

--- a/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/rocprim/include/rocprim/device/device_histogram.hpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <iterator>
 #include <type_traits>
+#include <chrono>
 
 #include "../config.hpp"
 #include "../common.hpp"

--- a/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/rocprim/include/rocprim/device/device_histogram.hpp
@@ -21,11 +21,11 @@
 #ifndef ROCPRIM_DEVICE_DEVICE_HISTOGRAM_HPP_
 #define ROCPRIM_DEVICE_DEVICE_HISTOGRAM_HPP_
 
+#include <chrono>
 #include <cmath>
 #include <iostream>
 #include <iterator>
 #include <type_traits>
-#include <chrono>
 
 #include "../config.hpp"
 #include "../common.hpp"

--- a/rocprim/include/rocprim/device/device_merge.hpp
+++ b/rocprim/include/rocprim/device/device_merge.hpp
@@ -21,9 +21,9 @@
 #ifndef ROCPRIM_DEVICE_DEVICE_MERGE_HPP_
 #define ROCPRIM_DEVICE_DEVICE_MERGE_HPP_
 
+#include <chrono>
 #include <iostream>
 #include <iterator>
-#include <type_traits>
 
 #include "../config.hpp"
 #include "../common.hpp"

--- a/rocprim/include/rocprim/device/device_nth_element.hpp
+++ b/rocprim/include/rocprim/device/device_nth_element.hpp
@@ -22,6 +22,7 @@
 #define ROCPRIM_DEVICE_DEVICE_NTH_ELEMENT_HPP_
 
 #include "detail/device_nth_element.hpp"
+#include "detail/ordered_block_id.hpp"
 
 #include "../detail/temp_storage.hpp"
 
@@ -84,79 +85,99 @@ hipError_t
 
     key_type* keys_buffer = nullptr;
 
-    {
-        using namespace temp_storage;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
 
-        hipError_t partition_result;
-        if(keys_double_buffer == nullptr)
+    ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(false, use_atomic_block_id)(
+        [&](auto /* use_sleepy_scan */, auto use_atomic_block_id)
         {
-            partition_result
-                = partition(temporary_storage,
-                            storage_size,
-                            make_linear_partition(
-                                ptr_aligned_array(&tree, num_splitters),
-                                ptr_aligned_array(&equality_buckets, num_buckets),
-                                ptr_aligned_array(&buckets, num_buckets),
-                                ptr_aligned_array(&keys_buffer, size),
-                                ptr_aligned_array(&nth_element_data, 1),
-                                ptr_aligned_array(&lookback_states, num_partitions * num_blocks)));
-        }
-        else
-        {
-            partition_result
-                = partition(temporary_storage,
-                            storage_size,
-                            make_linear_partition(
-                                ptr_aligned_array(&tree, num_splitters),
-                                ptr_aligned_array(&equality_buckets, num_buckets),
-                                ptr_aligned_array(&buckets, num_buckets),
-                                ptr_aligned_array(&nth_element_data, 1),
-                                ptr_aligned_array(&lookback_states, num_partitions * num_blocks)));
-            keys_buffer = keys_double_buffer;
-        }
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
+            typename ordered_bid_type::id_type* ordered_bid_storage;
 
-        if(partition_result != hipSuccess || temporary_storage == nullptr)
-        {
-            return partition_result;
-        }
-    }
+            {
+                using namespace temp_storage;
 
-    if((size == 0) || (size == 1 && nth == 0))
-    {
-        return hipSuccess;
-    }
+                hipError_t partition_result;
+                if(keys_double_buffer == nullptr)
+                {
+                    partition_result = partition(
+                        temporary_storage,
+                        storage_size,
+                        make_linear_partition(
+                            ptr_aligned_array(&tree, num_splitters),
+                            ptr_aligned_array(&equality_buckets, num_buckets),
+                            ptr_aligned_array(&buckets, num_buckets),
+                            ptr_aligned_array(&keys_buffer, size),
+                            ptr_aligned_array(&nth_element_data, 1),
+                            ptr_aligned_array(&lookback_states, num_partitions * num_blocks),
+                            detail::temp_storage::make_partition(
+                                &ordered_bid_storage,
+                                ordered_bid_type::get_temp_storage_layout())));
+                }
+                else
+                {
+                    partition_result = partition(
+                        temporary_storage,
+                        storage_size,
+                        make_linear_partition(
+                            ptr_aligned_array(&tree, num_splitters),
+                            ptr_aligned_array(&equality_buckets, num_buckets),
+                            ptr_aligned_array(&buckets, num_buckets),
+                            ptr_aligned_array(&nth_element_data, 1),
+                            ptr_aligned_array(&lookback_states, num_partitions * num_blocks),
+                            detail::temp_storage::make_partition(
+                                &ordered_bid_storage,
+                                ordered_bid_type::get_temp_storage_layout())));
+                    keys_buffer = keys_double_buffer;
+                }
 
-    if(nth >= size)
-    {
-        return hipErrorInvalidValue;
-    }
+                if(partition_result != hipSuccess || temporary_storage == nullptr)
+                {
+                    return partition_result;
+                }
+            }
 
-    if(debug_synchronous)
-    {
-        std::cout << "-----" << '\n';
-        std::cout << "size: " << size << '\n';
-        std::cout << "num_buckets: " << num_buckets << '\n';
-        std::cout << "num_threads_per_block: " << num_threads_per_block << '\n';
-        std::cout << "num_blocks: " << num_blocks << '\n';
-        std::cout << "storage_size: " << storage_size << '\n';
-    }
+            if((size == 0) || (size == 1 && nth == 0))
+            {
+                return hipSuccess;
+            }
 
-    return nth_element_keys_impl<config, num_partitions>(keys,
-                                                         keys_buffer,
-                                                         tree,
-                                                         nth,
-                                                         size,
-                                                         buckets,
-                                                         equality_buckets,
-                                                         lookback_states,
-                                                         num_buckets,
-                                                         stop_recursion_size,
-                                                         num_threads_per_block,
-                                                         num_items_per_threads,
-                                                         nth_element_data,
-                                                         compare_function,
-                                                         stream,
-                                                         debug_synchronous);
+            if(nth >= size)
+            {
+                return hipErrorInvalidValue;
+            }
+
+            if(debug_synchronous)
+            {
+                std::cout << "-----" << '\n';
+                std::cout << "size: " << size << '\n';
+                std::cout << "num_buckets: " << num_buckets << '\n';
+                std::cout << "num_threads_per_block: " << num_threads_per_block << '\n';
+                std::cout << "num_blocks: " << num_blocks << '\n';
+                std::cout << "storage_size: " << storage_size << '\n';
+            }
+
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            return nth_element_keys_impl<config, num_partitions>(keys,
+                                                                 keys_buffer,
+                                                                 tree,
+                                                                 nth,
+                                                                 size,
+                                                                 buckets,
+                                                                 equality_buckets,
+                                                                 lookback_states,
+                                                                 num_buckets,
+                                                                 stop_recursion_size,
+                                                                 num_threads_per_block,
+                                                                 num_items_per_threads,
+                                                                 nth_element_data,
+                                                                 compare_function,
+                                                                 stream,
+                                                                 debug_synchronous,
+                                                                 ordered_bid);
+        }));
+    return hipSuccess;
 }
 
 } // namespace detail

--- a/rocprim/include/rocprim/device/device_partition.hpp
+++ b/rocprim/include/rocprim/device/device_partition.hpp
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <iostream>
 #include <iterator>
-#include <type_traits>
+#include <chrono>
 
 #include "../config.hpp"
 #include "../common.hpp"
@@ -130,204 +130,163 @@ inline hipError_t partition_impl(void*                       temporary_storage,
                                  UnaryPredicates... predicates)
 {
     using offset_type = OffsetT;
-    using key_type = typename std::iterator_traits<KeyIterator>::value_type;
-    using value_type = typename std::iterator_traits<ValueIterator>::value_type;
+    using key_type    = typename std::iterator_traits<KeyIterator>::value_type;
+    using value_type  = typename std::iterator_traits<ValueIterator>::value_type;
 
-    using config = wrapped_partition_config<Config, SubAlgo, key_type, value_type>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
 
-    constexpr bool write_only_selected = SubAlgo == partition_subalgo::select_flag
-                                         || SubAlgo == partition_subalgo::select_predicate
-                                         || SubAlgo == partition_subalgo::select_predicated_flag
-                                         || SubAlgo == partition_subalgo::select_unique
-                                         || SubAlgo == partition_subalgo::select_unique_by_key;
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
 
-    constexpr bool is_unique = SubAlgo == partition_subalgo::select_unique
-                               || SubAlgo == partition_subalgo::select_unique_by_key;
-    constexpr bool is_flag = SubAlgo == partition_subalgo::partition_two_way_flag
-                             || SubAlgo == partition_subalgo::partition_flag
-                             || SubAlgo == partition_subalgo::select_flag;
-    constexpr bool is_predicated_flag = SubAlgo == partition_subalgo::select_predicated_flag;
-    constexpr select_method method
-        = is_unique
-              ? select_method::unique
-              : (is_predicated_flag ? select_method::predicated_flag
-                                    : (is_flag ? select_method::flag : select_method::predicate));
-
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const partition_config_params params = dispatch_target_arch<config>(target_arch);
-
-    using offset_scan_state_type = detail::lookback_scan_state<offset_type>;
-    using offset_scan_state_with_sleep_type = detail::lookback_scan_state<offset_type, true>;
-
-    const unsigned int block_size       = params.kernel_config.block_size;
-    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
-    const auto         items_per_block  = block_size * items_per_thread;
-
-    static constexpr bool is_three_way = sizeof...(UnaryPredicates) == 2;
-    static constexpr const size_t selected_count_size = is_three_way ? 2 : 1;
-
-    const size_t size_limit = params.kernel_config.size_limit;
-    const size_t aligned_size_limit
-        = ::rocprim::max<size_t>(size_limit - (size_limit % items_per_block), items_per_block);
-    const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
-    const bool   use_limited_size = limited_size == aligned_size_limit;
-
-    const unsigned int number_of_blocks
-        = static_cast<unsigned int>(::rocprim::detail::ceiling_div(limited_size, items_per_block));
-
-    // Calculate required temporary storage
-    void*                           offset_scan_state_storage;
-    size_t*                         selected_count;
-    size_t*                         prev_selected_count;
-
-    detail::temp_storage::layout layout{};
-    result = offset_scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    using block_id_wrapper_type = block_id_wrapper<uint32_t, UsingOrderedBlockId>;
-
-    typename block_id_wrapper_type::id_type* block_id_pool = nullptr;
-
-    const hipError_t partition_result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with offset_scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&offset_scan_state_storage, layout),
-            // Note: the following two are to be allocated continuously, so that they can be initialized
-            // simultaneously.
-            // They have the same base type, so there is no padding between the types.
-            detail::temp_storage::ptr_aligned_array(&selected_count, selected_count_size),
-            detail::temp_storage::ptr_aligned_array(&prev_selected_count, selected_count_size),
-            temp_storage::make_partition(&block_id_pool,
-                                         block_id_wrapper_type::get_temp_storage_layout())));
-    if(partition_result != hipSuccess || temporary_storage == nullptr)
-    {
-        return result;
-    }
-
-    auto block_id = block_id_wrapper_type::create(block_id_pool);
-
-    // Start point for time measurements
-    std::chrono::steady_clock::time_point start;
-
-    bool use_sleep;
-    result = is_sleep_scan_state_used(stream, use_sleep);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    // Create and initialize lookback_scan_state obj
-    offset_scan_state_type offset_scan_state{};
-    result = offset_scan_state_type::create(offset_scan_state,
-                                            offset_scan_state_storage,
-                                            number_of_blocks,
-                                            stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    offset_scan_state_with_sleep_type offset_scan_state_with_sleep{};
-    result = offset_scan_state_with_sleep_type::create(offset_scan_state_with_sleep,
-                                                       offset_scan_state_storage,
-                                                       number_of_blocks,
-                                                       stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    // Call the provided function with either offset_scan_state or offset_scan_state_with_sleep based on
-    // the value of use_sleep
-    auto with_scan_state = [use_sleep, offset_scan_state, offset_scan_state_with_sleep](
-                               auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(use_sleepy_scan, use_atomic_block_id)(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(offset_scan_state_with_sleep);
-        }
-        else
-        {
-            return func(offset_scan_state);
-        }
-    };
+            using scan_state_type
+                = detail::lookback_scan_state<offset_type, decltype(use_sleepy_scan)::value>;
+            using block_id_type
+                = detail::block_id_wrapper<uint32_t, decltype(use_atomic_block_id)::value>;
 
-    // Memset selected_count and prev_selected_count at once
-    result = hipMemsetAsync(selected_count,
-                            0,
-                            sizeof(*selected_count) * 2 * selected_count_size,
-                            stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
+            using config = wrapped_partition_config<Config, SubAlgo, key_type, value_type>;
 
-    const size_t number_of_launches = ::rocprim::detail::ceiling_div(size, aligned_size_limit);
+            constexpr bool write_only_selected
+                = SubAlgo == partition_subalgo::select_flag
+                  || SubAlgo == partition_subalgo::select_predicate
+                  || SubAlgo == partition_subalgo::select_predicated_flag
+                  || SubAlgo == partition_subalgo::select_unique
+                  || SubAlgo == partition_subalgo::select_unique_by_key;
 
-    if(debug_synchronous)
-    {
-        std::cout << "use_limited_size " << use_limited_size << '\n';
-        std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
-        std::cout << "number_of_launches " << number_of_launches << '\n';
-        std::cout << "size " << size << '\n';
-        std::cout << "block_size " << block_size << '\n';
-        std::cout << "number of blocks " << number_of_blocks << '\n';
-        std::cout << "items_per_block " << items_per_block << '\n';
-    }
+            constexpr bool is_unique = SubAlgo == partition_subalgo::select_unique
+                                       || SubAlgo == partition_subalgo::select_unique_by_key;
+            constexpr bool is_flag = SubAlgo == partition_subalgo::partition_two_way_flag
+                                     || SubAlgo == partition_subalgo::partition_flag
+                                     || SubAlgo == partition_subalgo::select_flag;
+            constexpr bool is_predicated_flag
+                = SubAlgo == partition_subalgo::select_predicated_flag;
+            constexpr select_method method
+                = is_unique ? select_method::unique
+                            : (is_predicated_flag
+                                   ? select_method::predicated_flag
+                                   : (is_flag ? select_method::flag : select_method::predicate));
 
-    for(size_t i = 0, prev_processed = 0; i < number_of_launches;
-        i++, prev_processed += limited_size)
-    {
-        const unsigned int current_size
-            = static_cast<unsigned int>(std::min<size_t>(size - prev_processed, limited_size));
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+            const partition_config_params params = dispatch_target_arch<config>(target_arch);
 
-        const unsigned int current_number_of_blocks = ::rocprim::detail::ceiling_div(current_size, items_per_block);
+            const unsigned int block_size       = params.kernel_config.block_size;
+            const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+            const auto         items_per_block  = block_size * items_per_thread;
 
-        if(debug_synchronous)
-        {
-            std::cout << "current size " << current_size << '\n';
-            std::cout << "current number of blocks " << current_number_of_blocks << '\n';
+            static constexpr bool         is_three_way        = sizeof...(UnaryPredicates) == 2;
+            static constexpr const size_t selected_count_size = is_three_way ? 2 : 1;
 
-            start = std::chrono::steady_clock::now();
-        }
+            const size_t size_limit         = params.kernel_config.size_limit;
+            const size_t aligned_size_limit = ::rocprim::max<size_t>(
+                size_limit - (size_limit % static_cast<size_t>(items_per_block)),
+                items_per_block);
+            const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
+            const bool   use_limited_size = limited_size == aligned_size_limit;
 
-        with_scan_state(
-            [&](const auto scan_state)
+            const unsigned int number_of_blocks = static_cast<unsigned int>(
+                ::rocprim::detail::ceiling_div(limited_size, items_per_block));
+
+            // Calculate required temporary storage
+            void*   scan_state_storage;
+            size_t* selected_count;
+            size_t* prev_selected_count;
+
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout));
+
+            typename block_id_type::id_type* block_id_pool = nullptr;
+
+            // temporary storage partition
+            ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    // Note: the following two are to be allocated continuously, so that they can be initialized
+                    // simultaneously.
+                    // They have the same base type, so there is no padding between the types.
+                    detail::temp_storage::ptr_aligned_array(&selected_count, selected_count_size),
+                    detail::temp_storage::ptr_aligned_array(&prev_selected_count,
+                                                            selected_count_size),
+                    detail::temp_storage::ptr_aligned_array(&block_id_pool,
+                                                            block_id_type::get_storage_size()))));
+
+            if(temporary_storage == nullptr)
             {
-                const unsigned int block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
-                const unsigned int grid_size
-                    = ::rocprim::detail::ceiling_div(current_number_of_blocks, block_size);
-                init_lookback_scan_state_kernel<decltype(scan_state)>
-                    <<<dim3(grid_size), dim3(block_size), 0, stream>>>(scan_state,
-                                                                       current_number_of_blocks);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_offset_scan_state_kernel",
-                                                    current_number_of_blocks,
-                                                    start);
+                return hipSuccess;
+            }
 
-        result = block_id.reset_from_host(stream);
+            block_id_type block_id = block_id_type::create(block_id_pool);
 
-        if(result != hipSuccess)
-        {
-            return result;
-        }
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
 
-        if(debug_synchronous) start = std::chrono::steady_clock::now();
+            // Create and initialize lookback_scan_state obj
+            scan_state_type scan_state{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream));
 
-        with_scan_state(
-            [&](const auto scan_state)
+            // Memset selected_count and prev_selected_count at once
+            ROCPRIM_RETURN_ON_ERROR(
+                hipMemsetAsync(selected_count,
+                               0,
+                               sizeof(*selected_count) * 2 * selected_count_size,
+                               stream));
+
+            const size_t number_of_launches
+                = ::rocprim::detail::ceiling_div(size, aligned_size_limit);
+
+            if(debug_synchronous)
             {
+                std::cout << "use_limited_size " << use_limited_size << '\n';
+                std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
+                std::cout << "number_of_launches " << number_of_launches << '\n';
+                std::cout << "size " << size << '\n';
+                std::cout << "block_size " << block_size << '\n';
+                std::cout << "number of blocks " << number_of_blocks << '\n';
+                std::cout << "items_per_block " << items_per_block << '\n';
+            }
+
+            for(size_t i = 0, prev_processed = 0; i < number_of_launches;
+                i++, prev_processed += limited_size)
+            {
+                const unsigned int current_size = static_cast<unsigned int>(
+                    std::min<size_t>(size - prev_processed, limited_size));
+
+                const unsigned int current_number_of_blocks
+                    = ::rocprim::detail::ceiling_div(current_size, items_per_block);
+
+                if(debug_synchronous)
+                {
+                    std::cout << "current size " << current_size << '\n';
+                    std::cout << "current number of blocks " << current_number_of_blocks << '\n';
+
+                    start = std::chrono::steady_clock::now();
+                }
+
+                // Define block and grid sizes for init kernel.
+                const size_t init_block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
+                const size_t init_grid_size
+                    = ::rocprim::detail::ceiling_div(current_number_of_blocks, init_block_size);
+                init_lookback_scan_state_kernel<<<init_grid_size, init_block_size, 0, stream>>>(
+                    scan_state,
+                    current_number_of_blocks,
+                    block_id);
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_offset_scan_state_kernel",
+                                                            current_number_of_blocks,
+                                                            start);
+                if(debug_synchronous)
+                {
+                    start = std::chrono::steady_clock::now();
+                }
+
                 partition_kernel<method, write_only_selected, config>
-                    <<<dim3(current_number_of_blocks), dim3(block_size), 0, stream>>>(
+                    <<<current_number_of_blocks, block_size, 0, stream>>>(
                         keys_input + prev_processed,
                         values_input + prev_processed,
                         flags + prev_processed,
@@ -342,22 +301,20 @@ inline hipError_t partition_impl(void*                       temporary_storage,
                         current_number_of_blocks,
                         block_id,
                         predicates...);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", size, start);
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", size, start);
 
-        std::swap(selected_count, prev_selected_count);
-    }
+                std::swap(selected_count, prev_selected_count);
+            }
 
-    result = ::rocprim::transform(prev_selected_count,
-                                  selected_count_output,
-                                  (is_three_way ? 2 : 1),
-                                  ::rocprim::identity<>{},
-                                  stream,
-                                  debug_synchronous);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
+            ROCPRIM_RETURN_ON_ERROR(::rocprim::transform(prev_selected_count,
+                                                         selected_count_output,
+                                                         (is_three_way ? 2 : 1),
+                                                         ::rocprim::identity<>{},
+                                                         stream,
+                                                         debug_synchronous));
+
+            return hipSuccess;
+        }));
 
     return hipSuccess;
 }

--- a/rocprim/include/rocprim/device/device_partition.hpp
+++ b/rocprim/include/rocprim/device/device_partition.hpp
@@ -22,9 +22,9 @@
 #define ROCPRIM_DEVICE_DEVICE_PARTITION_HPP_
 
 #include <algorithm>
+#include <chrono>
 #include <iostream>
 #include <iterator>
-#include <chrono>
 
 #include "../config.hpp"
 #include "../common.hpp"

--- a/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -25,6 +25,7 @@
 #include <iterator>
 #include <type_traits>
 #include <utility>
+#include <chrono>
 
 #include "../config.hpp"
 #include "../common.hpp"
@@ -38,6 +39,7 @@
 #include "../type_traits.hpp"
 #include "detail/config/device_radix_sort_onesweep.hpp"
 #include "detail/device_radix_sort.hpp"
+#include "detail/ordered_block_id.hpp"
 #include "device_transform.hpp"
 #include "specialization/device_radix_block_sort.hpp"
 #include "specialization/device_radix_merge_sort.hpp"
@@ -207,7 +209,8 @@ template<class Config,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Offset,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 ROCPRIM_KERNEL
     __launch_bounds__(device_params<Config>().sort.block_size) void onesweep_iteration_kernel(
         KeysInputIterator        keys_input,
@@ -221,7 +224,8 @@ ROCPRIM_KERNEL
         Decomposer               decomposer,
         const unsigned int       bit,
         const unsigned int       current_radix_bits,
-        const unsigned int       full_blocks)
+        const unsigned int       full_blocks,
+        BlockIdWrapper           block_id)
 {
     static constexpr radix_sort_onesweep_config_params params = device_params<Config>();
     onesweep_iteration<params.sort.block_size,
@@ -239,7 +243,8 @@ ROCPRIM_KERNEL
                                                     decomposer,
                                                     bit,
                                                     current_radix_bits,
-                                                    full_blocks);
+                                                    full_blocks,
+                                                    block_id);
 }
 
 template<class Config,
@@ -249,7 +254,8 @@ template<class Config,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Offset,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 hipError_t radix_sort_onesweep_iteration(
     KeysInputIterator                                               keys_input,
     typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
@@ -266,6 +272,7 @@ hipError_t radix_sort_onesweep_iteration(
     Decomposer                                                      decomposer,
     const unsigned int                                              bit,
     const unsigned int                                              end_bit,
+    BlockIdWrapper                                                  block_id,
     const hipStream_t                                               stream,
     const bool                                                      debug_synchronous)
 {
@@ -314,6 +321,8 @@ hipError_t radix_sort_onesweep_iteration(
         if(error != hipSuccess)
             return error;
 
+        ROCPRIM_RETURN_ON_ERROR(block_id.reset_from_host(stream));
+
         std::chrono::steady_clock::time_point start;
         if(debug_synchronous)
         {
@@ -350,7 +359,8 @@ hipError_t radix_sort_onesweep_iteration(
                                decomposer,
                                bit,
                                current_radix_bits,
-                               full_blocks);
+                               full_blocks,
+                               block_id);
         }
         else if(from_input)
         {
@@ -370,7 +380,8 @@ hipError_t radix_sort_onesweep_iteration(
                                decomposer,
                                bit,
                                current_radix_bits,
-                               full_blocks);
+                               full_blocks,
+                               block_id);
         }
         else if(to_output)
         {
@@ -390,7 +401,8 @@ hipError_t radix_sort_onesweep_iteration(
                                decomposer,
                                bit,
                                current_radix_bits,
-                               full_blocks);
+                               full_blocks,
+                               block_id);
         }
         else
         {
@@ -410,7 +422,8 @@ hipError_t radix_sort_onesweep_iteration(
                                decomposer,
                                bit,
                                current_radix_bits,
-                               full_blocks);
+                               full_blocks,
+                               block_id);
         }
 
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("onesweep_iteration", size, start);
@@ -449,161 +462,182 @@ hipError_t radix_sort_onesweep_impl(
     using value_type  = typename std::iterator_traits<ValuesInputIterator>::value_type;
     using offset_type = offset_type_t<Size>;
 
-    using config = wrapped_radix_sort_onesweep_config<Config, key_type, value_type>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
 
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const radix_sort_onesweep_config_params params = dispatch_target_arch<config>(target_arch);
-
-    const unsigned int sort_items_per_block = params.sort.block_size * params.sort.items_per_thread;
-    const unsigned int radix_size_per_place = 1u << params.radix_bits_per_place;
-    const unsigned int max_items_per_full_batch = 1u << 30;
-    const unsigned int items_per_full_batch
-        = max_items_per_full_batch - max_items_per_full_batch % sort_items_per_block;
-
-    const unsigned int places = ceiling_div(end_bit - begin_bit, params.radix_bits_per_place);
-    const unsigned int bins   = radix_size_per_place * places;
-    const unsigned int items_per_batch
-        = static_cast<unsigned int>(::rocprim::min<size_t>(size, items_per_full_batch));
-    const unsigned int num_lookback_states
-        = radix_size_per_place * ceiling_div(items_per_batch, sort_items_per_block);
-
-    constexpr bool with_values        = !std::is_same<value_type, ::rocprim::empty_type>::value;
-    const bool     with_double_buffer = keys_tmp != nullptr;
-
-    offset_type*             global_digit_offsets;
-    offset_type*             global_digit_offsets_tmp;
-    onesweep_lookback_state* lookback_states;
-    key_type*                keys_tmp_storage;
-    value_type*              values_tmp_storage;
-
-    const hipError_t partition_result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            detail::temp_storage::ptr_aligned_array(&global_digit_offsets, bins),
-            detail::temp_storage::ptr_aligned_array(&global_digit_offsets_tmp,
-                                                    radix_size_per_place),
-            detail::temp_storage::ptr_aligned_array(&lookback_states, num_lookback_states),
-            detail::temp_storage::ptr_aligned_array(&keys_tmp_storage,
-                                                    !with_double_buffer ? size : 0),
-            detail::temp_storage::ptr_aligned_array(&values_tmp_storage,
-                                                    !with_double_buffer && with_values ? size
-                                                                                       : 0)));
-
-    if(partition_result != hipSuccess || temporary_storage == nullptr)
-    {
-        return partition_result;
-    }
-
-    if(size == 0)
-        return hipSuccess;
-
-    if(debug_synchronous)
-    {
-        std::cout << "radix_size " << radix_size_per_place << '\n';
-        std::cout << "digit_places " << places << '\n';
-        std::cout << "histograms_size " << bins << '\n';
-        std::cout << "num_lookback_states " << num_lookback_states << '\n';
-        hipError_t error = hipStreamSynchronize(stream);
-        if(error != hipSuccess)
-            return error;
-    }
-
-    // Compute the global digit offset, for each digit and for each digit place.
-    {
-        hipError_t error
-            = radix_sort_onesweep_global_offsets<Config, Descending>(keys_input,
-                                                                     values_input,
-                                                                     global_digit_offsets,
-                                                                     static_cast<offset_type>(size),
-                                                                     places,
-                                                                     decomposer,
-                                                                     begin_bit,
-                                                                     end_bit,
-                                                                     stream,
-                                                                     debug_synchronous);
-        if(error != hipSuccess)
-            return error;
-    }
-
-    if(!with_double_buffer)
-    {
-        keys_tmp   = keys_tmp_storage;
-        values_tmp = values_tmp_storage;
-    }
-
-    // Copy input keys and values if necessary (in-place sorting: input and output iterators are equal).
-    bool to_output  = with_double_buffer || (places - 1) % 2 == 0;
-    bool from_input = true;
-    if(!with_double_buffer && to_output)
-    {
-        const bool keys_alias
-            = ::rocprim::detail::can_iterators_alias(keys_input, keys_output, size);
-        const bool values_alias
-            = with_values
-              && ::rocprim::detail::can_iterators_alias(values_input, values_output, size);
-        if(keys_alias || values_alias)
+    ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(false, use_atomic_block_id)(
+        [&](auto /* use_sleepy_scan */, auto use_atomic_block_id)
         {
-            hipError_t error = ::rocprim::transform(keys_input,
-                                                    keys_tmp,
-                                                    size,
-                                                    ::rocprim::identity<key_type>(),
-                                                    stream,
-                                                    debug_synchronous);
-            if(error != hipSuccess)
-                return error;
+            using block_id_type
+                = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
 
-            if(with_values)
+            using config = wrapped_radix_sort_onesweep_config<Config, key_type, value_type>;
+
+            detail::target_arch target_arch;
+            hipError_t          result = host_target_arch(stream, target_arch);
+            if(result != hipSuccess)
             {
-                hipError_t error = ::rocprim::transform(values_input,
-                                                        values_tmp,
-                                                        size,
-                                                        ::rocprim::identity<value_type>(),
-                                                        stream,
-                                                        debug_synchronous);
+                return result;
+            }
+            const radix_sort_onesweep_config_params params
+                = dispatch_target_arch<config>(target_arch);
+
+            const unsigned int sort_items_per_block
+                = params.sort.block_size * params.sort.items_per_thread;
+            const unsigned int radix_size_per_place     = 1u << params.radix_bits_per_place;
+            const unsigned int max_items_per_full_batch = 1u << 30;
+            const unsigned int items_per_full_batch
+                = max_items_per_full_batch - max_items_per_full_batch % sort_items_per_block;
+
+            const unsigned int places
+                = ceiling_div(end_bit - begin_bit, params.radix_bits_per_place);
+            const unsigned int bins = radix_size_per_place * places;
+            const unsigned int items_per_batch
+                = static_cast<unsigned int>(::rocprim::min<size_t>(size, items_per_full_batch));
+            const unsigned int num_lookback_states
+                = radix_size_per_place * ceiling_div(items_per_batch, sort_items_per_block);
+
+            constexpr bool with_values = !std::is_same<value_type, ::rocprim::empty_type>::value;
+            const bool     with_double_buffer = keys_tmp != nullptr;
+
+            offset_type*             global_digit_offsets;
+            offset_type*             global_digit_offsets_tmp;
+            onesweep_lookback_state* lookback_states;
+            key_type*                keys_tmp_storage;
+            value_type*              values_tmp_storage;
+            typename block_id_type::id_type* block_id_storage;
+
+            const hipError_t partition_result = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    detail::temp_storage::ptr_aligned_array(&global_digit_offsets, bins),
+                    detail::temp_storage::ptr_aligned_array(&global_digit_offsets_tmp,
+                                                            radix_size_per_place),
+                    detail::temp_storage::ptr_aligned_array(&lookback_states, num_lookback_states),
+                    detail::temp_storage::ptr_aligned_array(&keys_tmp_storage,
+                                                            !with_double_buffer ? size : 0),
+                    detail::temp_storage::ptr_aligned_array(
+                        &values_tmp_storage,
+                        !with_double_buffer && with_values ? size : 0),
+                        detail::temp_storage::make_partition(
+                            &block_id_storage,
+                            block_id_type::get_temp_storage_layout())));
+
+            if(partition_result != hipSuccess || temporary_storage == nullptr)
+            {
+                return partition_result;
+            }
+
+            if(size == 0)
+                return hipSuccess;
+
+            auto block_id = block_id_type::create(block_id_storage);
+
+            if(debug_synchronous)
+            {
+                std::cout << "radix_size " << radix_size_per_place << '\n';
+                std::cout << "digit_places " << places << '\n';
+                std::cout << "histograms_size " << bins << '\n';
+                std::cout << "num_lookback_states " << num_lookback_states << '\n';
+                hipError_t error = hipStreamSynchronize(stream);
                 if(error != hipSuccess)
                     return error;
             }
 
-            from_input = false;
-        }
-    }
+            // Compute the global digit offset, for each digit and for each digit place.
+            {
+                hipError_t error = radix_sort_onesweep_global_offsets<Config, Descending>(
+                    keys_input,
+                    values_input,
+                    global_digit_offsets,
+                    static_cast<offset_type>(size),
+                    places,
+                    decomposer,
+                    begin_bit,
+                    end_bit,
+                    stream,
+                    debug_synchronous);
+                if(error != hipSuccess)
+                    return error;
+            }
 
-    // Sort each digit place iteratively.
-    for(unsigned bit = begin_bit, place = 0; bit < end_bit;
-        bit += params.radix_bits_per_place, ++place)
-    {
-        hipError_t error = radix_sort_onesweep_iteration<Config, Descending>(
-            keys_input,
-            keys_tmp,
-            keys_output,
-            values_input,
-            values_tmp,
-            values_output,
-            static_cast<offset_type>(size),
-            global_digit_offsets + place * radix_size_per_place,
-            global_digit_offsets_tmp,
-            lookback_states,
-            from_input,
-            to_output,
-            decomposer,
-            bit,
-            end_bit,
-            stream,
-            debug_synchronous);
-        if(error != hipSuccess)
-            return error;
+            if(!with_double_buffer)
+            {
+                keys_tmp   = keys_tmp_storage;
+                values_tmp = values_tmp_storage;
+            }
 
-        is_result_in_output = to_output;
-        from_input          = false;
-        to_output           = !to_output;
-    }
+            // Copy input keys and values if necessary (in-place sorting: input and output iterators are equal).
+            bool to_output  = with_double_buffer || (places - 1) % 2 == 0;
+            bool from_input = true;
+            if(!with_double_buffer && to_output)
+            {
+                const bool keys_alias
+                    = ::rocprim::detail::can_iterators_alias(keys_input, keys_output, size);
+                const bool values_alias
+                    = with_values
+                      && ::rocprim::detail::can_iterators_alias(values_input, values_output, size);
+                if(keys_alias || values_alias)
+                {
+                    hipError_t error = ::rocprim::transform(keys_input,
+                                                            keys_tmp,
+                                                            size,
+                                                            ::rocprim::identity<key_type>(),
+                                                            stream,
+                                                            debug_synchronous);
+                    if(error != hipSuccess)
+                        return error;
 
+                    if(with_values)
+                    {
+                        hipError_t error = ::rocprim::transform(values_input,
+                                                                values_tmp,
+                                                                size,
+                                                                ::rocprim::identity<value_type>(),
+                                                                stream,
+                                                                debug_synchronous);
+                        if(error != hipSuccess)
+                            return error;
+                    }
+
+                    from_input = false;
+                }
+            }
+
+            // Sort each digit place iteratively.
+            for(unsigned bit = begin_bit, place = 0; bit < end_bit;
+                bit += params.radix_bits_per_place, ++place)
+            {
+                hipError_t error = radix_sort_onesweep_iteration<Config, Descending>(
+                    keys_input,
+                    keys_tmp,
+                    keys_output,
+                    values_input,
+                    values_tmp,
+                    values_output,
+                    static_cast<offset_type>(size),
+                    global_digit_offsets + place * radix_size_per_place,
+                    global_digit_offsets_tmp,
+                    lookback_states,
+                    from_input,
+                    to_output,
+                    decomposer,
+                    bit,
+                    end_bit,
+                    block_id,
+                    stream,
+                    debug_synchronous);
+                if(error != hipSuccess)
+                    return error;
+
+                is_result_in_output = to_output;
+                from_input          = false;
+                to_output           = !to_output;
+            }
+
+            return hipSuccess;
+        }));
     return hipSuccess;
 }
 

--- a/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -21,11 +21,11 @@
 #ifndef ROCPRIM_DEVICE_DEVICE_RADIX_SORT_HPP_
 #define ROCPRIM_DEVICE_DEVICE_RADIX_SORT_HPP_
 
+#include <chrono>
 #include <iostream>
 #include <iterator>
 #include <type_traits>
 #include <utility>
-#include <chrono>
 
 #include "../config.hpp"
 #include "../common.hpp"
@@ -211,21 +211,20 @@ template<class Config,
          class Offset,
          class Decomposer,
          class BlockIdWrapper>
-ROCPRIM_KERNEL
-    __launch_bounds__(device_params<Config>().sort.block_size) void onesweep_iteration_kernel(
-        KeysInputIterator        keys_input,
-        KeysOutputIterator       keys_output,
-        ValuesInputIterator      values_input,
-        ValuesOutputIterator     values_output,
-        const unsigned int       size,
-        Offset*                  global_digit_offsets_in,
-        Offset*                  global_digit_offsets_out,
-        onesweep_lookback_state* lookback_states,
-        Decomposer               decomposer,
-        const unsigned int       bit,
-        const unsigned int       current_radix_bits,
-        const unsigned int       full_blocks,
-        BlockIdWrapper           block_id)
+ROCPRIM_KERNEL __launch_bounds__(device_params<Config>().sort.block_size)
+void onesweep_iteration_kernel(KeysInputIterator        keys_input,
+                               KeysOutputIterator       keys_output,
+                               ValuesInputIterator      values_input,
+                               ValuesOutputIterator     values_output,
+                               const unsigned int       size,
+                               Offset*                  global_digit_offsets_in,
+                               Offset*                  global_digit_offsets_out,
+                               onesweep_lookback_state* lookback_states,
+                               Decomposer               decomposer,
+                               const unsigned int       bit,
+                               const unsigned int       current_radix_bits,
+                               const unsigned int       full_blocks,
+                               BlockIdWrapper           block_id)
 {
     static constexpr radix_sort_onesweep_config_params params = device_params<Config>();
     onesweep_iteration<params.sort.block_size,
@@ -468,8 +467,7 @@ hipError_t radix_sort_onesweep_impl(
     ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(false, use_atomic_block_id)(
         [&](auto /* use_sleepy_scan */, auto use_atomic_block_id)
         {
-            using block_id_type
-                = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
+            using block_id_type = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
 
             using config = wrapped_radix_sort_onesweep_config<Config, key_type, value_type>;
 
@@ -500,11 +498,11 @@ hipError_t radix_sort_onesweep_impl(
             constexpr bool with_values = !std::is_same<value_type, ::rocprim::empty_type>::value;
             const bool     with_double_buffer = keys_tmp != nullptr;
 
-            offset_type*             global_digit_offsets;
-            offset_type*             global_digit_offsets_tmp;
-            onesweep_lookback_state* lookback_states;
-            key_type*                keys_tmp_storage;
-            value_type*              values_tmp_storage;
+            offset_type*                     global_digit_offsets;
+            offset_type*                     global_digit_offsets_tmp;
+            onesweep_lookback_state*         lookback_states;
+            key_type*                        keys_tmp_storage;
+            value_type*                      values_tmp_storage;
             typename block_id_type::id_type* block_id_storage;
 
             const hipError_t partition_result = detail::temp_storage::partition(
@@ -520,9 +518,9 @@ hipError_t radix_sort_onesweep_impl(
                     detail::temp_storage::ptr_aligned_array(
                         &values_tmp_storage,
                         !with_double_buffer && with_values ? size : 0),
-                        detail::temp_storage::make_partition(
-                            &block_id_storage,
-                            block_id_type::get_temp_storage_layout())));
+                    detail::temp_storage::make_partition(
+                        &block_id_storage,
+                        block_id_type::get_temp_storage_layout())));
 
             if(partition_result != hipSuccess || temporary_storage == nullptr)
             {

--- a/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/rocprim/include/rocprim/device/device_reduce.hpp
@@ -22,9 +22,9 @@
 #define ROCPRIM_DEVICE_DEVICE_REDUCE_HPP_
 
 #include <algorithm>
+#include <chrono>
 #include <iostream>
 #include <iterator>
-#include <type_traits>
 
 #include "config_types.hpp"
 

--- a/rocprim/include/rocprim/device/device_reduce_by_key.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_by_key.hpp
@@ -51,14 +51,15 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<typename LookBackScanState, typename AccumulatorType>
+template<typename LookBackScanState, typename AccumulatorType, typename WrappedBlockId>
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
     reduce_by_key_init_kernel(LookBackScanState      lookback_scan_state,
                               const unsigned int     number_of_blocks,
                               const bool             is_first_launch,
                               const unsigned int     block_save_idx,
                               std::size_t* const     global_head_count,
-                              AccumulatorType* const previous_accumulated)
+                              AccumulatorType* const previous_accumulated,
+                              WrappedBlockId         wrapped_block_id)
 {
     const unsigned int block_id        = ::rocprim::detail::block_id<0>();
     const unsigned int block_size      = ::rocprim::detail::block_size<0>();
@@ -89,7 +90,7 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
                                       update_func);
     }
 
-    init_lookback_scan_state(lookback_scan_state, number_of_blocks, flat_thread_id);
+    init_lookback_scan_state(lookback_scan_state, number_of_blocks, wrapped_block_id, flat_thread_id);
 }
 
 template<lookback_scan_determinism Determinism,
@@ -102,21 +103,23 @@ template<lookback_scan_determinism Determinism,
          typename UniqueCountIterator,
          typename CompareFunction,
          typename BinaryOp,
-         typename LookbackScanState>
-ROCPRIM_KERNEL __launch_bounds__(device_params<Config>().kernel_config.block_size) void
-    reduce_by_key_kernel(const KeyIterator            keys_input,
-                         const ValueIterator          values_input,
-                         const UniqueIterator         unique_keys,
-                         const ReductionIterator      reductions,
-                         const UniqueCountIterator    unique_count,
-                         const BinaryOp               reduce_op,
-                         const CompareFunction        compare,
-                         const LookbackScanState      scan_state,
-                         const std::size_t            starting_block,
-                         const std::size_t            total_number_of_blocks,
-                         const std::size_t            size,
-                         const std::size_t* const     global_head_count,
-                         const AccumulatorType* const previous_accumulated)
+         typename LookbackScanState,
+         typename WrappedBlockId>
+ROCPRIM_KERNEL __launch_bounds__(device_params<Config>().kernel_config.block_size)
+void reduce_by_key_kernel(const KeyIterator            keys_input,
+                          const ValueIterator          values_input,
+                          const UniqueIterator         unique_keys,
+                          const ReductionIterator      reductions,
+                          const UniqueCountIterator    unique_count,
+                          const BinaryOp               reduce_op,
+                          const CompareFunction        compare,
+                          const LookbackScanState      scan_state,
+                          const std::size_t            starting_block,
+                          const std::size_t            total_number_of_blocks,
+                          const std::size_t            size,
+                          const std::size_t* const     global_head_count,
+                          const AccumulatorType* const previous_accumulated,
+                          WrappedBlockId               wrapped_block_id)
 {
     reduce_by_key::kernel_impl<Determinism, Config>(keys_input,
                                                     values_input,
@@ -130,7 +133,8 @@ ROCPRIM_KERNEL __launch_bounds__(device_params<Config>().kernel_config.block_siz
                                                     total_number_of_blocks,
                                                     size,
                                                     global_head_count,
-                                                    previous_accumulated);
+                                                    previous_accumulated,
+                                                    wrapped_block_id);
 }
 
 template<lookback_scan_determinism Determinism,
@@ -164,170 +168,163 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
     }
     const reduce_by_key_config_params params = dispatch_target_arch<config>(target_arch);
 
-    using scan_state_type
-        = reduce_by_key::lookback_scan_state_t<accumulator_type, /*UseSleep=*/false>;
-    using scan_state_with_sleep_type
-        = reduce_by_key::lookback_scan_state_t<accumulator_type, /*UseSleep=*/true>;
 
-    const unsigned int block_size      = params.kernel_config.block_size;
-    const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
 
-    const size_t size_limit = params.kernel_config.size_limit;
-    const size_t aligned_size_limit
-        = ::rocprim::max<size_t>(size_limit - size_limit % items_per_block, items_per_block);
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
 
-    const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
-    const bool   use_limited_size = limited_size == aligned_size_limit;
-
-    // Number of blocks in a single launch (or the only launch if it fits)
-    const std::size_t number_of_blocks = detail::ceiling_div(limited_size, items_per_block);
-
-    // Calculate required temporary storage
-    void* scan_state_storage;
-    // The number of segment heads in previous launches.
-    std::size_t* d_global_head_count = nullptr;
-    // The running accumulation across the launch boundary.
-    accumulator_type* d_previous_accumulated = nullptr;
-
-    detail::temp_storage::layout layout{};
-    result = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout),
-            detail::temp_storage::ptr_aligned_array(&d_global_head_count, use_limited_size ? 1 : 0),
-            detail::temp_storage::ptr_aligned_array(&d_previous_accumulated,
-                                                    use_limited_size ? 1 : 0)));
-    if(result != hipSuccess || temporary_storage == nullptr)
-    {
-        return result;
-    }
-
-    bool use_sleep;
-    result = detail::is_sleep_scan_state_used(stream, use_sleep);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    scan_state_type scan_state{};
-    result = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    scan_state_with_sleep_type scan_state_with_sleep{};
-    result = scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                scan_state_storage,
-                                                number_of_blocks,
-                                                stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    auto with_scan_state
-        = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(use_sleepy_scan, use_atomic_block_id)(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(scan_state_with_sleep);
-        }
-        else
-        {
-            return func(scan_state);
-        }
-    };
+            using scan_state_type
+                = reduce_by_key::lookback_scan_state_t<accumulator_type, use_sleepy_scan>;
+            using block_id_type
+                = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
 
-    if(size == 0)
-    {
-        // Fill out unique_count_output with zero
-        return rocprim::transform(rocprim::constant_iterator<std::size_t>(0),
-                                  unique_count_output,
-                                  1,
-                                  rocprim::identity<std::size_t>{},
-                                  stream,
-                                  debug_synchronous);
-    }
+            const unsigned int block_size      = params.kernel_config.block_size;
+            const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
 
-    // Total number of blocks in all launches
-    const std::size_t total_number_of_blocks = ceiling_div(size, items_per_block);
-    const std::size_t number_of_launch       = ceiling_div(size, limited_size);
+            const size_t size_limit = params.kernel_config.size_limit;
+            const size_t aligned_size_limit
+                = ::rocprim::max<size_t>(size_limit - size_limit % items_per_block,
+                                         items_per_block);
 
-    if(debug_synchronous)
-    {
-        std::cout << "size:               " << size << '\n';
-        std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
-        std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
-        std::cout << "number_of_launch:   " << number_of_launch << '\n';
-        std::cout << "block_size:         " << block_size << '\n';
-        std::cout << "number_of_blocks:   " << number_of_blocks << '\n';
-        std::cout << "items_per_block:    " << items_per_block << '\n';
-    }
+            const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
+            const bool   use_limited_size = limited_size == aligned_size_limit;
 
-    for(size_t i = 0, offset = 0; i < number_of_launch; ++i, offset += limited_size)
-    {
-        const std::size_t current_size = std::min<std::size_t>(size - offset, limited_size);
-        const std::size_t number_of_blocks_launch = ceiling_div(current_size, items_per_block);
+            // Number of blocks in a single launch (or the only launch if it fits)
+            const std::size_t number_of_blocks = detail::ceiling_div(limited_size, items_per_block);
 
-        // Start point for time measurements
-        std::chrono::steady_clock::time_point start;
-        if(debug_synchronous)
-        {
-            std::cout << "index:            " << i << '\n';
-            std::cout << "current_size:     " << current_size << '\n';
-            std::cout << "number of blocks: " << number_of_blocks_launch << '\n';
+            // Calculate required temporary storage
+            void* scan_state_storage;
+            // The number of segment heads in previous launches.
+            std::size_t* d_global_head_count = nullptr;
+            // The running accumulation across the launch boundary.
+            accumulator_type* d_previous_accumulated = nullptr;
 
-            start = std::chrono::steady_clock::now();
-        }
-
-        with_scan_state(
-            [&](const auto scan_state)
+            detail::temp_storage::layout layout{};
+            result = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
+            if(result != hipSuccess)
             {
-                const unsigned int block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
-                const std::size_t  grid_size
-                    = detail::ceiling_div(number_of_blocks_launch, block_size);
+                return result;
+            }
 
-                reduce_by_key_init_kernel<<<dim3(grid_size), dim3(block_size), 0, stream>>>(
-                    scan_state,
-                    number_of_blocks_launch,
-                    i == 0,
-                    number_of_blocks - 1,
-                    d_global_head_count,
-                    d_previous_accumulated);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_init_kernel",
-                                                    number_of_blocks_launch,
-                                                    start);
-
-        with_scan_state(
-            [&](const auto scan_state)
+            typename block_id_type::id_type* block_id_storage;
+            result = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    // This is valid even with scan_state_with_sleep_type
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::ptr_aligned_array(&d_global_head_count,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::ptr_aligned_array(&d_previous_accumulated,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::make_partition(
+                        &block_id_storage,
+                        block_id_type::get_temp_storage_layout())));
+            if(result != hipSuccess || temporary_storage == nullptr)
             {
-                reduce_by_key_kernel<Determinism, config>
-                    <<<dim3(number_of_blocks_launch), dim3(block_size), 0, stream>>>(
-                        keys_input + offset,
-                        values_input + offset,
-                        unique_output,
-                        aggregates_output,
-                        unique_count_output,
-                        reduce_op,
-                        key_compare_op,
+                return result;
+            }
+
+            auto block_id = block_id_type::create(block_id_storage);
+            scan_state_type scan_state{};
+            result
+                = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
+            if(result != hipSuccess)
+            {
+                return result;
+            }
+
+            if(size == 0)
+            {
+                // Fill out unique_count_output with zero
+                return rocprim::transform(rocprim::constant_iterator<std::size_t>(0),
+                                          unique_count_output,
+                                          1,
+                                          rocprim::identity<std::size_t>{},
+                                          stream,
+                                          debug_synchronous);
+            }
+
+            // Total number of blocks in all launches
+            const std::size_t total_number_of_blocks = ceiling_div(size, items_per_block);
+            const std::size_t number_of_launch       = ceiling_div(size, limited_size);
+
+            if(debug_synchronous)
+            {
+                std::cout << "size:               " << size << '\n';
+                std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
+                std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
+                std::cout << "number_of_launch:   " << number_of_launch << '\n';
+                std::cout << "block_size:         " << block_size << '\n';
+                std::cout << "number_of_blocks:   " << number_of_blocks << '\n';
+                std::cout << "items_per_block:    " << items_per_block << '\n';
+            }
+
+            for(size_t i = 0, offset = 0; i < number_of_launch; ++i, offset += limited_size)
+            {
+                const std::size_t current_size = std::min<std::size_t>(size - offset, limited_size);
+                const std::size_t number_of_blocks_launch
+                    = ceiling_div(current_size, items_per_block);
+
+                // Start point for time measurements
+                std::chrono::steady_clock::time_point start;
+                if(debug_synchronous)
+                {
+                    std::cout << "index:            " << i << '\n';
+                    std::cout << "current_size:     " << current_size << '\n';
+                    std::cout << "number of blocks: " << number_of_blocks_launch << '\n';
+
+                    start = std::chrono::steady_clock::now();
+                }
+
+                {
+                    const unsigned int block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
+                    const std::size_t  grid_size
+                        = detail::ceiling_div(number_of_blocks_launch, block_size);
+
+                    reduce_by_key_init_kernel<<<dim3(grid_size), dim3(block_size), 0, stream>>>(
                         scan_state,
-                        i * number_of_blocks,
-                        total_number_of_blocks,
-                        size,
-                        i > 0 ? d_global_head_count : nullptr,
-                        i > 0 ? d_previous_accumulated : nullptr);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_kernel", current_size, start);
-    }
+                        number_of_blocks_launch,
+                        i == 0,
+                        number_of_blocks - 1,
+                        d_global_head_count,
+                        d_previous_accumulated,
+                        block_id);
+                }
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_init_kernel",
+                                                            number_of_blocks_launch,
+                                                            start);
 
+                {
+                    reduce_by_key_kernel<Determinism, config>
+                        <<<dim3(number_of_blocks_launch), dim3(block_size), 0, stream>>>(
+                            keys_input + offset,
+                            values_input + offset,
+                            unique_output,
+                            aggregates_output,
+                            unique_count_output,
+                            reduce_op,
+                            key_compare_op,
+                            scan_state,
+                            i * number_of_blocks,
+                            total_number_of_blocks,
+                            size,
+                            i > 0 ? d_global_head_count : nullptr,
+                            i > 0 ? d_previous_accumulated : nullptr,
+                            block_id);
+                }
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_kernel",
+                                                            current_size,
+                                                            start);
+            }
+
+            return hipSuccess;
+        }));
     return hipSuccess;
 }
 

--- a/rocprim/include/rocprim/device/device_reduce_by_key.hpp
+++ b/rocprim/include/rocprim/device/device_reduce_by_key.hpp
@@ -90,7 +90,10 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
                                       update_func);
     }
 
-    init_lookback_scan_state(lookback_scan_state, number_of_blocks, wrapped_block_id, flat_thread_id);
+    init_lookback_scan_state(lookback_scan_state,
+                             number_of_blocks,
+                             wrapped_block_id,
+                             flat_thread_id);
 }
 
 template<lookback_scan_determinism Determinism,
@@ -168,7 +171,6 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
     }
     const reduce_by_key_config_params params = dispatch_target_arch<config>(target_arch);
 
-
     bool use_atomic_block_id;
     ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
 
@@ -180,8 +182,7 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
         {
             using scan_state_type
                 = reduce_by_key::lookback_scan_state_t<accumulator_type, use_sleepy_scan>;
-            using block_id_type
-                = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
+            using block_id_type = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
 
             const unsigned int block_size      = params.kernel_config.block_size;
             const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
@@ -230,7 +231,7 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
                 return result;
             }
 
-            auto block_id = block_id_type::create(block_id_storage);
+            auto            block_id = block_id_type::create(block_id_storage);
             scan_state_type scan_state{};
             result
                 = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);

--- a/rocprim/include/rocprim/device/device_run_length_encode.hpp
+++ b/rocprim/include/rocprim/device/device_run_length_encode.hpp
@@ -166,7 +166,8 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
             void* scan_state_storage;
 
             detail::temp_storage::layout layout{};
-            ROCPRIM_RETURN_ON_ERROR(scan_state_type::get_temp_storage_layout(grid_size, stream, layout));
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(grid_size, stream, layout));
 
             using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
             typename ordered_bid_type::id_type* ordered_bid_storage;
@@ -188,7 +189,7 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
 
             scan_state_type scan_state{};
             ROCPRIM_RETURN_ON_ERROR(
-                scan_state_type::create(scan_state, scan_state_storage, grid_size, stream));                
+                scan_state_type::create(scan_state, scan_state_storage, grid_size, stream));
             auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
 
             if(size == 0)
@@ -215,7 +216,7 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
 
             {
                 const unsigned int init_block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
-                const std::size_t  init_grid_size  = detail::ceiling_div(grid_size, init_block_size);
+                const std::size_t  init_grid_size = detail::ceiling_div(grid_size, init_block_size);
                 hipLaunchKernelGGL(init_lookback_scan_state_kernel,
                                    dim3(init_grid_size),
                                    dim3(init_block_size),

--- a/rocprim/include/rocprim/device/device_run_length_encode.hpp
+++ b/rocprim/include/rocprim/device/device_run_length_encode.hpp
@@ -33,10 +33,8 @@
 #include "../iterator/constant_iterator.hpp"
 #include "../type_traits.hpp"
 
-#include <algorithm>
 #include <chrono>
 #include <cstddef>
-#include <ios>
 #include <iostream>
 #include <iterator>
 
@@ -99,15 +97,17 @@ template<typename Config,
          typename OffsetsOutputIterator,
          typename CountsOutputIterator,
          typename RunsCountOutputIterator,
-         typename LookbackScanState>
-ROCPRIM_KERNEL __launch_bounds__(device_params<Config>().kernel_config.block_size) void
-    non_trivial_kernel(const InputIterator           input,
-                       const OffsetsOutputIterator   offsets_output,
-                       const CountsOutputIterator    counts_output,
-                       const RunsCountOutputIterator runs_count_output,
-                       const LookbackScanState       scan_state,
-                       const std::size_t             grid_size,
-                       const std::size_t             size)
+         typename LookbackScanState,
+         typename WrappedBlockId>
+ROCPRIM_KERNEL __launch_bounds__(device_params<Config>().kernel_config.block_size)
+void non_trivial_kernel(const InputIterator           input,
+                        const OffsetsOutputIterator   offsets_output,
+                        const CountsOutputIterator    counts_output,
+                        const RunsCountOutputIterator runs_count_output,
+                        const LookbackScanState       scan_state,
+                        const std::size_t             grid_size,
+                        const std::size_t             size,
+                        WrappedBlockId                ordered_bid)
 {
     run_length_encode::non_trivial_kernel_impl<Config, OffsetCountPairType>(input,
                                                                             offsets_output,
@@ -115,7 +115,8 @@ ROCPRIM_KERNEL __launch_bounds__(device_params<Config>().kernel_config.block_siz
                                                                             runs_count_output,
                                                                             scan_state,
                                                                             grid_size,
-                                                                            size);
+                                                                            size,
+                                                                            ordered_bid);
 }
 
 template<typename Config,
@@ -141,122 +142,120 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
 
     using config = rocprim::detail::wrapped_non_trivial_runs_config<Config, input_type>;
 
-    using scan_state_type
-        = ::rocprim::detail::lookback_scan_state<offset_count_pair_type, /*UseSleep=*/false>;
-    using scan_state_with_sleep_type
-        = ::rocprim::detail::lookback_scan_state<offset_count_pair_type, /*UseSleep=*/true>;
-
     detail::target_arch target_arch;
     ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
 
-    const non_trivial_runs_config_params params     = dispatch_target_arch<config>(target_arch);
-    const unsigned int                   block_size = params.kernel_config.block_size;
-    const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
-    const std::size_t  grid_size       = detail::ceiling_div(size, items_per_block);
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
 
-    // Calculate required temporary storage
-    void* scan_state_storage;
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
 
-    detail::temp_storage::layout layout{};
-    ROCPRIM_RETURN_ON_ERROR(scan_state_type::get_temp_storage_layout(grid_size, stream, layout));
-
-    hipError_t result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout)));
-
-    if(result != hipSuccess || temporary_storage == nullptr)
-    {
-        return result;
-    }
-
-    bool use_sleep;
-    ROCPRIM_RETURN_ON_ERROR(detail::is_sleep_scan_state_used(stream, use_sleep));
-
-    scan_state_type            scan_state{};
-    scan_state_with_sleep_type scan_state_with_sleep{};
-    ROCPRIM_RETURN_ON_ERROR(scan_state_type::create(scan_state, scan_state_storage, grid_size, stream));
-    ROCPRIM_RETURN_ON_ERROR(scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                       scan_state_storage,
-                                                       grid_size,
-                                                       stream));
-
-    auto with_scan_state
-        = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(false, use_atomic_block_id)(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(scan_state_with_sleep);
-        }
-        else
-        {
-            return func(scan_state);
-        }
-    };
+            using scan_state_type
+                = ::rocprim::detail::lookback_scan_state<offset_count_pair_type, use_sleepy_scan>;
 
-    if(size == 0)
-    {
-        // Fill out runs_count_output with zero
-        return rocprim::transform(rocprim::constant_iterator<std::size_t>(0),
-                                  runs_count_output,
-                                  1,
-                                  rocprim::identity<std::size_t>{},
-                                  stream,
-                                  debug_synchronous);
-    }
+            const non_trivial_runs_config_params params = dispatch_target_arch<config>(target_arch);
+            const unsigned int                   block_size = params.kernel_config.block_size;
+            const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
+            const std::size_t  grid_size       = detail::ceiling_div(size, items_per_block);
 
-    // Start point for time measurements
-    std::chrono::steady_clock::time_point start;
-    if(debug_synchronous)
-    {
-        std::cout << "size:               " << size << '\n';
-        std::cout << "block_size:         " << block_size << '\n';
-        std::cout << "grid_size:          " << grid_size << '\n';
-        std::cout << "items_per_block:    " << items_per_block << '\n';
-        start = std::chrono::steady_clock::now();
-    }
+            // Calculate required temporary storage
+            void* scan_state_storage;
 
-    with_scan_state(
-        [&](const auto scan_state)
-        {
-            const unsigned int init_block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
-            const std::size_t  init_grid_size  = detail::ceiling_div(grid_size, init_block_size);
-            hipLaunchKernelGGL(init_lookback_scan_state_kernel,
-                               dim3(init_grid_size),
-                               dim3(init_block_size),
-                               0,
-                               stream,
-                               scan_state,
-                               grid_size);
-        });
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
-                                                grid_size,
-                                                start);
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(grid_size, stream, layout));
 
-    with_scan_state(
-        [&](const auto scan_state)
-        {
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(
-                    run_length_encode::non_trivial_kernel<config, offset_count_pair_type>),
-                dim3(grid_size),
-                dim3(block_size),
-                0,
-                stream,
-                input + 0,
-                offsets_output,
-                counts_output,
-                runs_count_output,
-                scan_state,
-                grid_size,
-                size);
-        });
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("run_length_encode::non_trivial_kernel",
-                                                size,
-                                                start);
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
+            typename ordered_bid_type::id_type* ordered_bid_storage;
 
+            hipError_t result = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    // This is valid even with scan_state_with_sleep_type
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::make_partition(
+                        &ordered_bid_storage,
+                        ordered_bid_type::get_temp_storage_layout())));
+
+            if(result != hipSuccess || temporary_storage == nullptr)
+            {
+                return result;
+            }
+
+            bool use_sleep;
+            ROCPRIM_RETURN_ON_ERROR(detail::is_sleep_scan_state_used(stream, use_sleep));
+
+            scan_state_type scan_state{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::create(scan_state, scan_state_storage, grid_size, stream));                
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            if(size == 0)
+            {
+                // Fill out runs_count_output with zero
+                return rocprim::transform(rocprim::constant_iterator<std::size_t>(0),
+                                          runs_count_output,
+                                          1,
+                                          rocprim::identity<std::size_t>{},
+                                          stream,
+                                          debug_synchronous);
+            }
+
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
+            if(debug_synchronous)
+            {
+                std::cout << "size:               " << size << '\n';
+                std::cout << "block_size:         " << block_size << '\n';
+                std::cout << "grid_size:          " << grid_size << '\n';
+                std::cout << "items_per_block:    " << items_per_block << '\n';
+                start = std::chrono::steady_clock::now();
+            }
+
+            {
+                const unsigned int init_block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
+                const std::size_t  init_grid_size = detail::ceiling_div(grid_size, init_block_size);
+                hipLaunchKernelGGL(init_lookback_scan_state_kernel,
+                                   dim3(init_grid_size),
+                                   dim3(init_block_size),
+                                   0,
+                                   stream,
+                                   scan_state,
+                                   grid_size,
+                                   ordered_bid);
+            }
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
+                                                        grid_size,
+                                                        start);
+
+            {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(
+                        run_length_encode::non_trivial_kernel<config, offset_count_pair_type>),
+                    dim3(grid_size),
+                    dim3(block_size),
+                    0,
+                    stream,
+                    input + 0,
+                    offsets_output,
+                    counts_output,
+                    runs_count_output,
+                    scan_state,
+                    grid_size,
+                    size,
+                    ordered_bid);
+            }
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("run_length_encode::non_trivial_kernel",
+                                                        size,
+                                                        start);
+
+            return hipSuccess;
+        }));
     return hipSuccess;
 }
 } // namespace run_length_encode

--- a/rocprim/include/rocprim/device/device_run_length_encode.hpp
+++ b/rocprim/include/rocprim/device/device_run_length_encode.hpp
@@ -145,29 +145,28 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
     detail::target_arch target_arch;
     ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
 
+    const non_trivial_runs_config_params params     = dispatch_target_arch<config>(target_arch);
+    const unsigned int                   block_size = params.kernel_config.block_size;
+    const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
+    const std::size_t  grid_size       = detail::ceiling_div(size, items_per_block);
+
     bool use_atomic_block_id;
     ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
 
     bool use_sleepy_scan;
     ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
 
-    ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(false, use_atomic_block_id)(
+    ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(use_sleepy_scan, use_atomic_block_id)(
         [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
             using scan_state_type
                 = ::rocprim::detail::lookback_scan_state<offset_count_pair_type, use_sleepy_scan>;
 
-            const non_trivial_runs_config_params params = dispatch_target_arch<config>(target_arch);
-            const unsigned int                   block_size = params.kernel_config.block_size;
-            const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
-            const std::size_t  grid_size       = detail::ceiling_div(size, items_per_block);
-
             // Calculate required temporary storage
             void* scan_state_storage;
 
             detail::temp_storage::layout layout{};
-            ROCPRIM_RETURN_ON_ERROR(
-                scan_state_type::get_temp_storage_layout(grid_size, stream, layout));
+            ROCPRIM_RETURN_ON_ERROR(scan_state_type::get_temp_storage_layout(grid_size, stream, layout));
 
             using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
             typename ordered_bid_type::id_type* ordered_bid_storage;
@@ -186,9 +185,6 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
             {
                 return result;
             }
-
-            bool use_sleep;
-            ROCPRIM_RETURN_ON_ERROR(detail::is_sleep_scan_state_used(stream, use_sleep));
 
             scan_state_type scan_state{};
             ROCPRIM_RETURN_ON_ERROR(
@@ -219,7 +215,7 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
 
             {
                 const unsigned int init_block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
-                const std::size_t  init_grid_size = detail::ceiling_div(grid_size, init_block_size);
+                const std::size_t  init_grid_size  = detail::ceiling_div(grid_size, init_block_size);
                 hipLaunchKernelGGL(init_lookback_scan_state_kernel,
                                    dim3(init_grid_size),
                                    dim3(init_block_size),
@@ -232,7 +228,6 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
                                                         grid_size,
                                                         start);
-
             {
                 hipLaunchKernelGGL(
                     HIP_KERNEL_NAME(

--- a/rocprim/include/rocprim/device/device_scan.hpp
+++ b/rocprim/include/rocprim/device/device_scan.hpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <iterator>
 #include <type_traits>
+#include <chrono>
 
 #include "../config.hpp"
 #include "../common.hpp"
@@ -125,20 +126,22 @@ template<lookback_scan_determinism Determinism,
          class BinaryFunction,
          class InitValueType,
          class AccType,
-         class LookBackScanState>
+         class LookBackScanState,
+         class BlockIdWrapper>
 ROCPRIM_KERNEL
-    __launch_bounds__(device_params<Config>().kernel_config.block_size) void lookback_scan_kernel(
-        InputIterator       input,
-        OutputIterator      output,
-        const size_t        size,
-        const InitValueType initial_value,
-        BinaryFunction      scan_op,
-        LookBackScanState   lookback_scan_state,
-        const unsigned int  number_of_blocks,
-        AccType*            previous_last_element = nullptr,
-        AccType*            new_last_element      = nullptr,
-        bool                override_first_value  = false,
-        bool                save_last_value       = false)
+    __launch_bounds__(device_params<Config>().kernel_config.block_size)
+void lookback_scan_kernel(InputIterator       input,
+                          OutputIterator      output,
+                          const size_t        size,
+                          const InitValueType initial_value,
+                          BinaryFunction      scan_op,
+                          LookBackScanState   lookback_scan_state,
+                          const unsigned int  number_of_blocks,
+                          AccType*            previous_last_element,
+                          AccType*            new_last_element,
+                          bool                override_first_value,
+                          bool                save_last_value,
+                          BlockIdWrapper      block_id)
 {
     lookback_scan_kernel_impl<Determinism, Exclusive, Config>(
         input,
@@ -151,7 +154,8 @@ ROCPRIM_KERNEL
         previous_last_element,
         new_last_element,
         override_first_value,
-        save_last_value);
+        save_last_value,
+        block_id);
 }
 
 #define ROCPRIM_DETAIL_HIP_SYNC(name, size, start) \
@@ -183,150 +187,150 @@ inline auto scan_impl(void*               temporary_storage,
                       const hipStream_t   stream,
                       bool                debug_synchronous)
 {
-    using config = wrapped_scan_config<Config, AccType>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
 
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const scan_config_params params = dispatch_target_arch<config>(target_arch);
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
 
-    using scan_state_type            = detail::lookback_scan_state<AccType>;
-    using scan_state_with_sleep_type = detail::lookback_scan_state<AccType, true>;
-
-    const unsigned int block_size       = params.kernel_config.block_size;
-    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
-    const auto         items_per_block  = block_size * items_per_thread;
-
-    const size_t size_limit = params.kernel_config.size_limit;
-    const size_t aligned_size_limit
-        = ::rocprim::max<size_t>(size_limit - size_limit % items_per_block, items_per_block);
-    size_t limited_size = std::min<size_t>(size, aligned_size_limit);
-    const bool use_limited_size = limited_size == aligned_size_limit;
-
-    unsigned int number_of_blocks = (limited_size + items_per_block - 1)/items_per_block;
-
-    // Pointer to array with block_prefixes
-    void*    scan_state_storage;
-    AccType* previous_last_element;
-    AccType* new_last_element;
-
-    detail::temp_storage::layout layout{};
-    hipError_t                   layout_result
-        = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(layout_result != hipSuccess)
-    {
-        return layout_result;
-    }
-
-    const hipError_t partition_result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with offset_scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout),
-            detail::temp_storage::ptr_aligned_array(&previous_last_element,
-                                                    use_limited_size ? 1 : 0),
-            detail::temp_storage::ptr_aligned_array(&new_last_element, use_limited_size ? 1 : 0)));
-    if(partition_result != hipSuccess || temporary_storage == nullptr)
-    {
-        return partition_result;
-    }
-
-    // Start point for time measurements
-    std::chrono::steady_clock::time_point start;
-
-    if( number_of_blocks == 0u )
-        return hipSuccess;
-
-    if(number_of_blocks > 1 || use_limited_size)
-    {
-        bool use_sleep;
-        if(const hipError_t error = is_sleep_scan_state_used(stream, use_sleep))
+    ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(use_sleepy_scan, use_atomic_block_id)(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return error;
-        }
+            using scan_state_type
+                = detail::lookback_scan_state<AccType, decltype(use_sleepy_scan)::value>;
+            using block_id_type
+                = detail::block_id_wrapper<uint32_t, decltype(use_atomic_block_id)::value>;
 
-        // Create and initialize lookback_scan_state obj
-        scan_state_type scan_state{};
-        hipError_t      result
-            = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
-        scan_state_with_sleep_type scan_state_with_sleep{};
-        result = scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                    scan_state_storage,
-                                                    number_of_blocks,
-                                                    stream);
-        if(result != hipSuccess)
-        {
-            return result;
-        }
+            using config = wrapped_scan_config<Config, AccType>;
 
-        // Call the provided function with either scan_state or scan_state_with_sleep based on
-        // the value of use_sleep
-        auto with_scan_state
-            = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-        {
-            if(use_sleep)
+            detail::target_arch target_arch;
+            hipError_t          result = host_target_arch(stream, target_arch);
+            if(result != hipSuccess)
             {
-                return func(scan_state_with_sleep);
+                return result;
             }
-            else
+            const scan_config_params params = dispatch_target_arch<config>(target_arch);
+
+            const unsigned int block_size       = params.kernel_config.block_size;
+            const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+            const auto         items_per_block  = block_size * items_per_thread;
+
+            const size_t size_limit = params.kernel_config.size_limit;
+            const size_t aligned_size_limit
+                = ::rocprim::max<size_t>(size_limit - size_limit % items_per_block,
+                                         items_per_block);
+            size_t     limited_size     = std::min<size_t>(size, aligned_size_limit);
+            const bool use_limited_size = limited_size == aligned_size_limit;
+
+            unsigned int number_of_blocks = (limited_size + items_per_block - 1) / items_per_block;
+
+            // Pointer to array with block_prefixes
+            void*    scan_state_storage;
+            AccType* previous_last_element;
+            AccType* new_last_element;
+
+            detail::temp_storage::layout layout{};
+            hipError_t                   layout_result
+                = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
+            if(layout_result != hipSuccess)
             {
-                return func(scan_state);
-            }
-        };
-
-        if(debug_synchronous) start = std::chrono::steady_clock::now();
-
-        size_t number_of_launch = (size + limited_size - 1)/limited_size;
-        for (size_t i = 0, offset = 0; i < number_of_launch; i++, offset+=limited_size )
-        {
-            size_t current_size = std::min<size_t>(size - offset, limited_size);
-            number_of_blocks = (current_size + items_per_block - 1)/items_per_block;
-            auto grid_size = (number_of_blocks + block_size - 1)/block_size;
-
-            if(debug_synchronous)
-            {
-                std::cout << "use_limited_size " << use_limited_size << '\n';
-                std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
-                std::cout << "number_of_launch " << number_of_launch << '\n';
-                std::cout << "index " << i << '\n';
-                std::cout << "size " << current_size << '\n';
-                std::cout << "block_size " << block_size << '\n';
-                std::cout << "number of blocks " << number_of_blocks << '\n';
-                std::cout << "items_per_block " << items_per_block << '\n';
+                return layout_result;
             }
 
-            with_scan_state(
-                [&](const auto scan_state)
+            typename block_id_type::id_type* block_id_pool = nullptr;
+
+            const hipError_t partition_result = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    // This is valid even with offset_scan_state_with_sleep_type
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::ptr_aligned_array(&previous_last_element,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::ptr_aligned_array(&new_last_element,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::ptr_aligned_array(&block_id_pool,
+                                                            block_id_type::get_storage_size())));
+            if(partition_result != hipSuccess || temporary_storage == nullptr)
+            {
+                return partition_result;
+            }
+
+            block_id_type block_id = block_id_type::create(block_id_pool);
+
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
+
+            if(number_of_blocks == 0u)
+                return hipSuccess;
+
+            if(number_of_blocks > 1 || use_limited_size)
+            {
+                bool use_sleep;
+                if(const hipError_t error = is_sleep_scan_state_used(stream, use_sleep))
                 {
+                    return error;
+                }
+
+                // Create and initialize lookback_scan_state obj
+                scan_state_type scan_state{};
+                hipError_t      result = scan_state_type::create(scan_state,
+                                                            scan_state_storage,
+                                                            number_of_blocks,
+                                                            stream);
+                if(result != hipSuccess)
+                {
+                    return result;
+                }
+
+                // Call the provided function with either scan_state or scan_state_with_sleep based on
+                // the value of use_sleep;
+                if(debug_synchronous)
+                    start = std::chrono::steady_clock::now();
+
+                size_t number_of_launch = (size + limited_size - 1) / limited_size;
+                for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
+                {
+                    size_t current_size = std::min<size_t>(size - offset, limited_size);
+                    number_of_blocks    = (current_size + items_per_block - 1) / items_per_block;
+                    auto grid_size      = (number_of_blocks + block_size - 1) / block_size;
+
+                    if(debug_synchronous)
+                    {
+                        std::cout << "use_limited_size " << use_limited_size << '\n';
+                        std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
+                        std::cout << "number_of_launch " << number_of_launch << '\n';
+                        std::cout << "index " << i << '\n';
+                        std::cout << "size " << current_size << '\n';
+                        std::cout << "block_size " << block_size << '\n';
+                        std::cout << "number of blocks " << number_of_blocks << '\n';
+                        std::cout << "items_per_block " << items_per_block << '\n';
+                    }
+
                     init_lookback_scan_state_kernel<<<dim3(grid_size),
                                                       dim3(block_size),
                                                       0,
-                                                      stream>>>(scan_state, number_of_blocks);
-                });
-            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
-                                                        number_of_blocks,
-                                                        start);
+                                                      stream>>>(scan_state,
+                                                                number_of_blocks,
+                                                                block_id);
+                    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
+                                                                number_of_blocks,
+                                                                start);
 
-            if(debug_synchronous) start = std::chrono::steady_clock::now();
-            grid_size = number_of_blocks;
+                    if(debug_synchronous)
+                        start = std::chrono::steady_clock::now();
+                    grid_size = number_of_blocks;
 
-            if(debug_synchronous)
-            {
-                std::cout << "use_limited_size " << use_limited_size << '\n';
-                std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
-                std::cout << "size " << current_size << '\n';
-                std::cout << "block_size " << block_size << '\n';
-                std::cout << "number of blocks " << number_of_blocks << '\n';
-                std::cout << "items_per_block " << items_per_block << '\n';
-            }
+                    if(debug_synchronous)
+                    {
+                        std::cout << "use_limited_size " << use_limited_size << '\n';
+                        std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
+                        std::cout << "size " << current_size << '\n';
+                        std::cout << "block_size " << block_size << '\n';
+                        std::cout << "number of blocks " << number_of_blocks << '\n';
+                        std::cout << "items_per_block " << items_per_block << '\n';
+                    }
 
-            with_scan_state(
-                [&](const auto scan_state)
-                {
                     lookback_scan_kernel<Determinism,
                                          Exclusive,
                                          config,
@@ -345,44 +349,52 @@ inline auto scan_impl(void*               temporary_storage,
                                                                            previous_last_element,
                                                                            new_last_element,
                                                                            i != size_t(0),
-                                                                           number_of_launch > 1);
-                });
-            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("lookback_scan_kernel", current_size, start);
+                                                                           number_of_launch > 1,
+                                                                           block_id);
+                    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("lookback_scan_kernel",
+                                                                current_size,
+                                                                start);
 
-            // Swap the last_elements
-            if(number_of_launch > 1)
-            {
-                hipError_t error = ::rocprim::transform(new_last_element,
-                                                        previous_last_element,
-                                                        1,
-                                                        ::rocprim::identity<AccType>(),
-                                                        stream,
-                                                        debug_synchronous);
-                if(error != hipSuccess) return error;
+                    // Swap the last_elements
+                    if(number_of_launch > 1)
+                    {
+                        hipError_t error = ::rocprim::transform(new_last_element,
+                                                                previous_last_element,
+                                                                1,
+                                                                ::rocprim::identity<AccType>(),
+                                                                stream,
+                                                                debug_synchronous);
+                        if(error != hipSuccess)
+                            return error;
+                    }
+                }
             }
-        }
-    }
-    else
-    {
-        if(debug_synchronous)
-        {
-            std::cout << "size " << size << '\n';
-            std::cout << "block_size " << block_size << '\n';
-            std::cout << "number of blocks " << number_of_blocks << '\n';
-            std::cout << "items_per_block " << items_per_block << '\n';
-            start = std::chrono::steady_clock::now();
-        }
+            else
+            {
+                if(debug_synchronous)
+                {
+                    std::cout << "size " << size << '\n';
+                    std::cout << "block_size " << block_size << '\n';
+                    std::cout << "number of blocks " << number_of_blocks << '\n';
+                    std::cout << "items_per_block " << items_per_block << '\n';
+                    start = std::chrono::steady_clock::now();
+                }
 
-        single_scan_kernel<Exclusive, // flag for exclusive scan operation
-                           config,
-                           InputIterator,
-                           OutputIterator,
-                           BinaryFunction,
-                           InitValueType,
-                           AccType>
-            <<<dim3(1), dim3(block_size), 0, stream>>>(input, size, initial_value, output, scan_op);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("single_scan_kernel", size, start);
-    }
+                single_scan_kernel<Exclusive, // flag for exclusive scan operation
+                                   config,
+                                   InputIterator,
+                                   OutputIterator,
+                                   BinaryFunction,
+                                   InitValueType,
+                                   AccType><<<dim3(1), dim3(block_size), 0, stream>>>(input,
+                                                                                      size,
+                                                                                      initial_value,
+                                                                                      output,
+                                                                                      scan_op);
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("single_scan_kernel", size, start);
+            }
+            return hipSuccess;
+        }));
     return hipSuccess;
 }
 

--- a/rocprim/include/rocprim/device/device_scan.hpp
+++ b/rocprim/include/rocprim/device/device_scan.hpp
@@ -21,10 +21,10 @@
 #ifndef ROCPRIM_DEVICE_DEVICE_SCAN_HPP_
 #define ROCPRIM_DEVICE_DEVICE_SCAN_HPP_
 
+#include <chrono>
 #include <iostream>
 #include <iterator>
 #include <type_traits>
-#include <chrono>
 
 #include "../config.hpp"
 #include "../common.hpp"
@@ -128,8 +128,7 @@ template<lookback_scan_determinism Determinism,
          class AccType,
          class LookBackScanState,
          class BlockIdWrapper>
-ROCPRIM_KERNEL
-    __launch_bounds__(device_params<Config>().kernel_config.block_size)
+ROCPRIM_KERNEL __launch_bounds__(device_params<Config>().kernel_config.block_size)
 void lookback_scan_kernel(InputIterator       input,
                           OutputIterator      output,
                           const size_t        size,

--- a/rocprim/include/rocprim/device/device_scan_by_key.hpp
+++ b/rocprim/include/rocprim/device/device_scan_by_key.hpp
@@ -37,10 +37,10 @@
 
 #include <hip/hip_runtime.h>
 
+#include <chrono>
 #include <iostream>
 #include <iterator>
 #include <type_traits>
-#include <chrono>
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -60,18 +60,18 @@ template<lookback_scan_determinism Determinism,
          typename AccType,
          typename BlockIdWrapper>
 void __global__ __launch_bounds__(device_params<Config>().kernel_config.block_size)
-    device_scan_by_key_kernel(const KeyInputIterator                       keys,
-                              const InputIterator                          values,
-                              const OutputIterator                         output,
-                              const InitialValueType                       initial_value,
-                              const CompareFunction                        compare,
-                              const BinaryFunction                         scan_op,
-                              const LookbackScanState                      scan_state,
-                              const size_t                                 size,
-                              const size_t                                 starting_block,
-                              const size_t                                 number_of_blocks,
-                              const ::rocprim::tuple<AccType, bool>* const previous_last_value,
-                              BlockIdWrapper                               block_id)
+device_scan_by_key_kernel(const KeyInputIterator                       keys,
+                          const InputIterator                          values,
+                          const OutputIterator                         output,
+                          const InitialValueType                       initial_value,
+                          const CompareFunction                        compare,
+                          const BinaryFunction                         scan_op,
+                          const LookbackScanState                      scan_state,
+                          const size_t                                 size,
+                          const size_t                                 starting_block,
+                          const size_t                                 number_of_blocks,
+                          const ::rocprim::tuple<AccType, bool>* const previous_last_value,
+                          BlockIdWrapper                               block_id)
 {
     device_scan_by_key_kernel_impl<Determinism, Exclusive, Config>(
         keys,
@@ -134,8 +134,7 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
         [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
             using scan_state_type = detail::lookback_scan_state<wrapped_type, use_sleepy_scan>;
-            using block_id_type
-                = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
+            using block_id_type   = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
 
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -164,7 +163,7 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
             }
 
             typename block_id_type::id_type* block_id_storage;
-            const hipError_t partition_result = detail::temp_storage::partition(
+            const hipError_t                 partition_result = detail::temp_storage::partition(
                 temporary_storage,
                 storage_size,
                 detail::temp_storage::make_linear_partition(
@@ -183,7 +182,7 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
             {
                 return hipSuccess;
             }
-            
+
             auto block_id = block_id_type::create(block_id_storage);
 
             bool use_sleep;

--- a/rocprim/include/rocprim/device/device_scan_by_key.hpp
+++ b/rocprim/include/rocprim/device/device_scan_by_key.hpp
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <iterator>
 #include <type_traits>
+#include <chrono>
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -56,7 +57,8 @@ template<lookback_scan_determinism Determinism,
          typename CompareFunction,
          typename BinaryFunction,
          typename LookbackScanState,
-         typename AccType>
+         typename AccType,
+         typename BlockIdWrapper>
 void __global__ __launch_bounds__(device_params<Config>().kernel_config.block_size)
     device_scan_by_key_kernel(const KeyInputIterator                       keys,
                               const InputIterator                          values,
@@ -68,7 +70,8 @@ void __global__ __launch_bounds__(device_params<Config>().kernel_config.block_si
                               const size_t                                 size,
                               const size_t                                 starting_block,
                               const size_t                                 number_of_blocks,
-                              const ::rocprim::tuple<AccType, bool>* const previous_last_value)
+                              const ::rocprim::tuple<AccType, bool>* const previous_last_value,
+                              BlockIdWrapper                               block_id)
 {
     device_scan_by_key_kernel_impl<Determinism, Exclusive, Config>(
         keys,
@@ -81,7 +84,8 @@ void __global__ __launch_bounds__(device_params<Config>().kernel_config.block_si
         size,
         starting_block,
         number_of_blocks,
-        previous_last_value);
+        previous_last_value,
+        block_id);
 }
 
 
@@ -120,128 +124,119 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
     const scan_by_key_config_params params = dispatch_target_arch<config>(target_arch);
 
     using wrapped_type = ::rocprim::tuple<AccType, bool>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
 
-    using scan_state_type            = detail::lookback_scan_state<wrapped_type>;
-    using scan_state_with_sleep_type = detail::lookback_scan_state<wrapped_type, true>;
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
 
-    const unsigned int block_size       = params.kernel_config.block_size;
-    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
-    const unsigned int items_per_block  = block_size * items_per_thread;
-
-    const unsigned int size_limit = params.kernel_config.size_limit;
-    const unsigned int aligned_size_limit
-        = std::max(size_limit - size_limit % items_per_block, items_per_block);
-
-    const unsigned int limited_size
-        = static_cast<unsigned int>(std::min<size_t>(size, aligned_size_limit));
-    const bool use_limited_size = limited_size == aligned_size_limit;
-
-    // Number of blocks in a single launch (or the only launch if it fits)
-    const unsigned int number_of_blocks = ceiling_div(limited_size, items_per_block);
-
-    void*         scan_state_storage;
-    wrapped_type* previous_last_value;
-
-    detail::temp_storage::layout layout{};
-    const hipError_t             layout_result
-        = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(layout_result != hipSuccess)
-    {
-        return layout_result;
-    }
-
-    const hipError_t partition_result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with offset_scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout),
-            detail::temp_storage::ptr_aligned_array(&previous_last_value,
-                                                    use_limited_size ? 1 : 0)));
-    if(partition_result != hipSuccess || temporary_storage == nullptr)
-    {
-        return partition_result;
-    }
-
-    if(number_of_blocks == 0u)
-    {
-        return hipSuccess;
-    }
-
-    bool use_sleep;
-    if(const hipError_t error = is_sleep_scan_state_used(stream, use_sleep))
-    {
-        return error;
-    }
-
-    scan_state_type scan_state{};
-    hipError_t      scan_state_result
-        = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
-    scan_state_with_sleep_type scan_state_with_sleep{};
-    scan_state_result = scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                           scan_state_storage,
-                                                           number_of_blocks,
-                                                           stream);
-    if(scan_state_result != hipSuccess)
-    {
-        return scan_state_result;
-    }
-
-    // Call the provided function with either scan_state or scan_state_with_sleep based on
-    // the value of use_sleep
-    auto with_scan_state
-        = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(lookback_variant_util(use_sleepy_scan, use_atomic_block_id)(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(scan_state_with_sleep);
-        }
-        else
-        {
-            return func(scan_state);
-        }
-    };
+            using scan_state_type = detail::lookback_scan_state<wrapped_type, use_sleepy_scan>;
+            using block_id_type
+                = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
 
-    // Total number of blocks in all launches
-    const auto   total_number_of_blocks = ceiling_div(size, items_per_block);
-    const size_t number_of_launch       = ceiling_div(size, limited_size);
+            const unsigned int block_size       = params.kernel_config.block_size;
+            const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+            const unsigned int items_per_block  = block_size * items_per_thread;
 
-    if(debug_synchronous)
-    {
-        std::cout << "----------------------------------\n";
-        std::cout << "size:               " << size << '\n';
-        std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
-        std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
-        std::cout << "number_of_launch:   " << number_of_launch << '\n';
-        std::cout << "block_size:         " << block_size << '\n';
-        std::cout << "items_per_block:    " << items_per_block << '\n';
-        std::cout << "----------------------------------\n";
-    }
+            const unsigned int size_limit = params.kernel_config.size_limit;
+            const unsigned int aligned_size_limit
+                = std::max(size_limit - size_limit % items_per_block, items_per_block);
 
-    for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
-    {
-        // limited_size is of type unsigned int, so current_size also fits in an unsigned int
-        // size_t is necessary as type of std::min because 'size - offset' can exceed the
-        // upper limit of unsigned int and converting it can lead to wrong results
-        const unsigned int current_size
-            = static_cast<unsigned int>(std::min<size_t>(size - offset, limited_size));
-        const unsigned int scan_blocks    = ceiling_div(current_size, items_per_block);
-        const unsigned int init_grid_size = ceiling_div(scan_blocks, block_size);
+            const unsigned int limited_size
+                = static_cast<unsigned int>(std::min<size_t>(size, aligned_size_limit));
+            const bool use_limited_size = limited_size == aligned_size_limit;
 
-        // Start point for time measurements
-        std::chrono::steady_clock::time_point start;
-        if(debug_synchronous)
-        {
-            std::cout << "index:            " << i << '\n';
-            std::cout << "current_size:     " << current_size << '\n';
-            std::cout << "number of blocks: " << scan_blocks << '\n';
+            // Number of blocks in a single launch (or the only launch if it fits)
+            const unsigned int number_of_blocks = ceiling_div(limited_size, items_per_block);
 
-            start = std::chrono::steady_clock::now();
-        }
+            void*         scan_state_storage;
+            wrapped_type* previous_last_value;
 
-        with_scan_state(
-            [&](const auto scan_state)
+            detail::temp_storage::layout layout{};
+            const hipError_t             layout_result
+                = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
+            if(layout_result != hipSuccess)
             {
+                return layout_result;
+            }
+
+            typename block_id_type::id_type* block_id_storage;
+            const hipError_t partition_result = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::ptr_aligned_array(&previous_last_value,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::make_partition(
+                        &block_id_storage,
+                        block_id_type::get_temp_storage_layout())));
+            if(partition_result != hipSuccess || temporary_storage == nullptr)
+            {
+                return partition_result;
+            }
+
+            if(number_of_blocks == 0u)
+            {
+                return hipSuccess;
+            }
+            
+            auto block_id = block_id_type::create(block_id_storage);
+
+            bool use_sleep;
+            if(const hipError_t error = is_sleep_scan_state_used(stream, use_sleep))
+            {
+                return error;
+            }
+
+            scan_state_type scan_state{};
+            hipError_t      scan_state_result
+                = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
+            if(scan_state_result != hipSuccess)
+            {
+                return scan_state_result;
+            }
+
+            // Total number of blocks in all launches
+            const auto   total_number_of_blocks = ceiling_div(size, items_per_block);
+            const size_t number_of_launch       = ceiling_div(size, limited_size);
+
+            if(debug_synchronous)
+            {
+                std::cout << "----------------------------------\n";
+                std::cout << "size:               " << size << '\n';
+                std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
+                std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
+                std::cout << "number_of_launch:   " << number_of_launch << '\n';
+                std::cout << "block_size:         " << block_size << '\n';
+                std::cout << "items_per_block:    " << items_per_block << '\n';
+                std::cout << "----------------------------------\n";
+            }
+
+            for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
+            {
+                // limited_size is of type unsigned int, so current_size also fits in an unsigned int
+                // size_t is necessary as type of std::min because 'size - offset' can exceed the
+                // upper limit of unsigned int and converting it can lead to wrong results
+                const unsigned int current_size
+                    = static_cast<unsigned int>(std::min<size_t>(size - offset, limited_size));
+                const unsigned int scan_blocks    = ceiling_div(current_size, items_per_block);
+                const unsigned int init_grid_size = ceiling_div(scan_blocks, block_size);
+
+                // Start point for time measurements
+                std::chrono::steady_clock::time_point start;
+                if(debug_synchronous)
+                {
+                    std::cout << "index:            " << i << '\n';
+                    std::cout << "current_size:     " << current_size << '\n';
+                    std::cout << "number of blocks: " << scan_blocks << '\n';
+
+                    start = std::chrono::steady_clock::now();
+                }
+
                 hipLaunchKernelGGL(init_lookback_scan_state_kernel,
                                    dim3(init_grid_size),
                                    dim3(block_size),
@@ -249,20 +244,17 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                                    stream,
                                    scan_state,
                                    scan_blocks,
+                                   block_id,
                                    number_of_blocks - 1,
                                    i > 0 ? previous_last_value : nullptr);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
-                                                    scan_blocks,
-                                                    start);
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
+                                                            scan_blocks,
+                                                            start);
 
-        if(debug_synchronous)
-        {
-            start = std::chrono::steady_clock::now();
-        }
-        with_scan_state(
-            [&](auto& scan_state)
-            {
+                if(debug_synchronous)
+                {
+                    start = std::chrono::steady_clock::now();
+                }
                 hipLaunchKernelGGL(
                     HIP_KERNEL_NAME(device_scan_by_key_kernel<Determinism, Exclusive, config>),
                     dim3(scan_blocks),
@@ -279,12 +271,14 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                     size,
                     i * number_of_blocks,
                     total_number_of_blocks,
-                    i > 0 ? as_const_ptr(previous_last_value) : nullptr);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
-                                                    current_size,
-                                                    start);
-    }
+                    i > 0 ? as_const_ptr(previous_last_value) : nullptr,
+                    block_id);
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
+                                                            current_size,
+                                                            start);
+            }
+            return hipSuccess;
+        }));
     return hipSuccess;
 }
 

--- a/rocprim/include/rocprim/device/device_segmented_reduce.hpp
+++ b/rocprim/include/rocprim/device/device_segmented_reduce.hpp
@@ -21,9 +21,9 @@
 #ifndef ROCPRIM_DEVICE_DEVICE_SEGMENTED_REDUCE_HPP_
 #define ROCPRIM_DEVICE_DEVICE_SEGMENTED_REDUCE_HPP_
 
+#include <chrono>
 #include <iostream>
 #include <iterator>
-#include <type_traits>
 
 #include "../config.hpp"
 #include "../common.hpp"

--- a/rocprim/include/rocprim/device/device_transform.hpp
+++ b/rocprim/include/rocprim/device/device_transform.hpp
@@ -22,9 +22,9 @@
 #define ROCPRIM_DEVICE_DEVICE_TRANSFORM_HPP_
 
 #include <algorithm>
+#include <chrono>
 #include <iostream>
 #include <iterator>
-#include <chrono>
 
 #include "../config.hpp"
 #include "../common.hpp"

--- a/rocprim/include/rocprim/device/device_transform.hpp
+++ b/rocprim/include/rocprim/device/device_transform.hpp
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <iostream>
 #include <iterator>
-#include <type_traits>
+#include <chrono>
 
 #include "../config.hpp"
 #include "../common.hpp"

--- a/rocprim/include/rocprim/type_traits.hpp
+++ b/rocprim/include/rocprim/type_traits.hpp
@@ -303,12 +303,14 @@ private:
         return is_tuple_impl<Index + 1>();
     }
 
+    ROCPRIM_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexplicit-specialization-storage-class")
     template<>
     ROCPRIM_HOST_DEVICE
     static constexpr bool is_tuple_impl<sizeof...(Args)>()
     {
         return true;
     }
+    ROCPRIM_CLANG_SUPPRESS_WARNING_POP
 
 public:
     static constexpr bool value = is_tuple_impl<0>();
@@ -332,11 +334,13 @@ private:
         return std::is_reference<element_t>::value && is_tuple_of_references_impl<Index + 1>();
     }
 
+    ROCPRIM_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexplicit-specialization-storage-class")
     template<>
     ROCPRIM_HOST_DEVICE static constexpr bool is_tuple_of_references_impl<sizeof...(Args)>()
     {
         return true;
     }
+    ROCPRIM_CLANG_SUPPRESS_WARNING_POP
 
 public:
     static constexpr bool value = is_tuple_of_references_impl<0>();

--- a/test/rocprim/test_type_traits_interface.cpp
+++ b/test/rocprim/test_type_traits_interface.cpp
@@ -24,8 +24,9 @@
 
 #include <rocprim/type_traits.hpp>
 
+#include <hip/hip_runtime.h>
+
 #include <ostream>
-#include <type_traits>
 
 #include <cmath>
 

--- a/test/rocprim/test_utils.hpp
+++ b/test/rocprim/test_utils.hpp
@@ -21,6 +21,7 @@
 #ifndef TEST_TEST_UTILS_HPP_
 #define TEST_TEST_UTILS_HPP_
 
+#include <rocprim/config.hpp>
 #include <rocprim/device/config_types.hpp>
 #include <rocprim/functional.hpp>
 #include <rocprim/intrinsics.hpp>
@@ -54,6 +55,7 @@ namespace test_utils
 template<class T>
 static constexpr float precision = 0;
 
+ROCPRIM_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexplicit-specialization-storage-class")
 template<>
 static constexpr float precision<double> = 2.0f / (1ll << 52);
 
@@ -65,6 +67,7 @@ static constexpr float precision<rocprim::half> = 2.0f / (1ll << 10);
 
 template<>
 static constexpr float precision<rocprim::bfloat16> = 2.0f / (1ll << 7);
+ROCPRIM_CLANG_SUPPRESS_WARNING_POP
 
 template<class T>
 static constexpr float precision<const T> = precision<T>;


### PR DESCRIPTION
## Motivation

Backport of https://github.com/ROCm/rocm-libraries/pull/1981

## Technical Details

See linked PR.

## Test Plan

Idem.

## Test Result

Idem.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
